### PR TITLE
fix: respond to events

### DIFF
--- a/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/components/ConnectWallet/ConnectWallet.tsx
@@ -27,7 +27,7 @@ export default function ConnectWallet({ disabled }: ConnectWalletProps) {
 
   const onConnectWalletClick = useAtomValue(onConnectWalletClickAtom)
   const onClick = useCallback(async () => {
-    setOpen((await onConnectWalletClick?.()?.catch(() => true)) ?? true)
+    setOpen((await onConnectWalletClick?.()?.catch(() => false)) ?? true)
   }, [onConnectWalletClick])
 
   return (

--- a/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/components/ConnectWallet/ConnectWallet.tsx
@@ -27,7 +27,7 @@ export default function ConnectWallet({ disabled }: ConnectWalletProps) {
 
   const onConnectWalletClick = useAtomValue(onConnectWalletClickAtom)
   const onClick = useCallback(async () => {
-    setOpen((await onConnectWalletClick?.()) ?? true)
+    setOpen((await onConnectWalletClick?.()?.catch(() => true)) ?? true)
   }, [onConnectWalletClick])
 
   return (

--- a/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/components/ConnectWallet/ConnectWallet.tsx
@@ -27,7 +27,8 @@ export default function ConnectWallet({ disabled }: ConnectWalletProps) {
 
   const onConnectWalletClick = useAtomValue(onConnectWalletClickAtom)
   const onClick = useCallback(async () => {
-    setOpen((await onConnectWalletClick?.()?.catch(() => false)) ?? true)
+    const open = await onConnectWalletClick?.()?.catch(() => false)
+    setOpen(open ?? true)
   }, [onConnectWalletClick])
 
   return (

--- a/src/components/ConnectWallet/ConnectWallet.tsx
+++ b/src/components/ConnectWallet/ConnectWallet.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { Wallet as WalletIcon } from 'icons'
 import { useAtomValue } from 'jotai/utils'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { onConnectWalletClickAtom } from 'state/wallet'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -26,10 +26,9 @@ export default function ConnectWallet({ disabled }: ConnectWalletProps) {
   const onClose = () => setOpen(false)
 
   const onConnectWalletClick = useAtomValue(onConnectWalletClickAtom)
-  const onClick = () => {
-    const promise = onConnectWalletClick && onConnectWalletClick()
-    return promise ? promise.then((open) => setOpen(open)) : setOpen(true)
-  }
+  const onClick = useCallback(async () => {
+    setOpen((await onConnectWalletClick?.()) ?? true)
+  }, [onConnectWalletClick])
 
   return (
     <>

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -160,7 +160,8 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
         : trade.state === TradeState.VALID
         ? {
             onClick: async () => {
-              setOpen((await onReviewSwapClick?.()?.catch(() => false)) ?? true)
+              const open = await onReviewSwapClick?.()?.catch(() => false)
+              setOpen(open ?? true)
             },
           }
         : { disabled: true }

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -160,7 +160,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
         : trade.state === TradeState.VALID
         ? {
             onClick: async () => {
-              setOpen((await onReviewSwapClick?.()) ?? true)
+              setOpen((await onReviewSwapClick?.()?.catch(() => true)) ?? true)
             },
           }
         : { disabled: true }

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -160,7 +160,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
         : trade.state === TradeState.VALID
         ? {
             onClick: async () => {
-              setOpen((await onReviewSwapClick?.()?.catch(() => true)) ?? true)
+              setOpen((await onReviewSwapClick?.()?.catch(() => false)) ?? true)
             },
           }
         : { disabled: true }

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -159,9 +159,8 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
         ? { action: approvalAction }
         : trade.state === TradeState.VALID
         ? {
-            onClick: () => {
-              const promise = onReviewSwapClick && onReviewSwapClick()
-              return promise ? promise.then((open) => setOpen(open)) : setOpen(true)
+            onClick: async () => {
+              setOpen((await onReviewSwapClick?.()) ?? true)
             },
           }
         : { disabled: true }

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -9,10 +9,10 @@ import useSyncTokenDefaults, { TokenDefaults } from 'hooks/swap/useSyncTokenDefa
 import { usePendingTransactions } from 'hooks/transactions'
 import useHasFocus from 'hooks/useHasFocus'
 import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
-import useSyncEventHandlers from 'hooks/useSyncEventHandlers'
+import useSyncEventHandlers, { EventHandlers } from 'hooks/useSyncEventHandlers'
 import { useAtom } from 'jotai'
 import { useState } from 'react'
-import { displayTxHashAtom, Field } from 'state/swap'
+import { displayTxHashAtom } from 'state/swap'
 import { SwapTransactionInfo, Transaction, TransactionType, WrapTransactionInfo } from 'state/transactions'
 
 import Dialog from '../Dialog'
@@ -45,20 +45,17 @@ function getTransactionFromMap(
 
 // SwapProps also currently includes props needed for wallet connection, since the wallet connection component exists within the Swap component
 // TODO(kristiehuang): refactor WalletConnection outside of Swap component
-export interface SwapProps extends TokenDefaults, FeeOptions {
+export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults {
   hideConnectionUI?: boolean
   provider?: Eip1193Provider | JsonRpcProvider
   routerUrl?: string
-  onConnectWalletClick?: () => void | Promise<boolean>
-  onReviewSwapClick?: () => void | Promise<boolean>
-  onTokenSelectorClick?: (f: Field) => void | Promise<boolean>
 }
 
 export default function Swap(props: SwapProps) {
   useValidate(props)
-  useSyncConvenienceFee(props)
-  useSyncTokenDefaults(props)
-  useSyncEventHandlers(props)
+  useSyncEventHandlers(props as EventHandlers)
+  useSyncConvenienceFee(props as FeeOptions)
+  useSyncTokenDefaults(props as TokenDefaults)
 
   const { isActive } = useWeb3React()
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -134,7 +134,7 @@ export default memo(function TokenSelect({ collapsed, disabled, field, onSelect,
   const [open, setOpen] = useState(false)
   const onTokenSelectorClick = useAtomValue(onTokenSelectorClickAtom)
   const onOpen = useCallback(async () => {
-    setOpen((await onTokenSelectorClick?.(field)) ?? true)
+    setOpen((await onTokenSelectorClick?.(field)?.catch(() => true)) ?? true)
   }, [field, onTokenSelectorClick])
   const selectAndClose = useCallback(
     (value: Currency) => {

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -134,7 +134,8 @@ export default memo(function TokenSelect({ collapsed, disabled, field, onSelect,
   const [open, setOpen] = useState(false)
   const onTokenSelectorClick = useAtomValue(onTokenSelectorClickAtom)
   const onOpen = useCallback(async () => {
-    setOpen((await onTokenSelectorClick?.(field)?.catch(() => false)) ?? true)
+    const open = await onTokenSelectorClick?.(field)?.catch(() => false)
+    setOpen(open ?? true)
   }, [field, onTokenSelectorClick])
   const selectAndClose = useCallback(
     (value: Currency) => {

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -133,18 +133,8 @@ export default memo(function TokenSelect({ collapsed, disabled, field, onSelect,
 
   const [open, setOpen] = useState(false)
   const onTokenSelectorClick = useAtomValue(onTokenSelectorClickAtom)
-  const onOpen = useCallback(() => {
-    const promise = onTokenSelectorClick?.(field)
-    if (promise) {
-      return promise
-        .then((open) => {
-          setOpen(open)
-        })
-        .catch(() => {
-          setOpen(false)
-        })
-    }
-    return setOpen(true)
+  const onOpen = useCallback(async () => {
+    setOpen((await onTokenSelectorClick?.(field)) ?? true)
   }, [field, onTokenSelectorClick])
   const selectAndClose = useCallback(
     (value: Currency) => {

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -134,7 +134,7 @@ export default memo(function TokenSelect({ collapsed, disabled, field, onSelect,
   const [open, setOpen] = useState(false)
   const onTokenSelectorClick = useAtomValue(onTokenSelectorClickAtom)
   const onOpen = useCallback(async () => {
-    setOpen((await onTokenSelectorClick?.(field)?.catch(() => true)) ?? true)
+    setOpen((await onTokenSelectorClick?.(field)?.catch(() => false)) ?? true)
   }, [field, onTokenSelectorClick])
   const selectAndClose = useCallback(
     (value: Currency) => {

--- a/src/hooks/useSyncEventHandlers.ts
+++ b/src/hooks/useSyncEventHandlers.ts
@@ -1,37 +1,31 @@
-import { useAtom } from 'jotai'
+import { useUpdateAtom } from 'jotai/utils'
 import { useEffect } from 'react'
 import { Field, onReviewSwapClickAtom, onTokenSelectorClickAtom } from 'state/swap'
 import { onConnectWalletClickAtom } from 'state/wallet'
 
-interface UseSyncEventHandlersArgs {
+export interface EventHandlers {
   onConnectWalletClick?: () => void | Promise<boolean>
   onReviewSwapClick?: () => void | Promise<boolean>
-  onTokenSelectorClick?: (f: Field) => void | Promise<boolean>
+  onTokenSelectorClick?: (field: Field) => void | Promise<boolean>
 }
 
-export default function useSyncEventHandlers(handlers: UseSyncEventHandlersArgs): void {
-  const [onReviewSwapClick, setOnReviewSwapClick] = useAtom(onReviewSwapClickAtom)
-  useEffect(() => {
-    if (handlers.onReviewSwapClick !== onReviewSwapClick) {
-      setOnReviewSwapClick((old: (() => void | Promise<boolean>) | undefined) => (old = handlers.onReviewSwapClick))
-    }
-  }, [handlers.onReviewSwapClick, onReviewSwapClick, setOnReviewSwapClick])
+export default function useSyncEventHandlers({
+  onConnectWalletClick,
+  onReviewSwapClick,
+  onTokenSelectorClick,
+}: EventHandlers): void {
+  const setOnReviewSwapClick = useUpdateAtom(onReviewSwapClickAtom)
+  useEffect(() => setOnReviewSwapClick((old) => (old = onReviewSwapClick)), [onReviewSwapClick, setOnReviewSwapClick])
 
-  const [onConnectWalletClick, setOnConnectWalletClick] = useAtom(onConnectWalletClickAtom)
-  useEffect(() => {
-    if (handlers.onConnectWalletClick !== onConnectWalletClick) {
-      setOnConnectWalletClick(
-        (old: (() => void | Promise<boolean>) | undefined) => (old = handlers.onConnectWalletClick)
-      )
-    }
-  }, [handlers.onConnectWalletClick, onConnectWalletClick, setOnConnectWalletClick])
+  const setOnConnectWalletClick = useUpdateAtom(onConnectWalletClickAtom)
+  useEffect(
+    () => setOnConnectWalletClick((old) => (old = onConnectWalletClick)),
+    [onConnectWalletClick, setOnConnectWalletClick]
+  )
 
-  const [onTokenSelectorClick, setOnTokenSelectorClick] = useAtom(onTokenSelectorClickAtom)
-  useEffect(() => {
-    if (handlers.onTokenSelectorClick !== onTokenSelectorClick) {
-      setOnTokenSelectorClick(
-        (old: ((f: Field) => void | Promise<boolean>) | undefined) => (old = handlers.onTokenSelectorClick)
-      )
-    }
-  }, [handlers.onTokenSelectorClick, onTokenSelectorClick, setOnTokenSelectorClick])
+  const setOnTokenSelectorClick = useUpdateAtom(onTokenSelectorClickAtom)
+  useEffect(
+    () => setOnTokenSelectorClick((old: typeof onTokenSelectorClick) => (old = onTokenSelectorClick)),
+    [onTokenSelectorClick, setOnTokenSelectorClick]
+  )
 }


### PR DESCRIPTION
- Prevents re-keying web3-react when `Widget` props change
  Effectively, this was preventing state from updating in async handlers (such as event handlers).
- Simplifies event handler code throughout:
  - Integrates typings in SwapProps
  - Excludes values from hook deps (to reduce hook calls)
  - Simplifies cosmos `useEventHandler` to handle all arguments