### PR TITLE
fix: use back button instead of X

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -63,7 +63,7 @@ interface IconButtonProps {
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps & ComponentProps<typeof BaseButton>>(
   function IconButton({ icon: Icon, iconProps, ...props }: IconButtonProps & ComponentProps<typeof BaseButton>, ref) {
     return (
-      <SecondaryButton {...props} ref={ref} style={{ transform: 'translateY(2px)' }}>
+      <SecondaryButton {...props} ref={ref} style={{ transform: 'translateY(1.75px)' }}>
         <Icon {...iconProps} />
       </SecondaryButton>
     )

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -55,6 +55,10 @@ export const TextButton = transparentButton('accent')
 
 const SecondaryButton = transparentButton('secondary')
 
+const StyledIconButton = styled(SecondaryButton)`
+  transform: translateY(1.75px);
+`
+
 interface IconButtonProps {
   icon: Icon
   iconProps?: ComponentProps<Icon>
@@ -63,9 +67,9 @@ interface IconButtonProps {
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps & ComponentProps<typeof BaseButton>>(
   function IconButton({ icon: Icon, iconProps, ...props }: IconButtonProps & ComponentProps<typeof BaseButton>, ref) {
     return (
-      <SecondaryButton {...props} ref={ref} style={{ transform: 'translateY(1.75px)' }}>
+      <StyledIconButton {...props} ref={ref}>
         <Icon {...iconProps} />
-      </SecondaryButton>
+      </StyledIconButton>
     )
   }
 )

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -63,7 +63,7 @@ interface IconButtonProps {
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps & ComponentProps<typeof BaseButton>>(
   function IconButton({ icon: Icon, iconProps, ...props }: IconButtonProps & ComponentProps<typeof BaseButton>, ref) {
     return (
-      <SecondaryButton {...props} ref={ref}>
+      <SecondaryButton {...props} ref={ref} style={{ transform: 'translateY(2px)' }}>
         <Icon {...iconProps} />
       </SecondaryButton>
     )

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,15 +1,16 @@
 import 'wicg-inert'
 
-import { X } from 'icons'
+import { ChevronLeft } from 'icons'
+import { largeIconCss } from 'icons'
 import { createContext, ReactElement, ReactNode, useContext, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import styled from 'styled-components/macro'
-import { Color, Layer, ThemeProvider } from 'theme'
+import { Color, Layer, ThemedText, ThemeProvider } from 'theme'
 import { delayUnmountForAnimation } from 'utils/animations'
 
 import { IconButton } from './Button'
 import Column from './Column'
-import { default as BaseHeader } from './Header'
+import Row from './Row'
 import Rule from './Rule'
 
 // Include inert from wicg-inert
@@ -52,6 +53,12 @@ export function Provider({ value, children }: ProviderProps) {
 
 const OnCloseContext = createContext<() => void>(() => void 0)
 
+const HeaderRow = styled(Row)`
+  height: 1.75em;
+  margin: 0 0.75em 0.75em;
+  padding-top: 0.5em;
+  ${largeIconCss}
+`
 interface HeaderProps {
   title?: ReactElement
   ruled?: boolean
@@ -62,10 +69,13 @@ export function Header({ title, children, ruled }: HeaderProps) {
   return (
     <>
       <Column>
-        <BaseHeader title={title}>
+        <HeaderRow iconSize={1.2}>
+          <Row justify="flex-start" gap={0.5}>
+            <IconButton color="primary" onClick={useContext(OnCloseContext)} icon={ChevronLeft} />
+            <Row gap={0.5}>{title && <ThemedText.Subhead1>{title}</ThemedText.Subhead1>}</Row>
+          </Row>
           {children}
-          <IconButton color="primary" onClick={useContext(OnCloseContext)} icon={X} />
-        </BaseHeader>
+        </HeaderRow>
         {ruled && <Rule padded />}
       </Column>
     </>

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -1,6 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Currency } from '@uniswap/sdk-core'
-import { ChevronDown } from 'icons'
+import { ChevronRight } from 'icons'
 import { useEffect, useMemo, useState } from 'react'
 import styled, { css } from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -91,7 +91,7 @@ export default function TokenButton({ value, collapsed, disabled, onClick }: Tok
           ) : (
             <Trans>Select a token</Trans>
           )}
-          <ChevronDown color={contentColor} strokeWidth={3} />
+          <ChevronRight color={contentColor} strokeWidth={3} />
         </TokenButtonRow>
       </ThemedText.ButtonLarge>
     </StyledTokenButton>

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -51,12 +51,12 @@ const WidgetWrapper = styled.div<{ width?: number | string }>`
 
 const slideIn = keyframes`
   from {
-    transform: translateY(calc(100% - 0.25em));
+    transform: translateX(calc(100% - 0.25em));
   }
 `
 const slideOut = keyframes`
   to {
-    transform: translateY(calc(100% - 0.25em));
+    transform: translateX(calc(100% - 0.25em));
   }
 `
 

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -16,7 +16,8 @@ import {
   ArrowUp as ArrowUpIcon,
   BarChart2 as BarChart2Icon,
   CheckCircle as CheckCircleIcon,
-  ChevronDown as ChevronDownIcon,
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
   Clock as ClockIcon,
   ExternalLink as LinkIcon,
   HelpCircle as HelpCircleIcon,
@@ -81,7 +82,8 @@ export const ArrowRight = icon(ArrowRightIcon)
 export const ArrowUp = icon(ArrowUpIcon)
 export const CheckCircle = icon(CheckCircleIcon)
 export const BarChart = icon(BarChart2Icon)
-export const ChevronDown = icon(ChevronDownIcon)
+export const ChevronLeft = icon(ChevronLeftIcon)
+export const ChevronRight = icon(ChevronRightIcon)
 export const Clock = icon(ClockIcon)
 export const HelpCircle = icon(HelpCircleIcon)
 export const Info = icon(InfoIcon)


### PR DESCRIPTION
We use an X icon to close dialog tabs, which creates a double X when the widget is hosted in an integrator modal.
* change X to a back arrow
* change animation from vertical to horizontal slide

Previously:
<img width="800" alt="Screen Shot 2022-06-30 at 7 59 48 PM" src="https://user-images.githubusercontent.com/27475332/176797369-5c814105-d8b0-4f7e-bede-ed6b8ff7cd58.png">

Now:
![slide-in (1)](https://user-images.githubusercontent.com/27475332/176778157-fc7d9d7f-523e-4717-980f-3b11d66c9f91.gif)

