### PR TITLE
fix: make swap details row clickable

### DIFF
--- a/src/components/Expando.tsx
+++ b/src/components/Expando.tsx
@@ -8,11 +8,8 @@ import { PropsWithChildren, ReactNode, useState } from 'react'
 import styled from 'styled-components/macro'
 
 const HeaderColumn = styled(Column)`
+  cursor: pointer;
   transition: gap 0.25s;
-
-  :hover {
-    cursor: pointer;
-  }
 `
 
 const ExpandoColumn = styled(Column)<{ height: number; open: boolean }>`

--- a/src/components/Expando.tsx
+++ b/src/components/Expando.tsx
@@ -9,6 +9,10 @@ import styled from 'styled-components/macro'
 
 const HeaderColumn = styled(Column)`
   transition: gap 0.25s;
+
+  :hover {
+    cursor: pointer;
+  }
 `
 
 const ExpandoColumn = styled(Column)<{ height: number; open: boolean }>`
@@ -47,7 +51,7 @@ export default function Expando({ title, open, onExpand, height, children }: Pro
   const scrollbar = useScrollbar(scrollingEl)
   return (
     <Column>
-      <HeaderColumn gap={open ? 0.5 : 0.75}>
+      <HeaderColumn gap={open ? 0.5 : 0.75} onClick={onExpand}>
         <Rule />
         <Row>
           {title}
@@ -62,5 +66,4 @@ export default function Expando({ title, open, onExpand, height, children }: Pro
       </ExpandoColumn>
     </Column>
   )
-  return null
 }

--- a/src/components/Expando.tsx
+++ b/src/components/Expando.tsx
@@ -55,7 +55,7 @@ export default function Expando({ title, open, onExpand, height, children }: Pro
         <Rule />
         <Row>
           {title}
-          <IconButton color="secondary" onClick={onExpand} icon={ExpandoIcon} iconProps={{ open }} />
+          <IconButton color="secondary" icon={ExpandoIcon} iconProps={{ open }} />
         </Row>
         <Rule />
       </HeaderColumn>


### PR DESCRIPTION
Previously, only the arrow button was clickable to open swap details. Now, this entire row is clickable:

![swap gif](https://user-images.githubusercontent.com/27475332/176742193-d7c44fee-c7f6-437b-88d2-a1ed02e7ca8e.gif)

