### PR TITLE
fix: action overlay height

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -45,7 +45,7 @@ const actionCss = css`
   ${StyledButton} {
     border-radius: ${({ theme }) => theme.borderRadius}em;
     flex-grow: 0;
-    padding: 1em;
+    padding: 0 1em;
   }
 `
 


### PR DESCRIPTION
Fixes a bug where the action overlay button (eg "Allow" when allowing a new currency) added 1em vertical padding, thus expanding the borders of the widget.