### PR TITLE
fix: set isPending false if wrap tx errors

### DIFF
--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -92,7 +92,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       if (isAnimating(document)) {
         document.addEventListener('animationend', postWrap)
       } else {
-        postWrap()
+        setIsPending(false)
       }
     } catch (e) {
       // TODO(zzmp): Surface errors from wrap.
@@ -133,7 +133,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       if (isAnimating(document)) {
         document.addEventListener('animationend', postSwap)
       } else {
-        postSwap()
+        setOpen(false)
       }
     } catch (e) {
       // TODO(zzmp): Surface errors from swap.

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -84,6 +84,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       })
       setDisplayTxHash(transaction.hash)
     } catch (e) {
+      setIsPending(false)
       // TODO(zzmp): Surface errors from wrap.
       console.log(e)
     }

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -72,6 +72,11 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
   const [isPending, setIsPending] = useState(false)
   const onWrap = useCallback(async () => {
     setIsPending(true)
+
+    const postWrap = () => {
+      setIsPending(false)
+      document.removeEventListener('animationend', postWrap)
+    }
     try {
       const transaction = await wrapCallback?.()
       if (!transaction) return
@@ -84,17 +89,13 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       })
       setDisplayTxHash(transaction.hash)
     } catch (e) {
-      setIsPending(false)
+      postWrap()
       // TODO(zzmp): Surface errors from wrap.
       console.log(e)
     }
 
     // Only reset pending after any queued animations to avoid layout thrashing, because a
     // successful wrap will open the status dialog and immediately cover the button.
-    const postWrap = () => {
-      setIsPending(false)
-      document.removeEventListener('animationend', postWrap)
-    }
     if (isAnimating(document)) {
       document.addEventListener('animationend', postWrap)
     } else {


### PR DESCRIPTION
before: (wrap button stays in spinning state even after user rejects tx)
<img width="1227" alt="Screen Shot 2022-04-13 at 6 19 11 PM" src="https://user-images.githubusercontent.com/27475332/170299281-55c1c13a-f829-494f-b9b4-53b912af8940.png">

after:
![Untitled](https://user-images.githubusercontent.com/27475332/170356709-0d0bfae0-bde4-45a8-8d01-8432abb5f895.gif)


