### PR TITLE
fix: allow less than signed amount for swaps

### DIFF
--- a/src/hooks/useERC20Permit.ts
+++ b/src/hooks/useERC20Permit.ts
@@ -174,7 +174,8 @@ export function useERC20Permit(
       signatureData.tokenAddress === tokenAddress &&
       signatureData.nonce === nonceNumber &&
       signatureData.spender === spender &&
-      ('allowed' in signatureData || JSBI.equal(JSBI.BigInt(signatureData.amount), currencyAmount.quotient))
+      ('allowed' in signatureData ||
+        JSBI.greaterThanOrEqual(JSBI.BigInt(signatureData.amount), currencyAmount.quotient))
 
     return {
       state: isSignatureDataValid ? UseERC20PermitState.SIGNED : UseERC20PermitState.NOT_SIGNED,


### PR DESCRIPTION
Allows a user to trade _less than_ the signed amount in a swap.
Eg if a user allows 0.1 UNI to be swapped, this will allow 0.05 UNI to be swapped without requiring a new signature for the lesser amount.