### PR TITLE
fix: limiting height of swap button

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -10,6 +10,7 @@ const StyledButton = styled(Button)`
   border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   flex-grow: 1;
   transition: background-color 0.25s ease-out, border-radius 0.25s ease-out, flex-grow 0.25s ease-out;
+  max-height: 56px;
 
   :disabled {
     margin: -1px;


### PR DESCRIPTION
task: https://uniswaplabs.atlassian.net/browse/WEB-973?jql=project%20%3D%20WEB%20AND%20status%20in%20(%22In%20Progress%22%2C%20%22Needs%20Review%22%2C%20%22To%20Do%22)%20AND%20labels%20%3D%20Phase0%20ORDER%20BY%20priority%20DESC%2C%20created%20DESC

"Swap widget’s "Review swap" button on token page should be 56px tall instead of 60px"