### PR TITLE
chore: fix types related to tradeType

### DIFF
--- a/src/hooks/swap/useSyncTokenDefaults.ts
+++ b/src/hooks/swap/useSyncTokenDefaults.ts
@@ -1,4 +1,4 @@
-import { Currency } from '@uniswap/sdk-core'
+import { Currency, TradeType } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { nativeOnChain } from 'constants/tokens'
 import { useToken } from 'hooks/useCurrency'
@@ -61,12 +61,12 @@ export default function useSyncTokenDefaults({
       amount: '',
       [Field.INPUT]: defaultInputToken,
       [Field.OUTPUT]: defaultOutputToken,
-      independentField: Field.INPUT,
+      type: TradeType.EXACT_INPUT,
     }
     if (defaultInputToken && defaultInputAmount) {
       defaultSwapState.amount = defaultInputAmount.toString()
     } else if (defaultOutputToken && defaultOutputAmount) {
-      defaultSwapState.independentField = Field.OUTPUT
+      defaultSwapState.type = TradeType.EXACT_OUTPUT
       defaultSwapState.amount = defaultOutputAmount.toString()
     }
     updateSwap((swap) => ({ ...swap, ...defaultSwapState }))

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -8,7 +8,6 @@ import { TradeType } from '@uniswap/sdk-core'
 import type { ChainId } from '@uniswap/smart-order-router'
 import ms from 'ms.macro'
 import qs from 'qs'
-import { isExactInput } from 'utils/tradeType'
 
 import { GetQuoteResult } from './types'
 

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -78,13 +78,7 @@ export const routing = createApi({
           // Lazy-load the clientside router to improve initial pageload times.
           return await (
             await import('../../hooks/routing/clientSideSmartOrderRouter')
-          ).getClientSideQuote(
-            { ...args, tradeType: isExactInput(tradeType) ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT },
-            provider,
-            {
-              protocols,
-            }
-          )
+          ).getClientSideQuote(args, provider, { protocols })
         }
 
         let result

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -78,9 +78,13 @@ export const routing = createApi({
           // Lazy-load the clientside router to improve initial pageload times.
           return await (
             await import('../../hooks/routing/clientSideSmartOrderRouter')
-          ).getClientSideQuote({ ...args, type: isExactInput(tradeType) ? 'exactIn' : 'exactOut' }, provider, {
-            protocols,
-          })
+          ).getClientSideQuote(
+            { ...args, tradeType: isExactInput(tradeType) ? TradeType.EXACT_INPUT : TradeType.EXACT_OUTPUT },
+            provider,
+            {
+              protocols,
+            }
+          )
         }
 
         let result


### PR DESCRIPTION
```
$ tsc -p tsconfig.build.json && rollup --config --failAfterWarnings
src/hooks/swap/useSyncTokenDefaults.ts:64:7 - error TS2322: Type '{ amount: string; INPUT: Currency | undefined; OUTPUT: Currency | undefined; independentField: Field; }' is not assignable to type 'Swap'.
  Object literal may only specify known properties, and 'independentField' does not exist in type 'Swap'.

64       independentField: Field.INPUT,
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/hooks/swap/useSyncTokenDefaults.ts:69:24 - error TS2339: Property 'independentField' does not exist on type 'Swap'.

69       defaultSwapState.independentField = Field.OUTPUT
                          ~~~~~~~~~~~~~~~~

src/state/routing/slice.ts:81:43 - error TS2345: Argument of type '{ type: string; tokenInAddress: string; tokenInChainId: ChainId; tokenInDecimals: number; tokenInSymbol?: string | undefined; tokenOutAddress: string; tokenOutChainId: ChainId; ... 5 more ...; tradeType: TradeType; }' is not assignable to parameter of type 'QuoteArguments'.
  Object literal may only specify known properties, and 'type' does not exist in type 'QuoteArguments'.

81           ).getClientSideQuote({ ...args, type: isExactInput(tradeType) ? 'exactIn' : 'exactOut' }, provider, {
                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
<img width="755" alt="image" src="https://user-images.githubusercontent.com/5773490/187506086-7f3ba26f-960a-40c6-afff-25abb65085eb.png">
