### PR TITLE
docs: iframe as simple widget

### DIFF
--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -101,19 +101,11 @@ function Fixture() {
     />
   )
 
-  // If iframed, only display the SwapWidget, without any chrome.
+  // If framed in a different origin, only display the SwapWidget, without any chrome.
   // This is done to faciliate iframing in the documentation (https://docs.uniswap.org).
-  let isIframed = false
-  try {
-    // If the origin's differ, this will throw a DOMException due to the cross-origin frame.
-    void window.parent.location.origin
-  } catch {
-    isIframed = true
-  }
+  if (!window.frameElement) return widget
 
-  return isIframed ? (
-    widget
-  ) : (
+  return (
     <Row align="start" justify="space-around">
       {widget}
       <EventFeed events={events} onClear={() => setEvents([])} />

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -75,31 +75,40 @@ function Fixture() {
 
   const [routerUrl] = useValue('routerUrl', { defaultValue: 'https://api.uniswap.org/v1/' })
 
-  return (
+  const widget = (
+    <SwapWidget
+      convenienceFee={convenienceFee}
+      convenienceFeeRecipient={convenienceFeeRecipient}
+      defaultInputTokenAddress={defaultInputToken}
+      defaultInputAmount={defaultInputAmount}
+      defaultOutputTokenAddress={defaultOutputToken}
+      defaultOutputAmount={defaultOutputAmount}
+      hideConnectionUI={hideConnectionUI}
+      locale={locale}
+      jsonRpcUrlMap={INFURA_NETWORK_URLS}
+      defaultChainId={defaultChainId}
+      provider={connector}
+      theme={theme}
+      tokenList={tokenList}
+      width={width}
+      routerUrl={routerUrl}
+      onConnectWalletClick={useHandleEvent('onConnectWalletClick')}
+      onReviewSwapClick={useHandleEvent('onReviewSwapClick')}
+      onTokenSelectorClick={useHandleEvent('onTokenSelectorClick')}
+      onTxSubmit={useHandleEvent('onTxSubmit')}
+      onTxSuccess={useHandleEvent('onTxSuccess')}
+      onTxFail={useHandleEvent('onTxFail')}
+    />
+  )
+
+  // If iframed, only display the SwapWidget, without any Chrome.
+  // This is done to faciliate iframing in the documentation (https://docs.uniswap.org).
+  const isIframed = window.location.origin !== window.parent.location.origin
+  return isIframed ? (
+    widget
+  ) : (
     <Row align="start" justify="space-around">
-      <SwapWidget
-        convenienceFee={convenienceFee}
-        convenienceFeeRecipient={convenienceFeeRecipient}
-        defaultInputTokenAddress={defaultInputToken}
-        defaultInputAmount={defaultInputAmount}
-        defaultOutputTokenAddress={defaultOutputToken}
-        defaultOutputAmount={defaultOutputAmount}
-        hideConnectionUI={hideConnectionUI}
-        locale={locale}
-        jsonRpcUrlMap={INFURA_NETWORK_URLS}
-        defaultChainId={defaultChainId}
-        provider={connector}
-        theme={theme}
-        tokenList={tokenList}
-        width={width}
-        routerUrl={routerUrl}
-        onConnectWalletClick={useHandleEvent('onConnectWalletClick')}
-        onReviewSwapClick={useHandleEvent('onReviewSwapClick')}
-        onTokenSelectorClick={useHandleEvent('onTokenSelectorClick')}
-        onTxSubmit={useHandleEvent('onTxSubmit')}
-        onTxSuccess={useHandleEvent('onTxSuccess')}
-        onTxFail={useHandleEvent('onTxFail')}
-      />
+      {widget}
       <EventFeed events={events} onClear={() => setEvents([])} />
     </Row>
   )

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -101,9 +101,16 @@ function Fixture() {
     />
   )
 
-  // If iframed, only display the SwapWidget, without any Chrome.
+  // If iframed, only display the SwapWidget, without any chrome.
   // This is done to faciliate iframing in the documentation (https://docs.uniswap.org).
-  const isIframed = window.location.origin !== window.parent.location.origin
+  let isIframed = false
+  try {
+    // If the origin's differ, this will throw a DOMException due to the cross-origin frame.
+    void window.parent.location.origin
+  } catch {
+    isIframed = true
+  }
+
   return isIframed ? (
     widget
   ) : (


### PR DESCRIPTION
Allows the cosmos fixture to be used (iframed) in the official documentation at https://docs.uniswap.org/sdk/widgets/swap-widget.