### PR TITLE
fix: token select with less friction

### DIFF
--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -12,6 +12,7 @@ import {
   memo,
   SyntheticEvent,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -135,7 +136,6 @@ areEqual)
 
 interface TokenOptionsHandle {
   onKeyDown: (e: KeyboardEvent) => void
-  blur: () => void
 }
 
 interface TokenOptionsProps {
@@ -148,8 +148,11 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
   ref
 ) {
   const [focused, setFocused] = useState(false)
-  const [selected, setSelected] = useState<Currency>()
-  const hover = useMemo(() => (selected ? tokens.indexOf(selected) : -1), [selected, tokens])
+  const [selected, setSelected] = useState<Currency>(tokens[0])
+  useEffect(() => {
+    setSelected((selected) => (tokens.includes(selected) ? selected : tokens[0]))
+  }, [tokens, setSelected])
+  const hover = useMemo(() => tokens.indexOf(selected), [selected, tokens])
 
   const list = useRef<FixedSizeList>(null)
   const [element, setElement] = useState<HTMLElement | null>(null)
@@ -186,8 +189,7 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
     },
     [hover, onSelect, scrollTo, tokens]
   )
-  const blur = useCallback(() => setSelected(undefined), [])
-  useImperativeHandle(ref, () => ({ onKeyDown, blur }), [blur, onKeyDown])
+  useImperativeHandle(ref, () => ({ onKeyDown }), [onKeyDown])
 
   const onClick = useCallback(({ token }: BubbledEvent) => token && onSelect(token), [onSelect])
   const onFocus = useCallback(

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -148,11 +148,15 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
   ref
 ) {
   const [focused, setFocused] = useState(false)
+
   const [selected, setSelected] = useState<Currency>(tokens[0])
+  const hover = useMemo(() => tokens.indexOf(selected), [selected, tokens])
+
+  // If tokens updates (eg from searching), always default to selecting the first token.
+  // As long as tokens.length >= 1, a token should be selected.
   useEffect(() => {
     setSelected((selected) => (tokens.includes(selected) ? selected : tokens[0]))
   }, [tokens, setSelected])
-  const hover = useMemo(() => tokens.indexOf(selected), [selected, tokens])
 
   const list = useRef<FixedSizeList>(null)
   const [element, setElement] = useState<HTMLElement | null>(null)

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -94,7 +94,6 @@ export function TokenSelectDialog({ value, onSelect, onClose }: TokenSelectDialo
               onChange={setQuery}
               placeholder={t`Search by token name or address`}
               onKeyDown={options?.onKeyDown}
-              onBlur={options?.blur}
               ref={input}
             />
           </ThemedText.Body1>


### PR DESCRIPTION
Selects the top token from the token selector by default.
This allows a user to eg type `UNI<ENTER>` to use the UNI token, instead of needing to use arrows/mouse to select it from the list.