### PR TITLE
fix: stroke width of token button chevron to 2px

### DIFF
--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -91,7 +91,7 @@ export default function TokenButton({ value, collapsed, disabled, onClick }: Tok
           ) : (
             <Trans>Select a token</Trans>
           )}
-          <ChevronRight color={contentColor} strokeWidth={3} />
+          <ChevronRight color={contentColor} strokeWidth={2} />
         </TokenButtonRow>
       </ThemedText.ButtonLarge>
     </StyledTokenButton>


### PR DESCRIPTION
Nit from Phil - chevron stroke should be 2px, not 3px
<img width="360" alt="Screen Shot 2022-07-19 at 11 05 04 AM" src="https://user-images.githubusercontent.com/27475332/179783807-bc8c4d2c-6f16-450b-b10c-9a35aabed3ce.png">

<img width="366" alt="Screen Shot 2022-07-19 at 11 04 42 AM" src="https://user-images.githubusercontent.com/27475332/179783708-65c21e62-2d31-4a69-bf23-e8758a9b03b1.png">
