### PR TITLE
test: responsive event feed

### DIFF
--- a/src/cosmos/ControlledSwap.fixture.tsx
+++ b/src/cosmos/ControlledSwap.fixture.tsx
@@ -47,7 +47,7 @@ function Fixture() {
   const connector = useProvider(SupportedChainId.MAINNET)
 
   return (
-    <Row align="start" justify="space-around">
+    <Row flex align="start" justify="start" gap={0.5}>
       <SwapWidget
         value={{
           type,

--- a/src/cosmos/EventFeed.tsx
+++ b/src/cosmos/EventFeed.tsx
@@ -12,7 +12,7 @@ const EventFeedWrapper = styled.div`
   width: 360px;
 `
 const EventColumn = styled.div`
-  height: 80vh;
+  height: 306px;
   overflow: auto;
 `
 const EventRow = styled.div`

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -109,7 +109,7 @@ function Fixture() {
   if (!window.frameElement) return widget
 
   return (
-    <Row align="start" justify="space-around">
+    <Row flex align="start" justify="start" gap={0.5}>
       {widget}
       <EventFeed events={events} onClear={() => setEvents([])} />
     </Row>


### PR DESCRIPTION
Matches the event feed's height to the widget.
Uses a flex Row so that - if the DevTools are open to the right - the feed can go below the widget.

Fixes a testing pattern where opening DevTools would occlude the Widget being inspected.