### PR TITLE
fix: guard against undefined window for SSR (eg nextjs)

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,8 +1,7 @@
 import { Buffer } from 'buffer'
-if (typeof window !== "undefined") {
+if (typeof window !== 'undefined') {
   // WalletConnect relies on Buffer, so it must be polyfilled.
   if (!('Buffer' in window)) {
     window.Buffer = Buffer
   }
 }
-

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,6 +1,8 @@
 import { Buffer } from 'buffer'
-
-// WalletConnect relies on Buffer, so it must be polyfilled.
-if (!('Buffer' in window)) {
-  window.Buffer = Buffer
+if (typeof window !== "undefined") {
+  // WalletConnect relies on Buffer, so it must be polyfilled.
+  if (!('Buffer' in window)) {
+    window.Buffer = Buffer
+  }
 }
+


### PR DESCRIPTION
**Problem:** Fixes #146 when NextJS does a server side render there is no `window` object so the server throws an error and crashes in the `polyfill.js` file. 

**Solution:** Since server side node shouldn't need the polyfill, just check if the window object exists. If it doesn't, we're server side and don't need to attempt to polyfill. 

NOTE: NextJS has explicit dead-code elimination for when guarding against an undefined window as `typeof window`, so this is the canonical way to check for SSR (see https://nextjs.org/blog/next-9#dead-code-elimination-for-typeof-window-branches).