### PR TITLE
fix: fixing scroll, z-index and removing a dash

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -5,7 +5,7 @@ import { largeIconCss } from 'icons'
 import { createContext, ReactElement, ReactNode, useContext, useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import styled from 'styled-components/macro'
-import { Color, Layer, ThemedText, ThemeProvider } from 'theme'
+import { Color, ThemedText, ThemeProvider } from 'theme'
 import { useUnmountingAnimation } from 'utils/animations'
 
 import { TextButton } from './Button'

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -111,7 +111,7 @@ export const Modal = styled.div<{ color: Color }>`
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: ${Layer.DIALOG};
+  z-index: 1;
 `
 
 interface DialogProps {

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -120,7 +120,7 @@ export default function Input({ disabled, focused }: InputProps) {
       >
         <ThemedText.Body2 color="secondary" userSelect>
           <Row>
-            <USDC isLoading={isRouteLoading}>{usdc ? `$${formatCurrencyAmount(usdc, 6, 'en', 2)}` : '-'}</USDC>
+            <USDC isLoading={isRouteLoading}>{usdc ? `$${formatCurrencyAmount(usdc, 6, 'en', 2)}` : ''}</USDC>
             {balance && (
               <Balance color={insufficientBalance ? 'error' : focused ? 'secondary' : 'hint'}>
                 Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -33,7 +33,7 @@ export function SettingsDialog() {
           </ThemedText.ButtonSmall>
         </TextButton>
       </Header>
-      <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded css={scrollbar}>
+      <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
         <BoundaryProvider value={boundary}>
           <MaxSlippageSelect />
           <TransactionTtlInput />


### PR DESCRIPTION
Tasks
https://uniswaplabs.atlassian.net/browse/WEB-985
https://uniswaplabs.atlassian.net/browse/WEB-953
z-index: I noticed this when using the site that there is overlap of the navbar and widget


<img width="672" alt="Screen Shot 2022-08-31 at 12 42 43 PM" src="https://user-images.githubusercontent.com/15934595/187739002-5ca85a22-6ec2-4f92-ba70-15bac68f4fed.png">
<img width="506" alt="Screen Shot 2022-08-31 at 1 11 42 PM" src="https://user-images.githubusercontent.com/15934595/187739084-10e07073-c31e-4a84-aa4a-8108eb4bec3c.png">
<img width="526" alt="Screen Shot 2022-08-31 at 1 11 49 PM" src="https://user-images.githubusercontent.com/15934595/187739086-0b1e1699-b578-42ad-ae7d-f6cf7162b38e.png">
