### PR TITLE
refactor: use TradeType instead of derived independent field

### DIFF
--- a/src/components/Swap/RoutingDiagram/utils.ts
+++ b/src/components/Swap/RoutingDiagram/utils.ts
@@ -3,6 +3,7 @@ import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { FeeAmount } from '@uniswap/v3-sdk'
 import { InterfaceTrade } from 'state/routing/types'
+import { isExactInput } from 'utils/tradeType'
 
 export interface RoutingDiagramEntry {
   percent: Percent
@@ -17,10 +18,9 @@ const V2_DEFAULT_FEE_TIER = 3000
  */
 export function getTokenPath(trade: InterfaceTrade<Currency, Currency, TradeType>): RoutingDiagramEntry[] {
   return trade.swaps.map(({ route: { path: tokenPath, pools, protocol }, inputAmount, outputAmount }) => {
-    const portion =
-      trade.tradeType === TradeType.EXACT_INPUT
-        ? inputAmount.divide(trade.inputAmount)
-        : outputAmount.divide(trade.outputAmount)
+    const portion = isExactInput(trade.tradeType)
+      ? inputAmount.divide(trade.inputAmount)
+      : outputAmount.divide(trade.outputAmount)
     const percent = new Percent(portion.numerator, portion.denominator)
     const path: RoutingDiagramEntry['path'] = []
     for (let i = 0; i < pools.length; i++) {

--- a/src/components/Swap/Summary/Details.tsx
+++ b/src/components/Swap/Summary/Details.tsx
@@ -14,6 +14,7 @@ import { Color, ThemedText } from 'theme'
 import { currencyId } from 'utils/currencyId'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { computeRealizedLPFeeAmount } from 'utils/prices'
+import { isExactInput } from 'utils/tradeType'
 
 const Value = styled.span<{ color?: Color }>`
   color: ${({ color, theme }) => color && theme[color]};
@@ -73,14 +74,12 @@ export default function Details({ trade, slippage, impact }: DetailsProps) {
       rows.push([t`Liquidity provider fee`, `${parsedLpFee} ${inputCurrency.symbol || currencyId(inputCurrency)}`])
     }
 
-    if (trade.tradeType === TradeType.EXACT_OUTPUT) {
-      const localizedMaxSent = formatCurrencyAmount(trade.maximumAmountIn(slippage.allowed), 6, i18n.locale)
-      rows.push([t`Maximum sent`, `${localizedMaxSent} ${inputCurrency.symbol}`])
-    }
-
-    if (trade.tradeType === TradeType.EXACT_INPUT) {
+    if (isExactInput(trade.tradeType)) {
       const localizedMaxSent = formatCurrencyAmount(trade.minimumAmountOut(slippage.allowed), 6, i18n.locale)
       rows.push([t`Minimum received`, `${localizedMaxSent} ${outputCurrency.symbol}`])
+    } else {
+      const localizedMaxSent = formatCurrencyAmount(trade.maximumAmountIn(slippage.allowed), 6, i18n.locale)
+      rows.push([t`Maximum sent`, `${localizedMaxSent} ${inputCurrency.symbol}`])
     }
 
     rows.push([t`Slippage tolerance`, `${slippage.allowed.toFixed(2)}%`, slippage.warning])

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -15,6 +15,7 @@ import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { tradeMeaningfullyDiffers } from 'utils/tradeMeaningFullyDiffer'
+import { isExactInput } from 'utils/tradeType'
 
 import Price from '../Price'
 import Details from './Details'
@@ -67,26 +68,23 @@ interface EstimateProps {
 
 function Estimate({ trade, slippage }: EstimateProps) {
   const { i18n } = useLingui()
-  const text = useMemo(() => {
-    switch (trade.tradeType) {
-      case TradeType.EXACT_INPUT:
-        return (
-          <Trans>
-            Output is estimated. You will receive at least{' '}
-            {formatCurrencyAmount(trade.minimumAmountOut(slippage.allowed), 6, i18n.locale)}{' '}
-            {trade.outputAmount.currency.symbol} or the transaction will revert.
-          </Trans>
-        )
-      case TradeType.EXACT_OUTPUT:
-        return (
-          <Trans>
-            Output is estimated. You will send at most{' '}
-            {formatCurrencyAmount(trade.maximumAmountIn(slippage.allowed), 6, i18n.locale)}{' '}
-            {trade.inputAmount.currency.symbol} or the transaction will revert.
-          </Trans>
-        )
-    }
-  }, [i18n.locale, slippage.allowed, trade])
+  const text = useMemo(
+    () =>
+      isExactInput(trade.tradeType) ? (
+        <Trans>
+          Output is estimated. You will receive at least{' '}
+          {formatCurrencyAmount(trade.minimumAmountOut(slippage.allowed), 6, i18n.locale)}{' '}
+          {trade.outputAmount.currency.symbol} or the transaction will revert.
+        </Trans>
+      ) : (
+        <Trans>
+          Output is estimated. You will send at most{' '}
+          {formatCurrencyAmount(trade.maximumAmountIn(slippage.allowed), 6, i18n.locale)}{' '}
+          {trade.inputAmount.currency.symbol} or the transaction will revert.
+        </Trans>
+      ),
+    [i18n.locale, slippage.allowed, trade]
+  )
   return <StyledEstimate color="secondary">{text}</StyledEstimate>
 }
 

--- a/src/hooks/routing/transformSwapRouteToGetQuoteResult.ts
+++ b/src/hooks/routing/transformSwapRouteToGetQuoteResult.ts
@@ -1,13 +1,14 @@
 import { Protocol } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 // This file is lazy-loaded, so the import of smart-order-router is intentional.
 // eslint-disable-next-line no-restricted-imports
 import { routeAmountsToString, SwapRoute } from '@uniswap/smart-order-router'
 import { GetQuoteResult, V2PoolInRoute, V3PoolInRoute } from 'state/routing/types'
+import { isExactInput } from 'utils/tradeType'
 
 // from routing-api (https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/quote.ts#L243-L311)
 export function transformSwapRouteToGetQuoteResult(
-  type: 'exactIn' | 'exactOut',
+  tradeType: TradeType,
   amount: CurrencyAmount<Currency>,
   {
     quote,
@@ -36,12 +37,12 @@ export function transformSwapRouteToGetQuoteResult(
 
         let edgeAmountIn = undefined
         if (i === 0) {
-          edgeAmountIn = type === 'exactIn' ? amount.quotient.toString() : quote.quotient.toString()
+          edgeAmountIn = isExactInput(tradeType) ? amount.quotient.toString() : quote.quotient.toString()
         }
 
         let edgeAmountOut = undefined
         if (i === pools.length - 1) {
-          edgeAmountOut = type === 'exactIn' ? quote.quotient.toString() : amount.quotient.toString()
+          edgeAmountOut = isExactInput(tradeType) ? quote.quotient.toString() : amount.quotient.toString()
         }
 
         curRoute.push({
@@ -78,12 +79,12 @@ export function transformSwapRouteToGetQuoteResult(
 
         let edgeAmountIn = undefined
         if (i === 0) {
-          edgeAmountIn = type === 'exactIn' ? amount.quotient.toString() : quote.quotient.toString()
+          edgeAmountIn = isExactInput(tradeType) ? amount.quotient.toString() : quote.quotient.toString()
         }
 
         let edgeAmountOut = undefined
         if (i === pools.length - 1) {
-          edgeAmountOut = type === 'exactIn' ? quote.quotient.toString() : amount.quotient.toString()
+          edgeAmountOut = isExactInput(tradeType) ? quote.quotient.toString() : amount.quotient.toString()
         }
 
         const reserve0 = nextPool.reserve0

--- a/src/hooks/routing/useRouterArguments.ts
+++ b/src/hooks/routing/useRouterArguments.ts
@@ -38,7 +38,7 @@ export function useRouterArguments({
             tokenOutSymbol: tokenOut.wrapped.symbol,
             routerUrl,
             provider,
-            type: (tradeType === TradeType.EXACT_INPUT ? 'exactIn' : 'exactOut') as 'exactIn' | 'exactOut',
+            tradeType,
           },
     [amount, tokenIn, tokenOut, tradeType, routerUrl, provider]
   )

--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -15,6 +15,7 @@ import { useMemo } from 'react'
 import { useGetQuoteQuery } from 'state/routing/slice'
 import { GetQuoteResult, InterfaceTrade, TradeState } from 'state/routing/types'
 import { computeRoutes, transformRoutesToTrade } from 'state/routing/utils'
+import { isExactInput } from 'utils/tradeType'
 
 import { isAutoRouterSupportedChain } from './clientSideSmartOrderRouter'
 
@@ -50,7 +51,7 @@ export function useRouterTrade<TTradeType extends TradeType>(
 
   const [currencyIn, currencyOut]: [Currency | undefined, Currency | undefined] = useMemo(
     () =>
-      tradeType === TradeType.EXACT_INPUT
+      isExactInput(tradeType)
         ? [debouncedAmountSpecified?.currency, debouncedOtherCurrency]
         : [debouncedOtherCurrency, debouncedAmountSpecified?.currency],
     [debouncedAmountSpecified, debouncedOtherCurrency, tradeType]
@@ -106,10 +107,7 @@ export function useRouterTrade<TTradeType extends TradeType>(
 
     let otherAmount = undefined
     if (quoteResult) {
-      otherAmount = CurrencyAmount.fromRawAmount(
-        tradeType === TradeType.EXACT_INPUT ? currencyOut : currencyIn,
-        quoteResult.quote
-      )
+      otherAmount = CurrencyAmount.fromRawAmount(isExactInput(tradeType) ? currencyOut : currencyIn, quoteResult.quote)
     }
 
     if (isError || !otherAmount || !route || route.length === 0 || !queryArgs) {

--- a/src/hooks/swap/index.test.tsx
+++ b/src/hooks/swap/index.test.tsx
@@ -1,3 +1,4 @@
+import { TradeType } from '@uniswap/sdk-core'
 import { SupportedChainId } from 'constants/chains'
 import { DAI, UNI, USDC_MAINNET } from 'constants/tokens'
 import { useAtomValue } from 'jotai/utils'

--- a/src/hooks/swap/index.test.tsx
+++ b/src/hooks/swap/index.test.tsx
@@ -10,7 +10,7 @@ const DAI_MAINNET = DAI
 const UNI_MAINNET = UNI[SupportedChainId.MAINNET]
 
 const INITIAL_SWAP: Swap = {
-  independentField: Field.INPUT,
+  type: TradeType.EXACT_INPUT,
   amount: '42',
   [Field.INPUT]: DAI_MAINNET,
   [Field.OUTPUT]: USDC_MAINNET,
@@ -37,7 +37,7 @@ describe('swap state', () => {
       const { result } = rerender(() => useAtomValue(swapAtom))
       expect(result.current).toMatchObject({
         ...INITIAL_SWAP,
-        independentField: Field.OUTPUT,
+        type: TradeType.EXACT_OUTPUT,
         [Field.INPUT]: INITIAL_SWAP[Field.OUTPUT],
         [Field.OUTPUT]: INITIAL_SWAP[Field.INPUT],
       })
@@ -126,7 +126,7 @@ describe('swap state', () => {
       expect(spy).toHaveBeenCalledWith(Field.OUTPUT, '123')
 
       const { result } = rerender(() => useAtomValue(swapAtom))
-      expect(result.current).toMatchObject({ ...INITIAL_SWAP, amount: '123', independentField: Field.OUTPUT })
+      expect(result.current).toMatchObject({ ...INITIAL_SWAP, amount: '123', type: TradeType.EXACT_OUTPUT })
     })
 
     it('calls onAmountChange if present', () => {

--- a/src/hooks/swap/useSyncController.ts
+++ b/src/hooks/swap/useSyncController.ts
@@ -1,17 +1,10 @@
-import { Currency, TradeType } from '@uniswap/sdk-core'
 import { useUpdateAtom } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
-import { controlledAtom as swapAtom, Field, Swap } from 'state/swap'
+import { controlledAtom as swapAtom, Swap } from 'state/swap'
 import { controlledAtom as settingsAtom, Settings } from 'state/swap/settings'
 
 export type SwapSettingsController = Settings
-
-export interface SwapController {
-  type?: TradeType
-  amount?: string
-  [Field.INPUT]?: Currency
-  [Field.OUTPUT]?: Currency
-}
+export type SwapController = Swap
 
 export default function useSyncController({
   value,
@@ -33,19 +26,9 @@ export default function useSyncController({
   }, [settings, value])
 
   const setSwap = useUpdateAtom(swapAtom)
-  useEffect(() => setSwap(toSwap(value)), [value, setSwap])
+  useEffect(() => setSwap(value), [value, setSwap])
   const setSettings = useUpdateAtom(settingsAtom)
   useEffect(() => setSettings(settings), [settings, setSettings])
-}
-
-function toSwap(value?: SwapController): Swap | undefined {
-  if (!value) return undefined
-
-  return {
-    ...value,
-    independentField: value.type === TradeType.EXACT_INPUT ? Field.INPUT : Field.OUTPUT,
-    amount: value.amount || '',
-  }
 }
 
 function warnOnControlChange({ state, prop }: { state: string; prop: string }) {

--- a/src/hooks/useSwapCallArguments.tsx
+++ b/src/hooks/useSwapCallArguments.tsx
@@ -7,6 +7,7 @@ import { useWeb3React } from '@web3-react/core'
 import { SWAP_ROUTER_ADDRESSES, V3_ROUTER_ADDRESS } from 'constants/addresses'
 import { useMemo } from 'react'
 import approveAmountCalldata from 'utils/approveAmountCalldata'
+import { isExactInput } from 'utils/tradeType'
 
 import { useArgentWalletContract } from './useArgentWalletContract'
 import { useV2RouterContract } from './useContract'
@@ -62,7 +63,7 @@ export function useSwapCallArguments(
         })
       )
 
-      if (trade.tradeType === TradeType.EXACT_INPUT) {
+      if (isExactInput(trade.tradeType)) {
         swapMethods.push(
           V2SwapRouter.swapCallParameters(trade, {
             feeOnTransfer: true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,6 +32,7 @@ export { Field } from 'state/swap'
 export type { Slippage } from 'state/swap/settings'
 export type { Theme } from 'theme'
 export { darkTheme, defaultTheme, lightTheme } from 'theme'
+export { invertTradeType, toTradeType } from 'utils/tradeType'
 
 export type SwapWidgetProps = SwapProps & WidgetProps
 

--- a/src/state/swap/index.ts
+++ b/src/state/swap/index.ts
@@ -1,4 +1,4 @@
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, TradeType } from '@uniswap/sdk-core'
 import { FeeOptions } from '@uniswap/v3-sdk'
 import { SupportedChainId } from 'constants/chains'
 import { nativeOnChain } from 'constants/tokens'
@@ -13,14 +13,14 @@ export enum Field {
 }
 
 export interface Swap {
-  independentField: Field
+  type: TradeType
   amount: string
   [Field.INPUT]?: Currency
   [Field.OUTPUT]?: Currency
 }
 
 const initialSwap: Swap = {
-  independentField: Field.INPUT,
+  type: TradeType.EXACT_INPUT,
   amount: '',
   [Field.INPUT]: nativeOnChain(SupportedChainId.MAINNET),
 }

--- a/src/utils/tradeType.ts
+++ b/src/utils/tradeType.ts
@@ -1,0 +1,24 @@
+import { TradeType } from '@uniswap/sdk-core'
+import { Field } from 'state/swap'
+
+export function isExactInput(tradeType: TradeType): boolean {
+  return tradeType === TradeType.EXACT_INPUT
+}
+
+export function invertTradeType(tradeType: TradeType): TradeType {
+  switch (tradeType) {
+    case TradeType.EXACT_INPUT:
+      return TradeType.EXACT_OUTPUT
+    case TradeType.EXACT_OUTPUT:
+      return TradeType.EXACT_INPUT
+  }
+}
+
+export function toTradeType(modifiedField: Field): TradeType {
+  switch (modifiedField) {
+    case Field.INPUT:
+      return TradeType.EXACT_INPUT
+    case Field.OUTPUT:
+      return TradeType.EXACT_OUTPUT
+  }
+}


### PR DESCRIPTION
- Replaces usages of `independentField: Field` with `type: TradeType`, the primitive exposed through the SDK.
- Adds utilities (`invertTradeType` and `toTradeType`) to make it easier to deal with `TradeType`s.
- Replaces explicit checks of `tradeType === TradeType.EXACT_INPUT` with a boolean conversion `isExactInput` to standardize these checks.
- Standardizes `SwapController` to match internal `Swap` input (which makes internal conversion logic easier / unnecessary).