### PR TITLE
fix: switch chain outside of web3

### DIFF
--- a/src/components/Swap/SwapActionButton/SwitchChainButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwitchChainButton.tsx
@@ -12,14 +12,18 @@ export default function ChainSwitchButton({ color, chainId }: { color: keyof Col
   const [isPending, setIsPending] = useState(!account)
 
   const switchChain = useSwitchChain()
+  const [error, setError] = useState()
   const onSwitchChain = useCallback(async () => {
     setIsPending(true)
     try {
       await switchChain(chainId)
+    } catch (error) {
+      setError(error)
     } finally {
       setIsPending(false)
     }
   }, [chainId, switchChain])
+  if (error) throw error
 
   // If there is no account (ie no wallet to take agency), switch chains automatically
   useEffect(() => {

--- a/src/constants/eip1193.ts
+++ b/src/constants/eip1193.ts
@@ -5,4 +5,7 @@ export enum ErrorCode {
   UNSUPPORTED_METHOD = 4200,
   DISCONNECTED = 4900,
   CHAIN_DISCONNECTED = 4901,
+
+  // https://docs.metamask.io/guide/rpc-api.html#unrestricted-methods
+  CHAIN_NOT_ADDED = 4902,
 }

--- a/src/cosmos/ControlledSwap.fixture.tsx
+++ b/src/cosmos/ControlledSwap.fixture.tsx
@@ -61,7 +61,6 @@ function Fixture() {
         onTokenChange={useHandleEvent('onTokenChange')}
         onAmountChange={useHandleEvent('onAmountChange')}
         onSwitchTokens={useHandleEvent('onSwitchTokens')}
-        hideConnectionUI={true}
         jsonRpcUrlMap={INFURA_NETWORK_URLS}
         provider={connector}
         tokenList={tokens}

--- a/src/cosmos/useProvider.ts
+++ b/src/cosmos/useProvider.ts
@@ -30,7 +30,7 @@ export const INFURA_NETWORK_URLS: { [chainId: number]: string[] } = INFURA_KEY
 
 enum Wallet {
   MetaMask = 'MetaMask',
-  WalletConnect = 'WalletConenct',
+  WalletConnect = 'WalletConnect',
 }
 const [metaMask] = initializeConnector<MetaMask>((actions) => new MetaMask({ actions }))
 const [walletConnect] = initializeConnector<WalletConnect>(

--- a/src/hooks/useSwitchChain.ts
+++ b/src/hooks/useSwitchChain.ts
@@ -1,43 +1,66 @@
+import type { Web3Provider } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
 import { Network } from '@web3-react/network'
-import { AddEthereumChainParameter, Connector } from '@web3-react/types'
+import { ProviderRpcError } from '@web3-react/types'
 import { WalletConnect } from '@web3-react/walletconnect'
 import { getChainInfo } from 'constants/chainInfo'
 import { SupportedChainId } from 'constants/chains'
 import { ErrorCode } from 'constants/eip1193'
 import useJsonRpcUrlMap from 'hooks/web3/useJsonRpcUrlMap'
 import { useCallback } from 'react'
+import invariant from 'tiny-invariant'
 
-async function switchChain(connector: Connector, chainId: SupportedChainId, rpcUrls: string[]): Promise<void> {
-  if (connector instanceof WalletConnect || connector instanceof Network) {
-    await connector.activate(chainId)
-  } else {
-    const { label: chainName, nativeCurrency, explorer } = getChainInfo(chainId)
-    try {
-      const addChainParameter: AddEthereumChainParameter = {
-        chainId,
-        chainName,
-        rpcUrls,
-        nativeCurrency,
-        blockExplorerUrls: [explorer],
+async function switchChain(provider: Web3Provider, chainIdDecimal: SupportedChainId, rpcUrls: string[]): Promise<void> {
+  const { label: chainName, nativeCurrency, explorer } = getChainInfo(chainIdDecimal)
+  const chainId = `0x${chainIdDecimal.toString(16)}`
+
+  try {
+    // EIP-3326 (used by MetaMask)
+    await provider.send('wallet_switchEthereumChain', [{ chainId }]).catch(async (error: ProviderRpcError) => {
+      if (error.code !== ErrorCode.CHAIN_NOT_ADDED) throw error
+      await addChain(rpcUrls)
+      await provider.send('wallet_switchEthereumChain', [{ chainId }])
+
+      async function addChain(rpcUrls: string[]) {
+        const addChainParameter = {
+          chainId,
+          chainName,
+          rpcUrls: [rpcUrls[0]],
+          nativeCurrency,
+          blockExplorerUrls: [explorer],
+        }
+        try {
+          // EIP-3085
+          await provider.send('wallet_addEthereumChain', [addChainParameter])
+        } catch (error) {
+          // Some providers (eg MetaMask) make test calls from a background page before switching,
+          // so fallback urls which are publicly available must be used. Otherwise, the switch will fail
+          // if the background page origin is blocked.
+          if (error?.code !== ErrorCode.USER_REJECTED_REQUEST && rpcUrls.length > 1) {
+            await addChain(rpcUrls.slice(1))
+          }
+        }
       }
-      await connector.activate(addChainParameter)
-    } catch (error) {
-      // Some providers (eg MetaMask) make test calls from a background page before switching,
-      // so fallback urls which are publicly available must be used. Otherwise, the switch will fail
-      // if the background page origin is blocked.
-      if (error?.code !== ErrorCode.USER_REJECTED_REQUEST && rpcUrls.length > 1) {
-        await switchChain(connector, chainId, rpcUrls.slice(1))
-      }
+    })
+  } catch (error) {
+    if (error?.code !== ErrorCode.USER_REJECTED_REQUEST) {
+      throw new Error(`Failed to switch network: ${error}`)
     }
   }
 }
 
 export default function useSwitchChain(): (chainId: SupportedChainId) => Promise<void> {
-  const { connector } = useWeb3React()
+  const { connector, provider } = useWeb3React()
   const urlMap = useJsonRpcUrlMap()
   return useCallback(
-    (chainId: SupportedChainId) => switchChain(connector, chainId, urlMap[chainId]),
-    [connector, urlMap]
+    (chainId: SupportedChainId) => {
+      if (connector instanceof WalletConnect || connector instanceof Network) {
+        return connector.activate(chainId)
+      }
+
+      invariant(provider)
+      return switchChain(provider, chainId, urlMap[chainId])
+    },
+    [connector, provider, urlMap]
   )
 }

--- a/src/hooks/useSwitchChain.ts
+++ b/src/hooks/useSwitchChain.ts
@@ -1,7 +1,6 @@
 import type { Web3Provider } from '@ethersproject/providers'
 import { useWeb3React } from '@web3-react/core'
 import { Network } from '@web3-react/network'
-import { ProviderRpcError } from '@web3-react/types'
 import { WalletConnect } from '@web3-react/walletconnect'
 import { getChainInfo } from 'constants/chainInfo'
 import { SupportedChainId } from 'constants/chains'
@@ -10,42 +9,46 @@ import useJsonRpcUrlMap from 'hooks/web3/useJsonRpcUrlMap'
 import { useCallback } from 'react'
 import invariant from 'tiny-invariant'
 
-async function switchChain(provider: Web3Provider, chainIdDecimal: SupportedChainId, rpcUrls: string[]): Promise<void> {
-  const { label: chainName, nativeCurrency, explorer } = getChainInfo(chainIdDecimal)
-  const chainId = `0x${chainIdDecimal.toString(16)}`
+function toHex(chainId: SupportedChainId): string {
+  return `0x${chainId.toString(16)}`
+}
 
-  try {
-    // EIP-3326 (used by MetaMask)
-    await provider.send('wallet_switchEthereumChain', [{ chainId }]).catch(async (error: ProviderRpcError) => {
-      if (error.code !== ErrorCode.CHAIN_NOT_ADDED) throw error
-      await addChain(rpcUrls)
-      await provider.send('wallet_switchEthereumChain', [{ chainId }])
+async function addChain(provider: Web3Provider, chainId: SupportedChainId, rpcUrls: string[]): Promise<void> {
+  const { label: chainName, nativeCurrency, explorer } = getChainInfo(chainId)
+  const addChainParameter = {
+    chainId: toHex(chainId),
+    chainName,
+    nativeCurrency,
+    blockExplorerUrls: [explorer],
+  }
 
-      async function addChain(rpcUrls: string[]) {
-        const addChainParameter = {
-          chainId,
-          chainName,
-          rpcUrls: [rpcUrls[0]],
-          nativeCurrency,
-          blockExplorerUrls: [explorer],
-        }
-        try {
-          // EIP-3085
-          await provider.send('wallet_addEthereumChain', [addChainParameter])
-        } catch (error) {
-          // Some providers (eg MetaMask) make test calls from a background page before switching,
-          // so fallback urls which are publicly available must be used. Otherwise, the switch will fail
-          // if the background page origin is blocked.
-          if (error?.code !== ErrorCode.USER_REJECTED_REQUEST && rpcUrls.length > 1) {
-            await addChain(rpcUrls.slice(1))
-          }
-        }
-      }
-    })
-  } catch (error) {
-    if (error?.code !== ErrorCode.USER_REJECTED_REQUEST) {
-      throw new Error(`Failed to switch network: ${error}`)
+  for (const rpcUrl of rpcUrls) {
+    try {
+      await provider.send('wallet_addEthereumChain', [{ ...addChainParameter, rpcUrls: [rpcUrl] }]) // EIP-3085
+    } catch (error) {
+      // Some providers (eg MetaMask) make test calls from a background page before switching,
+      // so fallback urls which are publicly available must be used. Otherwise, the switch will fail
+      // if the background page origin is blocked.
+      if (error?.code !== ErrorCode.USER_REJECTED_REQUEST) continue
+      throw error
     }
+  }
+}
+
+async function switchChain(provider: Web3Provider, chainId: SupportedChainId, rpcUrls: string[] = []): Promise<void> {
+  try {
+    try {
+      await provider.send('wallet_switchEthereumChain', [{ chainId: toHex(chainId) }]) // EIP-3326 (used by MetaMask)
+    } catch (error) {
+      if (error?.code === ErrorCode.CHAIN_NOT_ADDED && rpcUrls.length) {
+        await addChain(provider, chainId, rpcUrls)
+        return switchChain(provider, chainId)
+      }
+      throw error
+    }
+  } catch (error) {
+    if (error?.code === ErrorCode.USER_REJECTED_REQUEST) return
+    throw new Error(`Failed to switch network: ${error}`)
   }
 }
 


### PR DESCRIPTION
Switches chains outside of web3-react. This makes it more portable (by not relying on the web3-react connectors), and avoids a bug where web3-react considers a connector inactive while it switches chains (thus temporarily changing to fallback connectors).