### PR TITLE
fix: set on connect wallet click

### DIFF
--- a/src/hooks/useSyncWidgetEventHandlers.ts
+++ b/src/hooks/useSyncWidgetEventHandlers.ts
@@ -9,5 +9,7 @@ export interface WidgetEventHandlers {
 
 export default function useSyncWidgetEventHandlers({ onConnectWalletClick }: WidgetEventHandlers): void {
   const setOnConnectWalletClick = useUpdateAtom(onConnectWalletClickAtom)
-  useEffect(() => setOnConnectWalletClick(onConnectWalletClick), [onConnectWalletClick, setOnConnectWalletClick])
+  useEffect(() => {
+    setOnConnectWalletClick(() => onConnectWalletClick)
+  }, [onConnectWalletClick, setOnConnectWalletClick])
 }


### PR DESCRIPTION
Fixes a bug where passing `onConnectWalletClick` to the atom updater caused infinite recursion, because passing a function runs that function and sets the return value. Instead, we want to set the function, so it should be returned from an anonymous function.