### PR TITLE
fix: set summary expando-open bool default true

### DIFF
--- a/src/components/Swap/Summary/Summary.tsx
+++ b/src/components/Swap/Summary/Summary.tsx
@@ -49,10 +49,10 @@ interface SummaryProps {
   inputUSDC?: CurrencyAmount<Currency>
   outputUSDC?: CurrencyAmount<Currency>
   impact?: PriceImpact
-  open: boolean // if expando is open
+  open?: boolean // if expando is open
 }
 
-export default function Summary({ input, output, inputUSDC, outputUSDC, impact, open }: SummaryProps) {
+export default function Summary({ input, output, inputUSDC, outputUSDC, impact, open = true }: SummaryProps) {
   const summaryContents = (
     <>
       <TokenValue input={input} usdc={inputUSDC} open={open} />


### PR DESCRIPTION
build was failing bc forgot to pass mandatory `open` prop to TransactionStatusDialog's usage of Summary component.

* Made `open` prop optional & default true

<img width="369" alt="Screen Shot 2022-08-05 at 2 38 44 PM" src="https://user-images.githubusercontent.com/27475332/183140771-1172e8ac-8104-4f4e-8635-043c9b14051d.png">
