### PR TITLE
feat: reset inputs after submission

### DIFF
--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { CurrencyAmount } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { useSwapInfo } from 'hooks/swap'
+import { useSwapAmount, useSwapInfo } from 'hooks/swap'
 import { useSwapApprovalOptimizedTrade } from 'hooks/swap/useSwapApproval'
 import { useSwapCallback } from 'hooks/swap/useSwapCallback'
 import useWrapCallback from 'hooks/swap/useWrapCallback'
@@ -69,12 +69,16 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
 
   const addTransactionInfo = useAddTransaction()
   const setDisplayTxHash = useUpdateAtom(displayTxHashAtom)
+  const [, setSwapAmount] = useSwapAmount(Field.INPUT)
+  const resetSwapAmount = useCallback(() => setSwapAmount(''), [setSwapAmount])
 
   const onSubmit = useCallback(
     async (submit: () => Promise<TransactionInfo | undefined>): Promise<void> => {
       try {
         const info = await submit()
         if (!info) return
+
+        resetSwapAmount()
         addTransactionInfo(info)
         setDisplayTxHash(info.response.hash)
 
@@ -93,7 +97,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
         console.error('Failed to submit', e)
       }
     },
-    [addTransactionInfo, setDisplayTxHash]
+    [addTransactionInfo, resetSwapAmount, setDisplayTxHash]
   )
 
   const [isPending, setIsPending] = useState(false)

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -111,7 +111,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       const response = await wrapCallback()
       if (!response) return
 
-      invariant(wrapType)
+      invariant(wrapType !== undefined)
       const amount = CurrencyAmount.fromRawAmount(native, response.value?.toString() ?? '0')
       return { response, type: wrapType, amount }
     })

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -5,7 +5,7 @@ import { useSwapAmount, useSwapInfo } from 'hooks/swap'
 import { useSwapApprovalOptimizedTrade } from 'hooks/swap/useSwapApproval'
 import { useSwapCallback } from 'hooks/swap/useSwapCallback'
 import useWrapCallback from 'hooks/swap/useWrapCallback'
-import { useAddTransaction } from 'hooks/transactions'
+import { useAddTransactionInfo } from 'hooks/transactions'
 import { useSetOldestValidBlock } from 'hooks/useIsValidBlock'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
@@ -67,7 +67,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
   // Close the review modal on chain change.
   useEffect(() => setOpen(false), [chainId])
 
-  const addTransactionInfo = useAddTransaction()
+  const addTransactionInfo = useAddTransactionInfo()
   const setDisplayTxHash = useUpdateAtom(displayTxHashAtom)
   const [, setSwapAmount] = useSwapAmount(Field.INPUT)
   const resetSwapAmount = useCallback(() => setSwapAmount(''), [setSwapAmount])

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -110,7 +110,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       const response = await wrapCallback()
       if (!response) return
 
-      invariant(wrapType !== undefined)
+      invariant(wrapType !== undefined) // if response is valid, then so is wrapType
       const amount = CurrencyAmount.fromRawAmount(native, response.value?.toString() ?? '0')
       return { response, type: wrapType, amount }
     })

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -69,8 +69,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
 
   const addTransactionInfo = useAddTransactionInfo()
   const setDisplayTxHash = useUpdateAtom(displayTxHashAtom)
-  const [, setSwapAmount] = useSwapAmount(Field.INPUT)
-  const resetSwapAmount = useCallback(() => setSwapAmount(''), [setSwapAmount])
+  const [, setInputAmount] = useSwapAmount(Field.INPUT)
 
   // Submits a transaction. Returns true if the transaction was submitted.
   const onSubmit = useCallback(
@@ -83,7 +82,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       }
       if (!info) return false
 
-      resetSwapAmount()
+      setInputAmount('')
       addTransactionInfo(info)
       setDisplayTxHash(info.response.hash)
 
@@ -100,7 +99,7 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       }
       return true
     },
-    [addTransactionInfo, resetSwapAmount, setDisplayTxHash]
+    [addTransactionInfo, setDisplayTxHash, setInputAmount]
   )
 
   const [isPending, setIsPending] = useState(false)

--- a/src/components/Swap/SwapButton/useApprovalData.tsx
+++ b/src/components/Swap/SwapButton/useApprovalData.tsx
@@ -8,7 +8,7 @@ import {
   useSwapApprovalOptimizedTrade,
   useSwapRouterAddress,
 } from 'hooks/swap/useSwapApproval'
-import { useAddTransaction, usePendingApproval } from 'hooks/transactions'
+import { useAddTransactionInfo, usePendingApproval } from 'hooks/transactions'
 import { Slippage } from 'hooks/useSlippage'
 import { Spinner } from 'icons'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -33,15 +33,15 @@ export default function useApprovalData(
   )
 
   const [isPending, setIsPending] = useState(false)
-  const addTransaction = useAddTransaction()
+  const addTransactionInfo = useAddTransactionInfo()
   const onApprove = useCallback(async () => {
     setIsPending(true)
     const transaction = await handleApproveOrPermit()
     if (transaction) {
-      addTransaction({ type: TransactionType.APPROVAL, ...transaction })
+      addTransactionInfo({ type: TransactionType.APPROVAL, ...transaction })
     }
     setIsPending(false)
-  }, [addTransaction, handleApproveOrPermit])
+  }, [addTransactionInfo, handleApproveOrPermit])
   // Reset the pending state if currency changes.
   useEffect(() => setIsPending(false), [currency])
 

--- a/src/hooks/transactions/index.tsx
+++ b/src/hooks/transactions/index.tsx
@@ -20,7 +20,7 @@ export function usePendingTransactions() {
   return (chainId ? txs[chainId] : null) ?? {}
 }
 
-export function useAddTransaction() {
+export function useAddTransactionInfo() {
   const { chainId } = useWeb3React()
   const blockNumber = useBlockNumber()
   const updateTxs = useUpdateAtom(transactionsAtom)


### PR DESCRIPTION
Zeroes out the inputs and sets Field.INPUT as the independent field (ie TradeType.EXACT_INPUT) once a swap or wrap is submitted. This is in line with github.com/Uniswap/interface, as per @infredible.

https://user-images.githubusercontent.com/5403956/186292639-13744922-1b1e-4fb4-b5ee-d5b477fd88c5.mov

