### PR TITLE
feat: remove tooltip hops description

### DIFF
--- a/src/components/Swap/RoutingDiagram/index.tsx
+++ b/src/components/Swap/RoutingDiagram/index.tsx
@@ -1,4 +1,4 @@
-import { Plural, Trans } from '@lingui/macro'
+import { Trans } from '@lingui/macro'
 import { Currency, TradeType } from '@uniswap/sdk-core'
 import { FeeAmount } from '@uniswap/v3-sdk'
 import { ReactComponent as DotLine } from 'assets/svg/dot_line.svg'
@@ -22,7 +22,7 @@ const StyledAutoRouterLabel = styled(ThemedText.ButtonSmall)`
   }
 `
 
-function Header({ routes }: { routes: RoutingDiagramEntry[] }) {
+function Header() {
   return (
     <Row justify="space-between" gap={1}>
       <ThemedText.Subhead2>
@@ -33,9 +33,6 @@ function Header({ routes }: { routes: RoutingDiagramEntry[] }) {
           </StyledAutoRouterLabel>
         </Row>
       </ThemedText.Subhead2>
-      <ThemedText.Body2>
-        <Plural value={routes.length} _1="Best route via 1 hop" other="Best route via # hops" />
-      </ThemedText.Body2>
     </Row>
   )
 }
@@ -130,7 +127,7 @@ export default function RoutingDiagram({ trade }: { trade: InterfaceTrade<Curren
 
   return (
     <Column gap={0.75}>
-      <Header routes={routes} />
+      <Header />
       <Rule />
       {routes.map((route, index) => (
         <Route key={index} route={route} />

--- a/src/components/Swap/RoutingDiagram/index.tsx
+++ b/src/components/Swap/RoutingDiagram/index.tsx
@@ -24,16 +24,14 @@ const StyledAutoRouterLabel = styled(ThemedText.ButtonSmall)`
 
 function Header() {
   return (
-    <Row justify="space-between" gap={1}>
-      <ThemedText.Subhead2>
-        <Row gap={0.25}>
-          <AutoRouter />
-          <StyledAutoRouterLabel color="primary" lineHeight={'16px'}>
-            <Trans>Auto Router</Trans>
-          </StyledAutoRouterLabel>
-        </Row>
-      </ThemedText.Subhead2>
-    </Row>
+    <ThemedText.Subhead2>
+      <Row justify="left" gap={0.25}>
+        <AutoRouter />
+        <StyledAutoRouterLabel color="primary" lineHeight={'16px'}>
+          <Trans>Auto Router</Trans>
+        </StyledAutoRouterLabel>
+      </Row>
+    </ThemedText.Subhead2>
   )
 }
 


### PR DESCRIPTION
remove tooltip hops description - confusing language + we took it off interface already

| before | after |
| ------ | ----- |
| <img width="200" alt="Screen Shot 2022-07-22 at 11 13 06 AM" src="https://user-images.githubusercontent.com/27475332/180469769-cf29b8be-456c-4bfc-a99a-486a7b59091a.png"> | <img width="200" alt="Screen Shot 2022-07-22 at 11 11 53 AM" src="https://user-images.githubusercontent.com/27475332/180469558-3bc6a8cf-9e91-41ae-869d-c87e5ab48f40.png"> |
