### PR TITLE
fix: make header text clickable

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -67,11 +67,12 @@ interface HeaderProps {
 }
 
 export function Header({ title, children, ruled }: HeaderProps) {
+  const onClose = useContext(OnCloseContext)
   return (
     <>
       <Column>
         <HeaderRow iconSize={1.2}>
-          <TextButton color="primary" onClick={useContext(OnCloseContext)}>
+          <TextButton color="primary" onClick={onClose}>
             <Row justify="flex-start" gap={0.5}>
               <ChevronLeft />
               <Row gap={0.5}>{title && <ThemedText.Subhead1>{title}</ThemedText.Subhead1>}</Row>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components/macro'
 import { Color, Layer, ThemedText, ThemeProvider } from 'theme'
 import { delayUnmountForAnimation } from 'utils/animations'
 
-import { IconButton } from './Button'
+import { TextButton } from './Button'
 import Column from './Column'
 import Row from './Row'
 import Rule from './Rule'
@@ -59,6 +59,7 @@ const HeaderRow = styled(Row)`
   padding-top: 0.5em;
   ${largeIconCss}
 `
+
 interface HeaderProps {
   title?: ReactElement
   ruled?: boolean
@@ -70,10 +71,12 @@ export function Header({ title, children, ruled }: HeaderProps) {
     <>
       <Column>
         <HeaderRow iconSize={1.2}>
-          <Row justify="flex-start" gap={0.5}>
-            <IconButton color="primary" onClick={useContext(OnCloseContext)} icon={ChevronLeft} />
-            <Row gap={0.5}>{title && <ThemedText.Subhead1>{title}</ThemedText.Subhead1>}</Row>
-          </Row>
+          <TextButton color="primary" onClick={useContext(OnCloseContext)}>
+            <Row justify="flex-start" gap={0.5}>
+              <ChevronLeft />
+              <Row gap={0.5}>{title && <ThemedText.Subhead1>{title}</ThemedText.Subhead1>}</Row>
+            </Row>
+          </TextButton>
           {children}
         </HeaderRow>
         {ruled && <Rule padded />}

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -91,9 +91,7 @@ function Fixture() {
           resolve(true) // to open our built-in wallet connect flow
         })
       }
-      onReviewSwapClick={() => {
-        return new Promise((resolve) => resolve(true))
-      }}
+      onReviewSwapClick={() => new Promise((resolve) => resolve(true))}
       onTxSubmit={(txHash: string, data: any) => console.log('tx submitted:', txHash, data)}
       onTxSuccess={(txHash: string, data: any) => console.log('tx success:', txHash, data)}
       onTxFail={(error: Error, data: any) => console.log('tx fail:', error, data)}


### PR DESCRIPTION
Both left arrow & header text are now clickable in a dialog popup (as per design request)

<img width="188" alt="Screen Shot 2022-08-08 at 1 30 05 PM" src="https://user-images.githubusercontent.com/27475332/183508763-bd344877-4725-4d9a-b978-aa7420996e3b.png">
