### PR TITLE
fix: change disabled state swap button opacity

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -72,7 +72,7 @@ export interface BaseProps {
 export type ActionButtonProps = BaseProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
 
 export default function ActionButton({ color = 'accent', disabled, action, onClick, children }: ActionButtonProps) {
-  const textColor = useMemo(() => (color === 'accent' && !disabled ? 'onAccent' : 'currentColor'), [color, disabled])
+  const textColor = useMemo(() => (color === 'accent' ? 'onAccent' : 'currentColor'), [color])
   return (
     <Overlay hasAction={Boolean(action)} flex align="stretch">
       {(action ? action.onClick : true) && (

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -41,11 +41,6 @@ export default styled(BaseButton)<{ color?: Color; transition?: boolean }>`
   :enabled:hover {
     background-color: ${({ color = 'interactive', theme }) => theme.onHover(theme[color])};
   }
-
-  :disabled {
-    border-color: ${({ theme }) => theme.outline};
-    color: ${({ theme }) => theme.secondary};
-  }
 `
 
 const transparentButton = (defaultColor: Color) => styled(BaseButton)<{ color?: Color }>`

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -22,7 +22,7 @@ export const BaseButton = styled.button`
 
   :disabled {
     cursor: initial;
-    filter: saturate(0) opacity(0.4);
+    filter: opacity(0.4);
   }
 `
 const transitionCss = css`
@@ -31,10 +31,10 @@ const transitionCss = css`
 
 export default styled(BaseButton)<{ color?: Color; transition?: boolean }>`
   border: 1px solid transparent;
+  background-color: ${({ color = 'interactive', theme }) => theme[color]};
   color: ${({ color = 'interactive', theme }) => color === 'interactive' && theme.onInteractive};
 
   :enabled {
-    background-color: ${({ color = 'interactive', theme }) => theme[color]};
     ${({ transition = true }) => transition && transitionCss};
   }
 

--- a/src/utils/formatCurrencyAmount.ts
+++ b/src/utils/formatCurrencyAmount.ts
@@ -18,7 +18,7 @@ export function formatCurrencyAmount(
   }
 
   if (amount.divide(amount.decimalScale).lessThan(new Fraction(1, 100000))) {
-    return `<${formatLocaleNumber({ number: 0.00001, locale })}`
+    return `<${formatLocaleNumber({ number: 0.00001, locale, sigFigs, fixedDecimals })}`
   }
 
   return formatLocaleNumber({ number: amount, locale, sigFigs, fixedDecimals })


### PR DESCRIPTION
currently the disabled swap button appears transparent. we want to switch from using an outline -> a 40% opacity button, as per integrator request

before:
<img width="363" alt="Screen Shot 2022-05-27 at 1 15 44 PM" src="https://user-images.githubusercontent.com/27475332/170757907-fdf46047-569a-477a-b745-219217429c83.png">
<img width="549" alt="Screen Shot 2022-05-27 at 1 15 51 PM" src="https://user-images.githubusercontent.com/27475332/170757313-e936d3bd-004d-4ebf-9841-7433ab59a359.png">

after:
<img width="363" alt="Screen Shot 2022-05-27 at 12 23 41 PM" src="https://user-images.githubusercontent.com/27475332/170756367-dc19cf4e-67e6-48ee-96a2-e404e56462e1.png">
<img width="367" alt="Screen Shot 2022-05-27 at 2 40 59 PM" src="https://user-images.githubusercontent.com/27475332/170771497-919ce95a-a498-4f3f-bfab-ab007fe00271.png">
<img width="361" alt="Screen Shot 2022-05-27 at 2 41 45 PM" src="https://user-images.githubusercontent.com/27475332/170771508-b22cef6e-e85b-4089-bb0d-bf0436a07139.png">


