### PR TITLE
feat: allow controlling the widget

### DIFF
--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -46,7 +46,7 @@ function getTransactionFromMap(
 
 // SwapProps also currently includes props needed for wallet connection, since the wallet connection component exists within the Swap component
 // TODO(kristiehuang): refactor WalletConnection outside of Swap component
-export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults, Partial<Controller> {
+export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults, Controller {
   hideConnectionUI?: boolean
   provider?: Eip1193Provider | JsonRpcProvider
   routerUrl?: string
@@ -54,7 +54,7 @@ export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults, Par
 
 export default function Swap(props: SwapProps) {
   useValidate(props)
-  useSyncController(props as Partial<Controller>)
+  useSyncController(props as Controller)
   useSyncEventHandlers(props as EventHandlers)
   useSyncConvenienceFee(props as FeeOptions)
   useSyncTokenDefaults(props as TokenDefaults)

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -4,6 +4,7 @@ import { useWeb3React } from '@web3-react/core'
 import { Provider as Eip1193Provider } from '@web3-react/types'
 import Wallet from 'components/ConnectWallet'
 import { SwapInfoProvider } from 'hooks/swap/useSwapInfo'
+import useSyncController, { Controller } from 'hooks/swap/useSyncController'
 import useSyncConvenienceFee, { FeeOptions } from 'hooks/swap/useSyncConvenienceFee'
 import useSyncTokenDefaults, { TokenDefaults } from 'hooks/swap/useSyncTokenDefaults'
 import { usePendingTransactions } from 'hooks/transactions'
@@ -45,7 +46,7 @@ function getTransactionFromMap(
 
 // SwapProps also currently includes props needed for wallet connection, since the wallet connection component exists within the Swap component
 // TODO(kristiehuang): refactor WalletConnection outside of Swap component
-export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults {
+export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults, Partial<Controller> {
   hideConnectionUI?: boolean
   provider?: Eip1193Provider | JsonRpcProvider
   routerUrl?: string
@@ -53,6 +54,7 @@ export interface SwapProps extends EventHandlers, FeeOptions, TokenDefaults {
 
 export default function Swap(props: SwapProps) {
   useValidate(props)
+  useSyncController(props as Partial<Controller>)
   useSyncEventHandlers(props as EventHandlers)
   useSyncConvenienceFee(props as FeeOptions)
   useSyncTokenDefaults(props as TokenDefaults)

--- a/src/cosmos/ControlledSwap.fixture.tsx
+++ b/src/cosmos/ControlledSwap.fixture.tsx
@@ -1,0 +1,67 @@
+import { tokens } from '@uniswap/default-token-list'
+import { Currency, TradeType } from '@uniswap/sdk-core'
+import { SupportedChainId, SwapWidget } from '@uniswap/widgets'
+import Row from 'components/Row'
+import { useCallback, useState } from 'react'
+import { useValue } from 'react-cosmos/fixture'
+
+import { DAI, nativeOnChain, USDC_MAINNET } from '../constants/tokens'
+import EventFeed, { Event } from './EventFeed'
+import useOption from './useOption'
+import useProvider, { INFURA_NETWORK_URLS } from './useProvider'
+
+function Fixture() {
+  const [events, setEvents] = useState<Event[]>([])
+  const useHandleEvent = useCallback(
+    (name: string) =>
+      (...data: unknown[]) =>
+        setEvents((events) => [...events, { name, data }]),
+    []
+  )
+
+  const tradeType = useOption('tradeType', {
+    nullable: false,
+    defaultValue: 'Exact Input',
+    options: {
+      'Exact Input': TradeType.EXACT_INPUT,
+      'Exact Output': TradeType.EXACT_OUTPUT,
+    },
+  })
+  const [amount] = useValue('amount', { defaultValue: '0' })
+  const currencies: Record<string, Currency> = {
+    ETH: nativeOnChain(SupportedChainId.MAINNET),
+    DAI,
+    USDC: USDC_MAINNET,
+  }
+  const inputToken = useOption('input', { options: currencies })
+  const outputToken = useOption('output', { options: currencies })
+
+  const connector = useProvider(SupportedChainId.MAINNET)
+
+  return (
+    <Row align="start" justify="space-around">
+      <SwapWidget
+        type={tradeType}
+        amount={amount}
+        inputToken={inputToken}
+        outputToken={outputToken}
+        onTokenChange={useHandleEvent('onTokenChange')}
+        onAmountChange={useHandleEvent('onAmountChange')}
+        onSwitchTokens={useHandleEvent('onSwitchTokens')}
+        hideConnectionUI={true}
+        jsonRpcUrlMap={INFURA_NETWORK_URLS}
+        provider={connector}
+        tokenList={tokens}
+        onConnectWalletClick={useHandleEvent('onConnectWalletClick')}
+        onReviewSwapClick={useHandleEvent('onReviewSwapClick')}
+        onTokenSelectorClick={useHandleEvent('onTokenSelectorClick')}
+        onTxSubmit={useHandleEvent('onTxSubmit')}
+        onTxSuccess={useHandleEvent('onTxSuccess')}
+        onTxFail={useHandleEvent('onTxFail')}
+      />
+      <EventFeed events={events} onClear={() => setEvents([])} />
+    </Row>
+  )
+}
+
+export default <Fixture />

--- a/src/cosmos/EventFeed.tsx
+++ b/src/cosmos/EventFeed.tsx
@@ -1,0 +1,59 @@
+import { defaultTheme } from '@uniswap/widgets'
+import Row from 'components/Row'
+import styled from 'styled-components/macro'
+import * as Type from 'theme/type'
+
+const EventFeedWrapper = styled.div`
+  background-color: ${defaultTheme.container};
+  border-radius: ${defaultTheme.borderRadius}em;
+  box-sizing: border-box;
+  font-family: ${defaultTheme.fontFamily.font};
+  padding: 1em;
+  width: 360px;
+`
+const EventColumn = styled.div`
+  height: 80vh;
+  overflow: auto;
+`
+const EventRow = styled.div`
+  background-color: ${defaultTheme.module};
+  border-radius: ${defaultTheme.borderRadius / 2}em;
+  margin: 0.5em 0;
+  padding: 0.2em 0.2em 0.5em;
+`
+const EventData = styled.pre`
+  margin: 0.5em 0 0;
+`
+
+export interface Event {
+  name: string
+  data: unknown
+}
+
+export interface EventFeedProps {
+  events: Event[]
+  onClear: () => void
+}
+
+export default function EventFeed({ events, onClear }: EventFeedProps) {
+  return (
+    <EventFeedWrapper>
+      <Row>
+        <Type.Subhead1>Event Feed</Type.Subhead1>
+        <button onClick={onClear}>
+          <Type.Subhead1>clear</Type.Subhead1>
+        </button>
+      </Row>
+      <EventColumn>
+        {events?.map(({ name, data }, i) => (
+          <EventRow key={i}>
+            <Type.Subhead2 margin={0} padding={0}>
+              {name}
+            </Type.Subhead2>
+            <EventData>{JSON.stringify(data, null, 2)}</EventData>
+          </EventRow>
+        ))}
+      </EventColumn>
+    </EventFeedWrapper>
+  )
+}

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -13,41 +13,11 @@ import Row from 'components/Row'
 import { CHAIN_NAMES_TO_IDS } from 'constants/chains'
 import { useCallback, useEffect, useState } from 'react'
 import { useValue } from 'react-cosmos/fixture'
-import styled from 'styled-components/macro'
-import * as Type from 'theme/type'
 
 import { DAI, USDC_MAINNET } from '../constants/tokens'
+import EventFeed, { Event } from './EventFeed'
 import useOption from './useOption'
 import useProvider, { INFURA_NETWORK_URLS } from './useProvider'
-
-const EventFeedWrapper = styled.div`
-  background-color: ${defaultTheme.container};
-  border-radius: ${defaultTheme.borderRadius}em;
-  box-sizing: border-box;
-  font-family: ${defaultTheme.fontFamily.font};
-  padding: 1em;
-  width: 360px;
-`
-const EventData = styled.div`
-  height: 80vh;
-  overflow: auto;
-`
-const EventJSON = styled.pre`
-  margin-top: 1em;
-`
-const EventRow = styled.div`
-  background-color: ${defaultTheme.module};
-  border-radius: ${defaultTheme.borderRadius / 2}em;
-  margin: 1em 0;
-  padding: 0.2em;
-`
-const Message = styled.pre`
-  margin: 0;
-`
-interface Event {
-  name: string
-  data: unknown
-}
 
 function Fixture() {
   const [events, setEvents] = useState<Event[]>([])
@@ -130,24 +100,7 @@ function Fixture() {
         onTxSuccess={useHandleEvent('onTxSuccess')}
         onTxFail={useHandleEvent('onTxFail')}
       />
-      <EventFeedWrapper>
-        <Type.H2>Event Feed</Type.H2>
-        <button onClick={() => setEvents([])} disabled={events.length === 0}>
-          clear
-        </button>
-        <EventData>
-          {events?.map(({ name, data }, i) => (
-            <EventRow key={i}>
-              <div>
-                <Type.H3 padding={0}>
-                  <Message>{name}</Message>
-                </Type.H3>
-                <EventJSON>{JSON.stringify(data, null, 2)}</EventJSON>
-              </div>
-            </EventRow>
-          ))}
-        </EventData>
-      </EventFeedWrapper>
+      <EventFeed events={events} onClear={() => setEvents([])} />
     </Row>
   )
 }

--- a/src/hooks/swap/index.test.tsx
+++ b/src/hooks/swap/index.test.tsx
@@ -1,0 +1,142 @@
+import { TradeType } from '@uniswap/sdk-core'
+import { SupportedChainId } from 'constants/chains'
+import { DAI, UNI, USDC_MAINNET } from 'constants/tokens'
+import { useAtomValue } from 'jotai/utils'
+import { Controlled, controlledAtom, Field, stateAtom, Swap, swapAtom } from 'state/swap'
+import { renderHook } from 'test'
+
+import { useSwapAmount, useSwapCurrency, useSwitchSwapCurrencies } from './'
+
+const DAI_MAINNET = DAI
+const UNI_MAINNET = UNI[SupportedChainId.MAINNET]
+
+const INITIAL_SWAP: Swap = {
+  independentField: Field.INPUT,
+  amount: '42',
+  [Field.INPUT]: DAI_MAINNET,
+  [Field.OUTPUT]: USDC_MAINNET,
+}
+
+const INITIAL_CONTROLLED: Controlled = {
+  ...INITIAL_SWAP,
+  onAmountChange: () => void 0,
+  onTokenChange: () => void 0,
+  onSwitchTokens: () => void 0,
+}
+
+describe('swap state', () => {
+  describe('useSwitchSwapCurrencies', () => {
+    it('swaps swap state currencies', () => {
+      const { rerender } = renderHook(
+        () => {
+          const switchSwapCurrencies = useSwitchSwapCurrencies()
+          switchSwapCurrencies()
+        },
+        { initialAtomValues: [[stateAtom, INITIAL_SWAP]] }
+      )
+
+      const { result } = rerender(() => useAtomValue(swapAtom))
+      expect(result.current).toMatchObject({
+        ...INITIAL_SWAP,
+        independentField: Field.OUTPUT,
+        [Field.INPUT]: INITIAL_SWAP[Field.OUTPUT],
+        [Field.OUTPUT]: INITIAL_SWAP[Field.INPUT],
+      })
+    })
+
+    it('calls onSwitchTokens if present', () => {
+      const spy = jest.fn()
+      const { rerender } = renderHook(
+        () => {
+          const switchSwapCurrencies = useSwitchSwapCurrencies()
+          switchSwapCurrencies()
+        },
+        {
+          initialAtomValues: [
+            [stateAtom, INITIAL_SWAP],
+            [controlledAtom, { ...INITIAL_CONTROLLED, onSwitchTokens: spy }],
+          ],
+        }
+      )
+      expect(spy).toHaveBeenCalledWith({
+        amount: INITIAL_SWAP.amount,
+        type: TradeType.EXACT_OUTPUT,
+        inputToken: INITIAL_SWAP[Field.OUTPUT],
+        outputToken: INITIAL_SWAP[Field.INPUT],
+      })
+
+      const { result } = rerender(() => useAtomValue(swapAtom))
+      expect(result.current).toMatchObject(INITIAL_SWAP)
+    })
+  })
+
+  describe('useSwapCurrency', () => {
+    it('sets currency', () => {
+      const { rerender } = renderHook(
+        () => {
+          const [, setCurrency] = useSwapCurrency(Field.INPUT)
+          setCurrency(UNI_MAINNET)
+        },
+        { initialAtomValues: [[stateAtom, INITIAL_SWAP]] }
+      )
+
+      const { result } = rerender(() => useAtomValue(swapAtom))
+      expect(result.current).toMatchObject({ ...INITIAL_SWAP, [Field.INPUT]: UNI_MAINNET })
+    })
+
+    it('calls onTokenChange if present', () => {
+      const spy = jest.fn()
+      const { rerender } = renderHook(
+        () => {
+          const [, setCurrency] = useSwapCurrency(Field.INPUT)
+          setCurrency(UNI_MAINNET)
+        },
+        {
+          initialAtomValues: [
+            [stateAtom, INITIAL_SWAP],
+            [controlledAtom, { ...INITIAL_CONTROLLED, onTokenChange: spy }],
+          ],
+        }
+      )
+      expect(spy).toHaveBeenCalledWith(Field.INPUT, UNI_MAINNET)
+
+      const { result } = rerender(() => useAtomValue(swapAtom))
+      expect(result.current).toMatchObject(INITIAL_SWAP)
+    })
+  })
+
+  describe('useSwapAmount', () => {
+    it('sets currency amount', () => {
+      const { rerender } = renderHook(
+        () => {
+          const [, setAmount] = useSwapAmount(Field.OUTPUT)
+          setAmount('123')
+        },
+        { initialAtomValues: [[stateAtom, INITIAL_SWAP]] }
+      )
+
+      const { result } = rerender(() => useAtomValue(swapAtom))
+      expect(result.current).toMatchObject({ ...INITIAL_SWAP, amount: '123', independentField: Field.OUTPUT })
+    })
+
+    it('calls onAmountChange if present', () => {
+      const spy = jest.fn()
+      const { rerender } = renderHook(
+        () => {
+          const [, setAmount] = useSwapAmount(Field.OUTPUT)
+          setAmount('123')
+        },
+        {
+          initialAtomValues: [
+            [stateAtom, INITIAL_SWAP],
+            [controlledAtom, { ...INITIAL_CONTROLLED, onAmountChange: spy }],
+          ],
+        }
+      )
+      expect(spy).toHaveBeenCalledWith(Field.OUTPUT, '123')
+
+      const { result } = rerender(() => useAtomValue(swapAtom))
+      expect(result.current).toMatchObject(INITIAL_SWAP)
+    })
+  })
+})

--- a/src/hooks/swap/index.ts
+++ b/src/hooks/swap/index.ts
@@ -55,18 +55,19 @@ export function useSwapCurrency(field: Field): [Currency | undefined, (currency:
   const onTokenChange = useAtomValue(controlledAtom)?.onTokenChange
   const switchSwapCurrencies = useSwitchSwapCurrencies()
   const setOrSwitchCurrency = useCallback(
-    (currency: Currency) => {
-      if (currency === otherCurrency) {
+    (update: Currency) => {
+      if (update === currency) return
+      if (update === otherCurrency) {
         switchSwapCurrencies()
       } else {
         if (onTokenChange) {
-          onTokenChange(field, currency)
+          onTokenChange(field, update)
         } else {
-          setCurrency(currency)
+          setCurrency(update)
         }
       }
     },
-    [field, onTokenChange, otherCurrency, setCurrency, switchSwapCurrencies]
+    [currency, field, onTokenChange, otherCurrency, setCurrency, switchSwapCurrencies]
   )
   return [currency, setOrSwitchCurrency]
 }
@@ -86,26 +87,27 @@ export function useIsAmountPopulated() {
 }
 
 export function useSwapAmount(field: Field): [string | undefined, (amount: string) => void] {
-  const amount = useAtomValue(amountAtom)
+  const value = useAtomValue(amountAtom)
   const isFieldIndependent = useIsSwapFieldIndependent(field)
-  const value = isFieldIndependent ? amount : undefined
+  const amount = isFieldIndependent ? value : undefined
 
   const onAmountChange = useAtomValue(controlledAtom)?.onAmountChange
   const setSwap = useUpdateAtom(swapAtom)
   const updateAmount = useCallback(
-    (amount: string) => {
+    (update: string) => {
+      if (update === amount) return
       if (onAmountChange) {
-        onAmountChange(field, amount)
+        onAmountChange(field, update)
       } else {
         setSwap((swap) => {
           swap.independentField = field
-          swap.amount = amount
+          swap.amount = update
         })
       }
     },
-    [field, onAmountChange, setSwap]
+    [amount, field, onAmountChange, setSwap]
   )
-  return [value, updateAmount]
+  return [amount, updateAmount]
 }
 
 export function useSwapCurrencyAmount(field: Field): CurrencyAmount<Currency> | undefined {

--- a/src/hooks/swap/index.ts
+++ b/src/hooks/swap/index.ts
@@ -1,9 +1,9 @@
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import { useAtom } from 'jotai'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { useCallback, useMemo } from 'react'
 import { pickAtom } from 'state/atoms'
-import { Field, swapAtom } from 'state/swap'
+import { controlledAtom, Field, swapAtom } from 'state/swap'
 import tryParseCurrencyAmount from 'utils/tryParseCurrencyAmount'
 export { default as useSwapInfo } from './useSwapInfo'
 
@@ -19,39 +19,54 @@ function otherField(field: Field) {
 }
 
 export function useSwitchSwapCurrencies() {
-  const update = useUpdateAtom(swapAtom)
+  const onSwitchTokens = useAtomValue(controlledAtom)?.onSwitchTokens
+  const setSwap = useUpdateAtom(swapAtom)
   return useCallback(() => {
-    update((swap) => {
-      const oldOutput = swap[Field.OUTPUT]
-      swap[Field.OUTPUT] = swap[Field.INPUT]
-      swap[Field.INPUT] = oldOutput
-      switch (swap.independentField) {
-        case Field.INPUT:
-          swap.independentField = Field.OUTPUT
-          break
-        case Field.OUTPUT:
-          swap.independentField = Field.INPUT
-          break
+    setSwap((swap) => {
+      if (onSwitchTokens) {
+        onSwitchTokens({
+          type: swap.independentField === Field.INPUT ? TradeType.EXACT_OUTPUT : TradeType.EXACT_INPUT,
+          amount: swap.amount,
+          inputToken: swap[Field.OUTPUT],
+          outputToken: swap[Field.INPUT],
+        })
+      } else {
+        const oldOutput = swap[Field.OUTPUT]
+        swap[Field.OUTPUT] = swap[Field.INPUT]
+        swap[Field.INPUT] = oldOutput
+        switch (swap.independentField) {
+          case Field.INPUT:
+            swap.independentField = Field.OUTPUT
+            break
+          case Field.OUTPUT:
+            swap.independentField = Field.INPUT
+            break
+        }
       }
     })
-  }, [update])
+  }, [onSwitchTokens, setSwap])
 }
 
-export function useSwapCurrency(field: Field): [Currency | undefined, (currency?: Currency) => void] {
-  const atom = useMemo(() => pickAtom(swapAtom, field), [field])
-  const otherAtom = useMemo(() => pickAtom(swapAtom, otherField(field)), [field])
-  const [currency, setCurrency] = useAtom(atom)
-  const otherCurrency = useAtomValue(otherAtom)
+export function useSwapCurrency(field: Field): [Currency | undefined, (currency: Currency) => void] {
+  const currencyAtom = useMemo(() => pickAtom(swapAtom, field), [field])
+  const [currency, setCurrency] = useAtom(currencyAtom)
+  const otherCurrencyAtom = useMemo(() => pickAtom(swapAtom, otherField(field)), [field])
+  const otherCurrency = useAtomValue(otherCurrencyAtom)
+  const onTokenChange = useAtomValue(controlledAtom)?.onTokenChange
   const switchSwapCurrencies = useSwitchSwapCurrencies()
   const setOrSwitchCurrency = useCallback(
-    (currency?: Currency) => {
+    (currency: Currency) => {
       if (currency === otherCurrency) {
         switchSwapCurrencies()
       } else {
-        setCurrency(currency)
+        if (onTokenChange) {
+          onTokenChange(field, currency)
+        } else {
+          setCurrency(currency)
+        }
       }
     },
-    [otherCurrency, setCurrency, switchSwapCurrencies]
+    [field, onTokenChange, otherCurrency, setCurrency, switchSwapCurrencies]
   )
   return [currency, setOrSwitchCurrency]
 }
@@ -74,14 +89,21 @@ export function useSwapAmount(field: Field): [string | undefined, (amount: strin
   const amount = useAtomValue(amountAtom)
   const isFieldIndependent = useIsSwapFieldIndependent(field)
   const value = isFieldIndependent ? amount : undefined
-  const updateSwap = useUpdateAtom(swapAtom)
+
+  const onAmountChange = useAtomValue(controlledAtom)?.onAmountChange
+  const setSwap = useUpdateAtom(swapAtom)
   const updateAmount = useCallback(
-    (amount: string) =>
-      updateSwap((swap) => {
-        swap.independentField = field
-        swap.amount = amount
-      }),
-    [field, updateSwap]
+    (amount: string) => {
+      if (onAmountChange) {
+        onAmountChange(field, amount)
+      } else {
+        setSwap((swap) => {
+          swap.independentField = field
+          swap.amount = amount
+        })
+      }
+    },
+    [field, onAmountChange, setSwap]
   )
   return [value, updateAmount]
 }

--- a/src/hooks/swap/useSyncController.ts
+++ b/src/hooks/swap/useSyncController.ts
@@ -1,0 +1,61 @@
+import { TradeType } from '@uniswap/sdk-core'
+import { useUpdateAtom } from 'jotai/utils'
+import { useEffect, useMemo, useRef } from 'react'
+import { Controlled, controlledAtom, ControlledValues, ControllerHandlers, Field } from 'state/swap'
+
+export interface Controller extends ControlledValues, Partial<ControllerHandlers> {}
+
+export default function useSyncController({
+  type,
+  amount,
+  inputToken,
+  outputToken,
+  onTokenChange,
+  onAmountChange,
+  onSwitchTokens,
+}: Controller): void {
+  const controlled = useMemo<Controlled | undefined>(() => {
+    if (
+      [type, amount, inputToken, outputToken, onTokenChange, onAmountChange, onSwitchTokens].every(
+        (prop) => prop === undefined
+      )
+    ) {
+      // Component is uncontrolled
+      return undefined
+    }
+
+    // Component is controlled
+    return {
+      independentField: type === TradeType.EXACT_INPUT ? Field.INPUT : Field.OUTPUT,
+      amount: amount || '',
+      [Field.INPUT]: inputToken,
+      [Field.OUTPUT]: outputToken,
+      onTokenChange: onTokenChange ?? nop,
+      onAmountChange: onAmountChange ?? nop,
+      onSwitchTokens: onSwitchTokens ?? nop,
+    }
+  }, [amount, inputToken, onAmountChange, onSwitchTokens, onTokenChange, outputToken, type])
+
+  // Log an error if the component changes from uncontrolled to controlled (or vice versa).
+  const isControlled = useRef(Boolean(controlled))
+  useEffect(() => {
+    if (Boolean(controlled) !== isControlled.current) {
+      const article = (isControlled: boolean) => (isControlled ? 'a ' : 'an un')
+      console.error(
+        `Warning: The SwapWidget component is changing from ${article(
+          isControlled.current
+        )}controlled component to ${article(
+          Boolean(controlled)
+        )}controlled component. The SwapWidget should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled SwapWidget for the lifetime of the component.`
+      )
+    }
+    isControlled.current = Boolean(controlled)
+  }, [controlled])
+
+  const setControlled = useUpdateAtom(controlledAtom)
+  useEffect(() => setControlled((old) => (old = controlled)), [controlled, setControlled])
+}
+
+function nop() {
+  void 0
+}

--- a/src/state/swap.ts
+++ b/src/state/swap.ts
@@ -17,7 +17,7 @@ export interface Swap {
   [Field.OUTPUT]?: Currency
 }
 
-const stateAtom = atomWithImmer<Swap>({
+export const stateAtom = atomWithImmer<Swap>({
   independentField: Field.INPUT,
   amount: '',
   [Field.INPUT]: nativeOnChain(SupportedChainId.MAINNET),

--- a/src/state/swap.ts
+++ b/src/state/swap.ts
@@ -1,4 +1,4 @@
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, TradeType } from '@uniswap/sdk-core'
 import { FeeOptions } from '@uniswap/v3-sdk'
 import { SupportedChainId } from 'constants/chains'
 import { nativeOnChain } from 'constants/tokens'
@@ -17,11 +17,33 @@ export interface Swap {
   [Field.OUTPUT]?: Currency
 }
 
-export const swapAtom = atomWithImmer<Swap>({
+const stateAtom = atomWithImmer<Swap>({
   independentField: Field.INPUT,
   amount: '',
   [Field.INPUT]: nativeOnChain(SupportedChainId.MAINNET),
 })
+
+export interface ControlledValues {
+  type?: TradeType
+  amount?: string
+  inputToken?: Currency
+  outputToken?: Currency
+}
+
+export interface ControllerHandlers {
+  onTokenChange: (field: Field, token: Currency) => void
+  onAmountChange: (field: Field, amount: string) => void
+  onSwitchTokens: (values: ControlledValues) => void
+}
+
+export interface Controlled extends Swap, ControllerHandlers {}
+
+export const controlledAtom = atom<Controlled | undefined>(undefined)
+
+export const swapAtom = atom((get) => {
+  const controlled = get(controlledAtom)
+  return controlled ? controlled : get(stateAtom)
+}, stateAtom.write)
 
 // If set, allows integrator to add behavior when 'Review swap' button is clicked
 export const onReviewSwapClickAtom = atom<(() => void | Promise<boolean>) | undefined>(undefined)


### PR DESCRIPTION
- [X] Adds a `Controller` interface to allow the widget to be a controlled component
- [X] Refactors `swapAtom` into a derived atom, so that it can be "controlled" if a `Controller` is defined
  - This lets us "control" the widget without putting special-cased code throughout the components' logic
- [x] Splits the cosmos example into "controlled" and "uncontrolled" `SwapWidget`s
- [x] Adds unit tests for the updated `swapAtom` operations