### PR TITLE
fix: slide modal out on other side

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -129,6 +129,9 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
 
   const modal = useRef<HTMLDivElement>(null)
   useUnmountingAnimation(modal, () => {
+    // Returns the context element's child count at the time of unmounting.
+    // This cannot be done through state because the count is updated outside of React's lifecycle -
+    // it *must* be checked at the time of unmounting in order to include the next page of Dialog.
     return (context.element?.childElementCount ?? 0) > 1 ? Animation.PAGING : Animation.CLOSING
   })
 

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -23,7 +23,12 @@ declare global {
 export enum Animation {
   /** Used when the Dialog is closing. */
   CLOSING = 'closing',
-  /** Used when the Dialog is paging to another Dialog screen. */
+  /**
+   * Used when the Dialog is paging to another Dialog screen.
+   * Paging occurs when multiple screens are sequenced in the Dialog, so that an action that closes
+   * one will simultaneously open the next. Special-casing paging animations can make the user feel
+   * like they are not leaving the Dialog, despite the initial screen closing.
+   */
   PAGING = 'paging',
 }
 

--- a/src/components/Swap/SwapButton/index.tsx
+++ b/src/components/Swap/SwapButton/index.tsx
@@ -82,21 +82,23 @@ export default memo(function SwapButton({ disabled }: SwapButtonProps) {
       }
       if (!info) return false
 
-      setInputAmount('')
       addTransactionInfo(info)
       setDisplayTxHash(info.response.hash)
 
       if (isAnimating(document)) {
-        // Only return after any queued animations to avoid layout thrashing, because a successful
-        // submit will open the status dialog and immediately cover the animating button.
+        // Only reset the input amount after any queued animations to avoid layout thrashing,
+        // because a successful submit will open the status dialog and immediately cover input.
         return new Promise((resolve) => {
           const onAnimationEnd = () => {
             document.removeEventListener('animationend', onAnimationEnd)
-            resolve(true)
+            setInputAmount('')
           }
           document.addEventListener('animationend', onAnimationEnd)
         })
+      } else {
+        setInputAmount('')
       }
+
       return true
     },
     [addTransactionInfo, setDisplayTxHash, setInputAmount]

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -13,9 +13,8 @@ import useHasFocus from 'hooks/useHasFocus'
 import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
 import useSyncWidgetEventHandlers, { WidgetEventHandlers } from 'hooks/useSyncWidgetEventHandlers'
 import { useAtom } from 'jotai'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { displayTxHashAtom } from 'state/swap'
-import { SwapTransactionInfo, Transaction, TransactionType, WrapTransactionInfo } from 'state/transactions'
 
 import Dialog from '../Dialog'
 import Header from '../Header'
@@ -28,22 +27,6 @@ import { StatusDialog } from './Status'
 import SwapButton from './SwapButton'
 import Toolbar from './Toolbar'
 import useValidate from './useValidate'
-
-function getTransactionFromMap(
-  txs: { [hash: string]: Transaction },
-  hash?: string
-): Transaction<SwapTransactionInfo | WrapTransactionInfo> | undefined {
-  if (hash) {
-    const tx = txs[hash]
-    if (tx?.info?.type === TransactionType.SWAP) {
-      return tx as Transaction<SwapTransactionInfo>
-    }
-    if (tx?.info?.type === TransactionType.WRAP) {
-      return tx as Transaction<WrapTransactionInfo>
-    }
-  }
-  return
-}
 
 // SwapProps also currently includes props needed for wallet connection,
 // since the wallet connection component exists within the Swap component.
@@ -70,7 +53,7 @@ export default function Swap(props: SwapProps) {
 
   const [displayTxHash, setDisplayTxHash] = useAtom(displayTxHashAtom)
   const pendingTxs = usePendingTransactions()
-  const displayTx = getTransactionFromMap(pendingTxs, displayTxHash)
+  const displayTx = useMemo(() => displayTxHash && pendingTxs[displayTxHash], [displayTxHash, pendingTxs])
 
   const onSupportedNetwork = useOnSupportedNetwork()
   const isDisabled = !(isActive && onSupportedNetwork)

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -16,9 +16,8 @@ import { store } from 'state'
 import { MulticallUpdater } from 'state/multicall'
 import styled, { keyframes } from 'styled-components/macro'
 import { Theme, ThemeProvider } from 'theme'
-import { UNMOUNTING } from 'utils/animations'
 
-import { Modal, Provider as DialogProvider } from './Dialog'
+import { Animation, Modal, Provider as DialogProvider } from './Dialog'
 import ErrorBoundary, { ErrorHandler } from './Error/ErrorBoundary'
 
 const DEFAULT_CHAIN_ID = SupportedChainId.MAINNET
@@ -59,9 +58,14 @@ const slideIn = keyframes`
     transform: translateX(calc(100% - 0.25em));
   }
 `
-const slideOut = keyframes`
+const slideBack = keyframes`
   to {
     transform: translateX(calc(0.25em - 100%));
+  }
+`
+const slideOut = keyframes`
+  to {
+    transform: translateX(calc(100% - 0.25em));
   }
 `
 
@@ -82,7 +86,10 @@ export const DialogWrapper = styled.div`
   ${Modal} {
     animation: ${slideIn} 0.25s ease-in;
 
-    &.${UNMOUNTING} {
+    &.${Animation.PAGING} {
+      animation: ${slideBack} 0.25s ease-in;
+    }
+    &.${Animation.CLOSING} {
       animation: ${slideOut} 0.25s ease-out;
     }
   }

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -53,17 +53,17 @@ const WidgetWrapper = styled.div<{ width?: number | string }>`
   }
 `
 
-const slideIn = keyframes`
+const slideInLeft = keyframes`
   from {
     transform: translateX(calc(100% - 0.25em));
   }
 `
-const slideBack = keyframes`
+const slideOutLeft = keyframes`
   to {
     transform: translateX(calc(0.25em - 100%));
   }
 `
-const slideOut = keyframes`
+const slideOutRight = keyframes`
   to {
     transform: translateX(calc(100% - 0.25em));
   }
@@ -84,13 +84,13 @@ export const DialogWrapper = styled.div`
   }
 
   ${Modal} {
-    animation: ${slideIn} 0.25s ease-in;
+    animation: ${slideInLeft} 0.25s ease-in;
 
     &.${Animation.PAGING} {
-      animation: ${slideBack} 0.25s ease-in;
+      animation: ${slideOutLeft} 0.25s ease-in;
     }
     &.${Animation.CLOSING} {
-      animation: ${slideOut} 0.25s ease-out;
+      animation: ${slideOutRight} 0.25s ease-out;
     }
   }
 `

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -61,7 +61,7 @@ const slideIn = keyframes`
 `
 const slideOut = keyframes`
   to {
-    transform: translateX(calc(100% - 0.25em));
+    transform: translateX(calc(0.25em - 100%));
   }
 `
 

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -9,10 +9,11 @@ export function isAnimating(node?: Animatable | Document) {
  * Delays a node's unmounting until any animations on that node are finished, so that an unmounting
  * animation may be applied. If there is no animation, this is a no-op.
  *
- * CSS should target the animationClass to determine when to apply the animation. If animationClass
- * is a function, it will be invoking when the node would begin unmounting.
+ * CSS should target the class returned from getAnimatingClass to determine when to apply the
+ * animation.
+ * Note that getAnimatingClass will be called when the node would normally begin unmounting.
  */
-export function useUnmountingAnimation(node: RefObject<HTMLElement>, animatingClass: (() => string) | string) {
+export function useUnmountingAnimation(node: RefObject<HTMLElement>, getAnimatingClass: () => string) {
   useEffect(() => {
     const current = node.current
     const parent = current?.parentElement
@@ -21,8 +22,7 @@ export function useUnmountingAnimation(node: RefObject<HTMLElement>, animatingCl
 
     parent.removeChild = function <T extends Node>(child: T) {
       if ((child as Node) === current) {
-        const klass = typeof animatingClass === 'string' ? animatingClass : animatingClass()
-        current.classList.add(klass)
+        current.classList.add(getAnimatingClass())
         if (isAnimating(current)) {
           current.addEventListener('animationend', () => {
             removeChild.call(parent, child)
@@ -38,5 +38,5 @@ export function useUnmountingAnimation(node: RefObject<HTMLElement>, animatingCl
     return () => {
       parent.removeChild = removeChild
     }
-  }, [animatingClass, node])
+  }, [getAnimatingClass, node])
 }

--- a/src/utils/animations.ts
+++ b/src/utils/animations.ts
@@ -1,26 +1,28 @@
-import { RefObject } from 'react'
+import { RefObject, useEffect } from 'react'
 
 // Some tests will pass undefined for the Document.
 export function isAnimating(node?: Animatable | Document) {
   return (node?.getAnimations?.().length ?? 0) > 0
 }
 
-export const UNMOUNTING = 'unmounting'
-
 /**
  * Delays a node's unmounting until any animations on that node are finished, so that an unmounting
  * animation may be applied. If there is no animation, this is a no-op.
  *
- * CSS should target the UNMOUNTING class to determine when to apply an unmounting animation.
+ * CSS should target the animationClass to determine when to apply the animation. If animationClass
+ * is a function, it will be invoking when the node would begin unmounting.
  */
-export function delayUnmountForAnimation(node: RefObject<HTMLElement>) {
-  const current = node.current
-  const parent = current?.parentElement
-  const removeChild = parent?.removeChild
-  if (parent && removeChild) {
+export function useUnmountingAnimation(node: RefObject<HTMLElement>, animatingClass: (() => string) | string) {
+  useEffect(() => {
+    const current = node.current
+    const parent = current?.parentElement
+    const removeChild = parent?.removeChild
+    if (!(parent && removeChild)) return
+
     parent.removeChild = function <T extends Node>(child: T) {
       if ((child as Node) === current) {
-        current.classList.add(UNMOUNTING)
+        const klass = typeof animatingClass === 'string' ? animatingClass : animatingClass()
+        current.classList.add(klass)
         if (isAnimating(current)) {
           current.addEventListener('animationend', () => {
             removeChild.call(parent, child)
@@ -33,5 +35,8 @@ export function delayUnmountForAnimation(node: RefObject<HTMLElement>) {
         return removeChild.call(parent, child) as T
       }
     }
-  }
+    return () => {
+      parent.removeChild = removeChild
+    }
+  }, [animatingClass, node])
 }


### PR DESCRIPTION
This PR changes the transition behavior for modals.

If there is another dialog taking the place of an active one, the old dialog will slide out to the left (instead of to the right). In code, this is called "PAGING". This avoids risking exposing the screen underneath modals when they are replacing each other, and makes the modals look more sequenced.

It also fixes some issues I discovered while implementing this:
- Displays unwrap transactions, which was broken by #159 
- Delays input reset until after animations, to avoid layout thrashing

Before

https://user-images.githubusercontent.com/5403956/186477938-81c2ded0-4364-4bf9-a25d-4bf8a823710f.mov


After

https://user-images.githubusercontent.com/5403956/186519113-772405ce-da6e-44b4-9f8e-e551904cb471.mov


