### PR TITLE
fix: very small integrator fee in swap details should render more decimals

### DIFF
--- a/src/utils/formatCurrencyAmount.ts
+++ b/src/utils/formatCurrencyAmount.ts
@@ -18,7 +18,7 @@ export function formatCurrencyAmount(
   }
 
   if (amount.divide(amount.decimalScale).lessThan(new Fraction(1, 100000))) {
-    return `<${formatLocaleNumber({ number: 0.00001, locale })}`
+    return `<${formatLocaleNumber({ number: 0.00001, locale, sigFigs, fixedDecimals })}`
   }
 
   return formatLocaleNumber({ number: amount, locale, sigFigs, fixedDecimals })


### PR DESCRIPTION
minor fix — very small fees were previously rendering as "<0"
before:
<img width="370" alt="Screen Shot 2022-05-24 at 4 28 18 PM" src="https://user-images.githubusercontent.com/27475332/170126243-3c0fcbb7-756f-42c4-abbf-ca3009c53f6a.png">

after:
now renders as "<0.00001"
<img width="364" alt="Screen Shot 2022-05-24 at 4 29 13 PM" src="https://user-images.githubusercontent.com/27475332/170126387-ded718b9-7450-43b7-ba57-1154fd19e38c.png">
