### PR TITLE
fix: token dropdown balances should use 4 sigfigs

### DIFF
--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -110,8 +110,7 @@ function TokenOption({ index, value, style }: TokenOptionProps) {
             </Column>
           </Row>
           <TokenBalance isLoading={Boolean(account) && !balance}>
-            {balance?.greaterThan(0) && balance?.toFixed(2)}
-            {/* or formatCurrencyAmount(balance, 4, i18n.locale), which does it cleaner but doesnt include number locale */}
+            {balance?.greaterThan(0) && balance?.toSignificant(4)}
           </TokenBalance>
         </Row>
       </ThemedText.Body1>

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -22,7 +22,6 @@ import { areEqual, FixedSizeList, FixedSizeListProps } from 'react-window'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { currencyId } from 'utils/currencyId'
-import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import { BaseButton } from '../Button'
 import Column from '../Column'
@@ -111,7 +110,8 @@ function TokenOption({ index, value, style }: TokenOptionProps) {
             </Column>
           </Row>
           <TokenBalance isLoading={Boolean(account) && !balance}>
-            {balance?.greaterThan(0) && formatCurrencyAmount(balance, 2, i18n.locale)}
+            {balance?.greaterThan(0) && balance?.toFixed(2)}
+            {/* or formatCurrencyAmount(balance, 4, i18n.locale), which does it cleaner but doesnt include number locale */}
           </TokenBalance>
         </Row>
       </ThemedText.Body1>

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -1,3 +1,4 @@
+import { useLingui } from '@lingui/react'
 import { Currency } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useCurrencyBalance from 'hooks/useCurrencyBalance'
@@ -21,6 +22,7 @@ import { areEqual, FixedSizeList, FixedSizeListProps } from 'react-window'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { currencyId } from 'utils/currencyId'
+import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import { BaseButton } from '../Button'
 import Column from '../Column'
@@ -75,6 +77,7 @@ const TokenBalance = styled.div<{ isLoading: boolean }>`
 `
 
 function TokenOption({ index, value, style }: TokenOptionProps) {
+  const { i18n } = useLingui()
   const ref = useRef<HTMLButtonElement>(null)
   // Annotate the event to be handled later instead of passing in handlers to avoid rerenders.
   // This prevents token logos from reloading and flashing on the screen.
@@ -108,7 +111,7 @@ function TokenOption({ index, value, style }: TokenOptionProps) {
             </Column>
           </Row>
           <TokenBalance isLoading={Boolean(account) && !balance}>
-            {balance?.greaterThan(0) && balance?.toSignificant(4)}
+            {balance?.greaterThan(0) && formatCurrencyAmount(balance, 4, i18n.locale)}
           </TokenBalance>
         </Row>
       </ThemedText.Body1>

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -1,4 +1,3 @@
-import { useLingui } from '@lingui/react'
 import { Currency } from '@uniswap/sdk-core'
 import useActiveWeb3React from 'hooks/useActiveWeb3React'
 import useCurrencyBalance from 'hooks/useCurrencyBalance'
@@ -76,7 +75,6 @@ const TokenBalance = styled.div<{ isLoading: boolean }>`
 `
 
 function TokenOption({ index, value, style }: TokenOptionProps) {
-  const { i18n } = useLingui()
   const ref = useRef<HTMLButtonElement>(null)
   // Annotate the event to be handled later instead of passing in handlers to avoid rerenders.
   // This prevents token logos from reloading and flashing on the screen.


### PR DESCRIPTION
Previously, token dropdown only used 2 sigfigs (i.e. token balance of 1234 would get displayed as 1200)
Use 4 sigfigs to standardize with interface.

<img width="368" alt="Screen Shot 2022-06-30 at 4 07 18 PM" src="https://user-images.githubusercontent.com/27475332/176768409-2da2a0e6-ce80-4ec7-ab85-a6063e79df80.png">

