### PR TITLE
fix: use container color for button

### DIFF
--- a/src/components/ConnectWallet/ConnectWalletDialog.tsx
+++ b/src/components/ConnectWallet/ConnectWalletDialog.tsx
@@ -38,7 +38,6 @@ const StyledButtonContents = styled(Column)`
 `
 
 const StyledMainButton = styled(Button)`
-  background-color: ${({ theme }) => theme.container};
   border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   height: 200px;
   padding: 22px;
@@ -50,7 +49,6 @@ const StyledMainButtonRow = styled(Row)`
 `
 
 const StyledSmallButton = styled(Button)`
-  background-color: ${({ theme }) => theme.container};
   border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   height: 88px;
   padding: 16px;
@@ -161,7 +159,7 @@ function WalletConnectButton({ walletName, logoSrc, connection: wcTileConnection
   })
 
   return (
-    <StyledMainButton onClick={onClick}>
+    <StyledMainButton color="container" onClick={onClick}>
       <StyledMainButtonRow>
         <ButtonContents
           logoSrc={logoSrc}
@@ -176,7 +174,7 @@ function WalletConnectButton({ walletName, logoSrc, connection: wcTileConnection
 
 function MetaMaskButton({ walletName, logoSrc, onClick }: ButtonProps) {
   return (
-    <StyledSmallButton onClick={onClick}>
+    <StyledSmallButton color="container" onClick={onClick}>
       <ButtonContents logoSrc={logoSrc} walletName={walletName} />
     </StyledSmallButton>
   )
@@ -184,7 +182,7 @@ function MetaMaskButton({ walletName, logoSrc, onClick }: ButtonProps) {
 
 function NoWalletButton() {
   return (
-    <StyledSmallButton onClick={() => window.open(NO_WALLET_HELP_CENTER_URL)}>
+    <StyledSmallButton color="container" onClick={() => window.open(NO_WALLET_HELP_CENTER_URL)}>
       <StyledNoWalletText>
         <Trans>{`I don't have a wallet`}</Trans>
       </StyledNoWalletText>


### PR DESCRIPTION
Pass in `container` theme color to button so that hover states use "container" theme

before:
<img width="200" alt="Screen Shot 2022-08-08 at 5 47 54 PM" src="https://user-images.githubusercontent.com/27475332/183538891-aa99e068-0aa0-410f-b991-fed3fc47b02e.png">
after:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/27475332/183538935-674ca1ca-2f32-49bf-9e71-ac7cb7ea9c49.png">