### PR TITLE
fix: clientside router should use existing JsonRpcProvider obj

### DIFF
--- a/src/hooks/routing/clientSideSmartOrderRouter.ts
+++ b/src/hooks/routing/clientSideSmartOrderRouter.ts
@@ -32,10 +32,9 @@ async function getQuote(
     tokenOut: { address: string; chainId: number; decimals: number; symbol?: string }
     amount: BigintIsh
   },
-  providerUrl: string,
+  provider: JsonRpcProvider,
   routerConfig: Partial<AlphaRouterConfig>
 ): Promise<{ data: GetQuoteResult; error?: unknown }> {
-  const provider = new JsonRpcProvider(providerUrl)
   const routerParams: AlphaRouterParams = { chainId, provider }
   const router = new AlphaRouter(routerParams)
 
@@ -85,7 +84,7 @@ export async function getClientSideQuote(
     amount,
     type,
   }: QuoteArguments,
-  providerUrl: string,
+  provider: JsonRpcProvider,
   routerConfig: Partial<AlphaRouterConfig>
 ) {
   return getQuote(
@@ -106,7 +105,7 @@ export async function getClientSideQuote(
       },
       amount,
     },
-    providerUrl,
+    provider,
     routerConfig
   )
 }

--- a/src/hooks/routing/useRouterArguments.ts
+++ b/src/hooks/routing/useRouterArguments.ts
@@ -1,3 +1,4 @@
+import { JsonRpcProvider } from '@ethersproject/providers'
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
 
@@ -12,14 +13,14 @@ export function useRouterArguments({
   amount,
   tradeType,
   routerUrl,
-  providerUrl,
+  provider,
 }: {
   tokenIn: Currency | undefined
   tokenOut: Currency | undefined
   amount: CurrencyAmount<Currency> | undefined
   tradeType: TradeType
   routerUrl: string | undefined
-  providerUrl: string
+  provider: JsonRpcProvider
 }) {
   return useMemo(
     () =>
@@ -36,9 +37,9 @@ export function useRouterArguments({
             tokenOutDecimals: tokenOut.wrapped.decimals,
             tokenOutSymbol: tokenOut.wrapped.symbol,
             routerUrl,
-            providerUrl,
+            provider,
             type: (tradeType === TradeType.EXACT_INPUT ? 'exactIn' : 'exactOut') as 'exactIn' | 'exactOut',
           },
-    [amount, tokenIn, tokenOut, tradeType, routerUrl, providerUrl]
+    [amount, tokenIn, tokenOut, tradeType, routerUrl, provider]
   )
 }

--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -1,3 +1,4 @@
+import { JsonRpcProvider } from '@ethersproject/providers'
 import { skipToken } from '@reduxjs/toolkit/query/react'
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 // Importing just the type, so smart-order-router is lazy-loaded
@@ -60,14 +61,13 @@ export function useRouterTrade<TTradeType extends TradeType>(
   // TODO(kristiehuang): after merging in fallback jsonRpcEndpoints, cloudflare-eth.com does not support eth_feeHistory, which we need for the router :/
   // is there any downside to just using the (free) flashbots RPC endpoints (https://rpc.flashbots.net) instead? https://docs.flashbots.net/flashbots-protect/rpc/ratelimiting
   const { library } = useActiveWeb3React()
-  const providerUrl = library?.connection.url || ''
   const queryArgs = useRouterArguments({
     tokenIn: currencyIn,
     tokenOut: currencyOut,
     amount: debouncedAmountSpecified,
     tradeType,
     routerUrl,
-    providerUrl,
+    provider: library as JsonRpcProvider,
   })
 
   const { isFetching, isError, data, currentData } = useGetQuoteQuery(queryArgs ?? skipToken, {

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -10,5 +10,8 @@ const reducer = combineReducers({
 })
 export const store = configureStore({
   reducer,
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware({ thunk: true }).concat(routing.middleware),
+  middleware: (getDefaultMiddleware) =>
+    // in routing, we pass in a non-serializable provider object to queryFn to avoid re-instantiating on every query
+    // since we don't use time-travel debugging nor persistance, we can ignore the serializable check + store non-serializable items in state
+    getDefaultMiddleware({ thunk: true, serializableCheck: false }).concat(routing.middleware),
 })

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -19,7 +19,7 @@ const DEFAULT_QUERY_PARAMS = {
 }
 
 const serializeRoutingCacheKey: SerializeQueryArgs<any> = ({ endpointName, queryArgs }) => {
-  // same as default serializeQueryArgs, but we add extra case for serialization if key is provider
+  // same as default serializeQueryArgs, but we add extra case if key is our non-serializable JsonRpcProvider
   return `${endpointName}(${JSON.stringify(queryArgs, (key, value) => {
     if (key === 'provider') {
       return value?.connection?.url
@@ -64,7 +64,7 @@ export const routing = createApi({
           args
 
         async function getClientSideQuote() {
-          // Lazy-load the smart order router to improve initial pageload times.
+          // Lazy-load the clientside router to improve initial pageload times.
           return await (
             await import('../../hooks/routing/clientSideSmartOrderRouter')
           ).getClientSideQuote(args, provider, { protocols })
@@ -72,7 +72,7 @@ export const routing = createApi({
 
         let result
         if (Boolean(routerUrl)) {
-          // Try routing API, fallback to SOR
+          // Try routing API, fallback to clientside SOR
           try {
             const query = qs.stringify({
               ...DEFAULT_QUERY_PARAMS,
@@ -95,7 +95,7 @@ export const routing = createApi({
             result = await getClientSideQuote()
           }
         } else {
-          // If integrator did not provide a routing API URL param, use client-side SOR
+          // If integrator did not provide a routing API URL param, use clientside SOR
           result = await getClientSideQuote()
         }
         if (result?.error) return { error: result.error as FetchBaseQueryError }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -1,6 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { isPlainObject } from '@reduxjs/toolkit'
-import type { BaseQueryArg, BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
 import { SerializeQueryArgs } from '@reduxjs/toolkit/dist/query/defaultSerializeQueryArgs'
 import { createApi, fetchBaseQuery, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 import { Protocol } from '@uniswap/router-sdk'
@@ -20,7 +19,7 @@ const DEFAULT_QUERY_PARAMS = {
 }
 
 const serializeRoutingCacheKey: SerializeQueryArgs<any> = ({ endpointName, queryArgs }) => {
-  // take the query arguments, sort object keys where applicable, stringify the result, and concatenate it with the endpoint name
+  // same as default serializeQueryArgs, but we add extra case for serialization if key is provider
   return `${endpointName}(${JSON.stringify(queryArgs, (key, value) => {
     if (key === 'provider') {
       return value?.connection?.url

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -1,3 +1,7 @@
+import { JsonRpcProvider } from '@ethersproject/providers'
+import { isPlainObject } from '@reduxjs/toolkit'
+import type { BaseQueryArg, BaseQueryFn } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import { SerializeQueryArgs } from '@reduxjs/toolkit/dist/query/defaultSerializeQueryArgs'
 import { createApi, fetchBaseQuery, FetchBaseQueryError } from '@reduxjs/toolkit/query/react'
 import { Protocol } from '@uniswap/router-sdk'
 // Importing just the type, so smart-order-router is lazy-loaded
@@ -15,9 +19,29 @@ const DEFAULT_QUERY_PARAMS = {
   protocols: protocols.map((p) => p.toLowerCase()).join(','),
 }
 
+const serializeRoutingCacheKey: SerializeQueryArgs<any> = ({ endpointName, queryArgs }) => {
+  // take the query arguments, sort object keys where applicable, stringify the result, and concatenate it with the endpoint name
+  return `${endpointName}(${JSON.stringify(queryArgs, (key, value) => {
+    if (key === 'provider') {
+      return value?.connection?.url
+    }
+    if (isPlainObject(value)) {
+      return Object.keys(value)
+        .sort()
+        .reduce<any>((acc, key) => {
+          acc[key] = (value as any)[key]
+          return acc
+        }, {})
+    } else {
+      return value
+    }
+  })})`
+}
+
 export const routing = createApi({
   reducerPath: 'routing',
   baseQuery: fetchBaseQuery({ baseUrl: '/' }),
+  serializeQueryArgs: serializeRoutingCacheKey,
   endpoints: (build) => ({
     getQuote: build.query<
       GetQuoteResult,
@@ -32,27 +56,19 @@ export const routing = createApi({
         tokenOutSymbol?: string
         amount: string
         routerUrl?: string
-        providerUrl: string
+        provider: JsonRpcProvider
         type: 'exactIn' | 'exactOut'
       }
     >({
       async queryFn(args, _api, _extraOptions) {
-        const {
-          tokenInAddress,
-          tokenInChainId,
-          tokenOutAddress,
-          tokenOutChainId,
-          amount,
-          routerUrl,
-          providerUrl,
-          type,
-        } = args
+        const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, routerUrl, provider, type } =
+          args
 
         async function getClientSideQuote() {
           // Lazy-load the smart order router to improve initial pageload times.
           return await (
             await import('../../hooks/routing/clientSideSmartOrderRouter')
-          ).getClientSideQuote(args, providerUrl, { protocols })
+          ).getClientSideQuote(args, provider, { protocols })
         }
 
         let result


### PR DESCRIPTION
Instead of reinstantiating provider obj from providerUrl, we want to pass in our existing JsonRpcProvider obj to routingApi. While rtk-query will cache args, it doesn't destroy the provider args - meaning our javascript garbage collector will collect it, which mean it may live in memory for longer than we want. (??)

Since we don't need time-travel debugging nor persistence, we can store non-serializable objects in state.
* We turn off the serializable check for routing
* Use a custom `serializeQueryArgs` fxn to generate a query cache key