### PR TITLE
fix: display the trade that will execute

### DIFF
--- a/src/components/Swap/Price.tsx
+++ b/src/components/Swap/Price.tsx
@@ -1,8 +1,8 @@
 import { useLingui } from '@lingui/react'
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import Row from 'components/Row'
 import { useCallback, useMemo, useState } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 import { ThemedText } from 'theme'
 import { formatCurrencyAmount, formatPrice } from 'utils/formatCurrencyAmount'
 import formatLocaleNumber from 'utils/formatLocaleNumber'
@@ -10,7 +10,7 @@ import formatLocaleNumber from 'utils/formatLocaleNumber'
 import { TextButton } from '../Button'
 
 interface PriceProps {
-  trade: Trade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
   outputUSDC?: CurrencyAmount<Currency>
 }
 

--- a/src/components/Swap/RoutingDiagram/index.tsx
+++ b/src/components/Swap/RoutingDiagram/index.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { Currency, TradeType } from '@uniswap/sdk-core'
+import { Currency } from '@uniswap/sdk-core'
 import { FeeAmount } from '@uniswap/v3-sdk'
 import { ReactComponent as DotLine } from 'assets/svg/dot_line.svg'
 import Column from 'components/Column'
@@ -120,7 +120,7 @@ function Route({ route }: { route: RoutingDiagramEntry }) {
   )
 }
 
-export default function RoutingDiagram({ trade }: { trade: InterfaceTrade<Currency, Currency, TradeType> }) {
+export default function RoutingDiagram({ trade }: { trade: InterfaceTrade }) {
   const routes: RoutingDiagramEntry[] = useMemo(() => getTokenPath(trade), [trade])
 
   return (

--- a/src/components/Swap/RoutingDiagram/utils.ts
+++ b/src/components/Swap/RoutingDiagram/utils.ts
@@ -1,7 +1,8 @@
 import { Protocol } from '@uniswap/router-sdk'
-import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
-import { Pair } from '@uniswap/v2-sdk'
+import { Currency, Percent } from '@uniswap/sdk-core'
+import { Pair, Trade as V2Trade } from '@uniswap/v2-sdk'
 import { FeeAmount } from '@uniswap/v3-sdk'
+import { ONE_HUNDRED_PERCENT } from 'constants/misc'
 import { InterfaceTrade } from 'state/routing/types'
 import { isExactInput } from 'utils/tradeType'
 
@@ -11,27 +12,34 @@ export interface RoutingDiagramEntry {
   protocol: Protocol
 }
 
-const V2_DEFAULT_FEE_TIER = 3000
+const V2_FEE_AMOUNT = FeeAmount.MEDIUM
 
 /**
  * Loops through all routes on a trade and returns an array of diagram entries.
  */
-export function getTokenPath(trade: InterfaceTrade<Currency, Currency, TradeType>): RoutingDiagramEntry[] {
-  return trade.swaps.map(({ route: { path: tokenPath, pools, protocol }, inputAmount, outputAmount }) => {
+export function getTokenPath(trade: InterfaceTrade): RoutingDiagramEntry[] {
+  if (trade instanceof V2Trade) {
+    const path: [Currency, Currency, FeeAmount][] = trade.route.pairs.map((pair) => [
+      pair.token0,
+      pair.token1,
+      V2_FEE_AMOUNT,
+    ])
+    return [{ path, percent: ONE_HUNDRED_PERCENT, protocol: Protocol.V2 }]
+  }
+
+  return trade.swaps.map(({ route: { pools }, inputAmount, outputAmount }) => {
     const portion = isExactInput(trade.tradeType)
       ? inputAmount.divide(trade.inputAmount)
       : outputAmount.divide(trade.outputAmount)
     const percent = new Percent(portion.numerator, portion.denominator)
     const path: RoutingDiagramEntry['path'] = []
+    let protocol = Protocol.V2
     for (let i = 0; i < pools.length; i++) {
-      const nextPool = pools[i]
-      const tokenIn = tokenPath[i]
-      const tokenOut = tokenPath[i + 1]
-      const entry: RoutingDiagramEntry['path'][0] = [
-        tokenIn,
-        tokenOut,
-        nextPool instanceof Pair ? V2_DEFAULT_FEE_TIER : nextPool.fee,
-      ]
+      const pool = pools[i]
+      const tokenIn = pool.token0
+      const tokenOut = pool.token1
+      protocol = pool instanceof Pair ? Protocol.V2 : Protocol.V3
+      const entry: RoutingDiagramEntry['path'][0] = [tokenIn, tokenOut, pool instanceof Pair ? V2_FEE_AMOUNT : pool.fee]
       path.push(entry)
     }
     return {

--- a/src/components/Swap/Summary/Details.tsx
+++ b/src/components/Swap/Summary/Details.tsx
@@ -1,13 +1,12 @@
 import { t } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, TradeType } from '@uniswap/sdk-core'
 import Column from 'components/Column'
 import Row from 'components/Row'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { Slippage } from 'hooks/useSlippage'
 import { useAtomValue } from 'jotai/utils'
 import { useMemo } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 import { feeOptionsAtom } from 'state/swap'
 import styled from 'styled-components/macro'
 import { Color, ThemedText } from 'theme'
@@ -39,7 +38,7 @@ function Detail({ label, value, color }: DetailProps) {
 }
 
 interface DetailsProps {
-  trade: Trade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
   slippage: Slippage
   impact?: PriceImpact
 }

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -1,7 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import ActionButton, { Action } from 'components/ActionButton'
 import Column from 'components/Column'
 import { Header } from 'components/Dialog'
@@ -11,6 +10,7 @@ import { PriceImpact } from 'hooks/usePriceImpact'
 import { Slippage } from 'hooks/useSlippage'
 import { AlertTriangle, BarChart, Info, Spinner } from 'icons'
 import { useCallback, useMemo, useState } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
@@ -63,7 +63,7 @@ function Subhead({ impact, slippage }: { impact?: PriceImpact; slippage: Slippag
 
 interface EstimateProps {
   slippage: Slippage
-  trade: Trade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
 }
 
 function Estimate({ trade, slippage }: EstimateProps) {
@@ -93,7 +93,7 @@ function ConfirmButton({
   highPriceImpact,
   onConfirm,
 }: {
-  trade: Trade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
   highPriceImpact: boolean
   onConfirm: () => Promise<void>
 }) {
@@ -150,7 +150,7 @@ function ConfirmButton({
 }
 
 interface SummaryDialogProps {
-  trade: Trade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
   slippage: Slippage
   inputUSDC?: CurrencyAmount<Currency>
   outputUSDC?: CurrencyAmount<Currency>

--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -1,7 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
 import { useSwapInfo } from 'hooks/swap'
-import { useSwapApprovalOptimizedTrade } from 'hooks/swap/useSwapApproval'
 import { useSwapCallback } from 'hooks/swap/useSwapCallback'
 import { useConditionalHandler } from 'hooks/useConditionalHandler'
 import { SignatureData } from 'hooks/useERC20Permit'
@@ -24,12 +23,10 @@ import { SummaryDialog } from '../Summary'
  */
 export default function SwapButton({
   color,
-  optimizedTrade,
   signatureData,
   onSubmit,
 }: {
   color: keyof Colors
-  optimizedTrade: ReturnType<typeof useSwapApprovalOptimizedTrade>
   signatureData: SignatureData | null
   onSubmit: (submit: () => Promise<SwapTransactionInfo | undefined>) => Promise<boolean>
 }) {
@@ -45,7 +42,7 @@ export default function SwapButton({
   const deadline = useTransactionDeadline()
 
   const { callback: swapCallback } = useSwapCallback({
-    trade: optimizedTrade,
+    trade,
     allowedSlippage: slippage.allowed,
     recipientAddressOrName: account ?? null,
     signatureData,

--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
 import { useSwapInfo } from 'hooks/swap'
-import { ApproveOrPermitState, useApproveOrPermit, useSwapApprovalOptimizedTrade } from 'hooks/swap/useSwapApproval'
+import { ApproveOrPermitState, useApproveOrPermit } from 'hooks/swap/useSwapApproval'
 import { useIsWrap } from 'hooks/swap/useWrapCallback'
 import { memo, useMemo } from 'react'
 import { Field } from 'state/swap'
@@ -23,17 +23,14 @@ export default memo(function SwapActionButton({ disabled }: SwapButtonProps) {
   const {
     [Field.INPUT]: { currency: inputCurrency, amount: inputCurrencyAmount, balance: inputCurrencyBalance },
     [Field.OUTPUT]: { currency: outputCurrency },
-    trade,
+    trade: { trade },
     slippage,
   } = useSwapInfo()
 
   const tokenChainId = inputCurrency?.chainId ?? outputCurrency?.chainId
 
   // TODO(zzmp): Return an optimized trade directly from useSwapInfo.
-  const optimizedTrade =
-    // Use trade.trade if there is no swap optimized trade. This occurs if approvals are still pending.
-    useSwapApprovalOptimizedTrade(trade.trade, slippage.allowed, useIsPendingApproval) || trade.trade
-  const approval = useApproveOrPermit(optimizedTrade, slippage.allowed, useIsPendingApproval, inputCurrencyAmount)
+  const approval = useApproveOrPermit(trade, slippage.allowed, useIsPendingApproval, inputCurrencyAmount)
   const onSubmit = useOnSubmit()
 
   const isWrap = useIsWrap()
@@ -41,10 +38,10 @@ export default memo(function SwapActionButton({ disabled }: SwapButtonProps) {
     () =>
       disabled ||
       !chainId ||
-      (!isWrap && !optimizedTrade) ||
+      (!isWrap && !trade) ||
       !(inputCurrencyAmount && inputCurrencyBalance) ||
       inputCurrencyBalance.lessThan(inputCurrencyAmount),
-    [disabled, chainId, isWrap, optimizedTrade, inputCurrencyAmount, inputCurrencyBalance]
+    [disabled, chainId, isWrap, trade, inputCurrencyAmount, inputCurrencyBalance]
   )
 
   const { tokenColorExtraction } = useTheme()
@@ -61,15 +58,8 @@ export default memo(function SwapActionButton({ disabled }: SwapButtonProps) {
   } else if (isWrap) {
     return <WrapButton color={color} onSubmit={onSubmit} />
   } else if (approval.approvalState !== ApproveOrPermitState.APPROVED) {
-    return <ApproveButton color={color} onSubmit={onSubmit} trade={trade.trade} {...approval} />
+    return <ApproveButton color={color} onSubmit={onSubmit} trade={trade} {...approval} />
   } else {
-    return (
-      <SwapButton
-        color={color}
-        onSubmit={onSubmit}
-        optimizedTrade={optimizedTrade}
-        signatureData={approval.signatureData}
-      />
-    )
+    return <SwapButton color={color} onSubmit={onSubmit} signatureData={approval.signatureData} />
   }
 })

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import Column from 'components/Column'
 import Rule from 'components/Rule'
 import Tooltip from 'components/Tooltip'
@@ -101,7 +101,7 @@ export function Trade({
   outputUSDC,
   impact,
 }: {
-  trade: InterfaceTrade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
   outputUSDC?: CurrencyAmount<Currency>
   impact?: PriceImpact
 }) {

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -48,7 +48,7 @@ export default memo(function Toolbar() {
       if (isWrap) {
         return <Caption.WrapCurrency inputCurrency={inputCurrency} outputCurrency={outputCurrency} />
       }
-      if (state === TradeState.NO_ROUTE_FOUND || (trade && !trade.swaps)) {
+      if (state === TradeState.NO_ROUTE_FOUND) {
         return <Caption.InsufficientLiquidity />
       }
       if (trade?.inputAmount && trade.outputAmount) {

--- a/src/hooks/swap/useSendSwapTransaction.tsx
+++ b/src/hooks/swap/useSendSwapTransaction.tsx
@@ -2,20 +2,12 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { JsonRpcProvider, TransactionResponse } from '@ethersproject/providers'
 // eslint-disable-next-line no-restricted-imports
 import { t, Trans } from '@lingui/macro'
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, TradeType } from '@uniswap/sdk-core'
-import { Trade as V2Trade } from '@uniswap/v2-sdk'
-import { Trade as V3Trade } from '@uniswap/v3-sdk'
 import { ErrorCode } from 'constants/eip1193'
 import { useMemo } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 import { calculateGasMargin } from 'utils/calculateGasMargin'
 import isZero from 'utils/isZero'
 import { swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
-
-type AnyTrade =
-  | V2Trade<Currency, Currency, TradeType>
-  | V3Trade<Currency, Currency, TradeType>
-  | Trade<Currency, Currency, TradeType>
 
 interface SwapCall {
   address: string
@@ -42,7 +34,7 @@ export default function useSendSwapTransaction(
   account: string | null | undefined,
   chainId: number | undefined,
   provider: JsonRpcProvider | undefined,
-  trade: AnyTrade | undefined, // trade to execute, required
+  trade: InterfaceTrade | undefined, // trade to execute, required
   swapCalls: SwapCall[]
 ): { callback: null | (() => Promise<TransactionResponse>) } {
   return useMemo(() => {

--- a/src/hooks/swap/useSwapApproval.ts
+++ b/src/hooks/swap/useSwapApproval.ts
@@ -8,6 +8,7 @@ import { ErrorCode } from 'constants/eip1193'
 import { useERC20PermitFromTrade, UseERC20PermitState } from 'hooks/useERC20Permit'
 import useTransactionDeadline from 'hooks/useTransactionDeadline'
 import { useCallback, useMemo } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 import { getTxOptimizedSwapRouter, SwapRouterVersion } from 'utils/getTxOptimizedSwapRouter'
 
 import { ApprovalState, useApproval, useApprovalStateForSpender } from '../useApproval'
@@ -36,13 +37,7 @@ function useSwapApprovalStates(
   return useMemo(() => ({ v2, v3, v2V3 }), [v2, v2V3, v3])
 }
 
-export function useSwapRouterAddress(
-  trade:
-    | V2Trade<Currency, Currency, TradeType>
-    | V3Trade<Currency, Currency, TradeType>
-    | Trade<Currency, Currency, TradeType>
-    | undefined
-) {
+export function useSwapRouterAddress(trade: InterfaceTrade | undefined) {
   const { chainId } = useWeb3React()
   return useMemo(
     () =>
@@ -59,11 +54,7 @@ export function useSwapRouterAddress(
 
 // wraps useApproveCallback in the context of a swap
 export default function useSwapApproval(
-  trade:
-    | V2Trade<Currency, Currency, TradeType>
-    | V3Trade<Currency, Currency, TradeType>
-    | Trade<Currency, Currency, TradeType>
-    | undefined,
+  trade: InterfaceTrade | undefined,
   allowedSlippage: Percent,
   useIsPendingApproval: (token?: Token, spender?: string) => boolean,
   amount?: CurrencyAmount<Currency> // defaults to trade.maximumAmountIn(allowedSlippage)
@@ -82,11 +73,7 @@ export function useSwapApprovalOptimizedTrade(
   trade: Trade<Currency, Currency, TradeType> | undefined,
   allowedSlippage: Percent,
   useIsPendingApproval: (token?: Token, spender?: string) => boolean
-):
-  | V2Trade<Currency, Currency, TradeType>
-  | V3Trade<Currency, Currency, TradeType>
-  | Trade<Currency, Currency, TradeType>
-  | undefined {
+): InterfaceTrade | undefined {
   const onlyV2Routes = trade?.routes.every((route) => route.protocol === Protocol.V2)
   const onlyV3Routes = trade?.routes.every((route) => route.protocol === Protocol.V3)
   const tradeHasSplits = (trade?.routes.length ?? 0) > 1
@@ -146,11 +133,7 @@ export enum ApproveOrPermitState {
  * Considers both standard approval and ERC20 permit.
  */
 export const useApproveOrPermit = (
-  trade:
-    | V2Trade<Currency, Currency, TradeType>
-    | V3Trade<Currency, Currency, TradeType>
-    | Trade<Currency, Currency, TradeType>
-    | undefined,
+  trade: InterfaceTrade | undefined,
   allowedSlippage: Percent,
   useIsPendingApproval: (token?: Token, spender?: string) => boolean,
   amount?: CurrencyAmount<Currency> // defaults to trade.maximumAmountIn(allowedSlippage)

--- a/src/hooks/swap/useSwapCallback.tsx
+++ b/src/hooks/swap/useSwapCallback.tsx
@@ -7,8 +7,9 @@ import { FeeOptions } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
 import useENS from 'hooks/useENS'
 import { SignatureData } from 'hooks/useERC20Permit'
-import { AnyTrade, useSwapCallArguments } from 'hooks/useSwapCallArguments'
+import { useSwapCallArguments } from 'hooks/useSwapCallArguments'
 import { ReactNode, useMemo } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 
 import useSendSwapTransaction from './useSendSwapTransaction'
 
@@ -24,7 +25,7 @@ interface UseSwapCallbackReturns {
   error?: ReactNode
 }
 interface UseSwapCallbackArgs {
-  trade: AnyTrade | undefined // trade to execute, required
+  trade: InterfaceTrade | undefined // trade to execute, required
   allowedSlippage: Percent // in bips
   recipientAddressOrName: string | null | undefined // the ENS name or address of the recipient of the trade, or null if swap should be returned to sender
   signatureData: SignatureData | null | undefined

--- a/src/hooks/useERC20Permit.ts
+++ b/src/hooks/useERC20Permit.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { splitSignature } from '@ethersproject/bytes'
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
+import { Currency, CurrencyAmount, Percent } from '@uniswap/sdk-core'
 import { Trade as V2Trade } from '@uniswap/v2-sdk'
 import { Trade as V3Trade } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
@@ -10,6 +9,7 @@ import { DAI, UNI, USDC_MAINNET } from 'constants/tokens'
 import { useSingleCallResult } from 'hooks/multicall'
 import JSBI from 'jsbi'
 import { useMemo, useState } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 
 import { useEIP2612Contract } from './useContract'
 import useIsArgentWallet from './useIsArgentWallet'
@@ -261,11 +261,7 @@ export function useERC20Permit(
 }
 
 export function useERC20PermitFromTrade(
-  trade:
-    | V2Trade<Currency, Currency, TradeType>
-    | V3Trade<Currency, Currency, TradeType>
-    | Trade<Currency, Currency, TradeType>
-    | undefined,
+  trade: InterfaceTrade | undefined,
   allowedSlippage: Percent,
   transactionDeadline: BigNumber | undefined
 ) {

--- a/src/hooks/usePriceImpact.ts
+++ b/src/hooks/usePriceImpact.ts
@@ -1,4 +1,4 @@
-import { Currency, CurrencyAmount, Percent, Token, TradeType } from '@uniswap/sdk-core'
+import { CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
@@ -11,7 +11,7 @@ export interface PriceImpact {
 }
 
 export function usePriceImpact(
-  trade: InterfaceTrade<Currency, Currency, TradeType> | undefined,
+  trade: InterfaceTrade | undefined,
   {
     inputUSDCValue,
     outputUSDCValue,

--- a/src/hooks/useSlippage.ts
+++ b/src/hooks/useSlippage.ts
@@ -1,8 +1,8 @@
-import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
+import { Trade } from '@uniswap/router-sdk'
+import { Currency, CurrencyAmount, Percent, Token, TradeType } from '@uniswap/sdk-core'
 import useAutoSlippageTolerance, { DEFAULT_AUTO_SLIPPAGE } from 'hooks/useAutoSlippageTolerance'
 import { useAtomValue } from 'jotai/utils'
 import { useMemo } from 'react'
-import { InterfaceTrade } from 'state/routing/types'
 import { slippageAtom } from 'state/swap/settings'
 
 export function toPercent(maxSlippage: string | undefined): Percent | undefined {
@@ -21,9 +21,12 @@ export interface Slippage {
 export const DEFAULT_SLIPPAGE = { auto: true, allowed: DEFAULT_AUTO_SLIPPAGE }
 
 /** Returns the allowed slippage, and whether it is auto-slippage. */
-export default function useSlippage(trade: InterfaceTrade<Currency, Currency, TradeType> | undefined): Slippage {
+export default function useSlippage(
+  trade: Trade<Currency, Currency, TradeType> | undefined,
+  gasUseEstimateUSD: CurrencyAmount<Token> | undefined
+): Slippage {
   const slippage = useAtomValue(slippageAtom)
-  const autoSlippage = useAutoSlippageTolerance(slippage.auto ? trade : undefined)
+  const autoSlippage = useAutoSlippageTolerance(slippage.auto ? trade : undefined, gasUseEstimateUSD)
   const maxSlippage = useMemo(() => toPercent(slippage.max), [slippage.max])
   return useMemo(() => {
     const auto = slippage.auto || !slippage.max

--- a/src/hooks/useSwapCallArguments.tsx
+++ b/src/hooks/useSwapCallArguments.tsx
@@ -1,11 +1,12 @@
 import { BigNumber } from '@ethersproject/bignumber'
-import { SwapRouter, Trade } from '@uniswap/router-sdk'
-import { Currency, Percent, TradeType } from '@uniswap/sdk-core'
+import { SwapRouter } from '@uniswap/router-sdk'
+import { Percent } from '@uniswap/sdk-core'
 import { Router as V2SwapRouter, Trade as V2Trade } from '@uniswap/v2-sdk'
 import { FeeOptions, SwapRouter as V3SwapRouter, Trade as V3Trade } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { SWAP_ROUTER_ADDRESSES, V3_ROUTER_ADDRESS } from 'constants/addresses'
 import { useMemo } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
 import approveAmountCalldata from 'utils/approveAmountCalldata'
 import { isExactInput } from 'utils/tradeType'
 
@@ -13,11 +14,6 @@ import { useArgentWalletContract } from './useArgentWalletContract'
 import { useV2RouterContract } from './useContract'
 import useENS from './useENS'
 import { SignatureData } from './useERC20Permit'
-
-export type AnyTrade =
-  | V2Trade<Currency, Currency, TradeType>
-  | V3Trade<Currency, Currency, TradeType>
-  | Trade<Currency, Currency, TradeType>
 
 interface SwapCall {
   address: string
@@ -33,7 +29,7 @@ interface SwapCall {
  * @param signatureData the signature data of the permit of the input token amount, if available
  */
 export function useSwapCallArguments(
-  trade: AnyTrade | undefined,
+  trade: InterfaceTrade | undefined,
   allowedSlippage: Percent,
   recipientAddressOrName: string | null | undefined,
   signatureData: SignatureData | null | undefined,

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -1,7 +1,4 @@
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
-import { Route as V2Route } from '@uniswap/v2-sdk'
-import { Route as V3Route } from '@uniswap/v3-sdk'
+import { Token } from '@uniswap/sdk-core'
 
 export enum TradeState {
   LOADING,
@@ -66,33 +63,4 @@ export interface GetQuoteResult {
   quoteGasAdjustedDecimals: string
   route: Array<V3PoolInRoute[] | V2PoolInRoute[]>
   routeString: string
-}
-
-export class InterfaceTrade<
-  TInput extends Currency,
-  TOutput extends Currency,
-  TTradeType extends TradeType
-> extends Trade<TInput, TOutput, TTradeType> {
-  gasUseEstimateUSD: CurrencyAmount<Token> | null | undefined
-
-  constructor({
-    gasUseEstimateUSD,
-    ...routes
-  }: {
-    gasUseEstimateUSD?: CurrencyAmount<Token> | undefined | null
-    v2Routes: {
-      routev2: V2Route<TInput, TOutput>
-      inputAmount: CurrencyAmount<TInput>
-      outputAmount: CurrencyAmount<TOutput>
-    }[]
-    v3Routes: {
-      routev3: V3Route<TInput, TOutput>
-      inputAmount: CurrencyAmount<TInput>
-      outputAmount: CurrencyAmount<TOutput>
-    }[]
-    tradeType: TTradeType
-  }) {
-    super(routes)
-    this.gasUseEstimateUSD = gasUseEstimateUSD
-  }
 }

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -1,4 +1,7 @@
-import { Token } from '@uniswap/sdk-core'
+import { Trade } from '@uniswap/router-sdk'
+import { Currency, Token, TradeType } from '@uniswap/sdk-core'
+import { Trade as V2Trade } from '@uniswap/v2-sdk'
+import { Trade as V3Trade } from '@uniswap/v3-sdk'
 
 export enum TradeState {
   LOADING,
@@ -64,3 +67,8 @@ export interface GetQuoteResult {
   route: Array<V3PoolInRoute[] | V2PoolInRoute[]>
   routeString: string
 }
+
+export type InterfaceTrade =
+  | Trade<Currency, Currency, TradeType>
+  | V2Trade<Currency, Currency, TradeType>
+  | V3Trade<Currency, Currency, TradeType>

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -1,9 +1,10 @@
+import { Trade } from '@uniswap/router-sdk'
 import { Currency, CurrencyAmount, Token, TradeType } from '@uniswap/sdk-core'
 import { Pair, Route as V2Route } from '@uniswap/v2-sdk'
 import { FeeAmount, Pool, Route as V3Route } from '@uniswap/v3-sdk'
 import { nativeOnChain } from 'constants/tokens'
 
-import { GetQuoteResult, InterfaceTrade, V2PoolInRoute, V3PoolInRoute } from './types'
+import { GetQuoteResult, V2PoolInRoute, V3PoolInRoute } from './types'
 
 /**
  * Transforms a Routing API quote into an array of routes that can be used to create
@@ -58,10 +59,9 @@ export function computeRoutes(
 
 export function transformRoutesToTrade<TTradeType extends TradeType>(
   route: ReturnType<typeof computeRoutes>,
-  tradeType: TTradeType,
-  gasUseEstimateUSD?: CurrencyAmount<Token> | null
-): InterfaceTrade<Currency, Currency, TTradeType> {
-  return new InterfaceTrade({
+  tradeType: TTradeType
+): Trade<Currency, Currency, TTradeType> {
+  return new Trade({
     v2Routes:
       route
         ?.filter((r): r is typeof route[0] & { routev2: NonNullable<typeof route[0]['routev2']> } => r.routev2 !== null)
@@ -71,7 +71,6 @@ export function transformRoutesToTrade<TTradeType extends TradeType>(
         ?.filter((r): r is typeof route[0] & { routev3: NonNullable<typeof route[0]['routev3']> } => r.routev3 !== null)
         .map(({ routev3, inputAmount, outputAmount }) => ({ routev3, inputAmount, outputAmount })) ?? [],
     tradeType,
-    gasUseEstimateUSD,
   })
 }
 

--- a/src/state/transactions.ts
+++ b/src/state/transactions.ts
@@ -1,7 +1,7 @@
 import { TransactionReceipt, TransactionResponse } from '@ethersproject/abstract-provider'
-import { Trade } from '@uniswap/router-sdk'
 import { Currency, CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
 import { atomWithImmer } from 'jotai/immer'
+import { InterfaceTrade } from 'state/routing/types'
 
 export enum TransactionType {
   APPROVAL,
@@ -24,7 +24,7 @@ export interface ApprovalTransactionInfo extends BaseTransactionInfo {
 export interface SwapTransactionInfo extends BaseTransactionInfo {
   type: TransactionType.SWAP
   tradeType: TradeType
-  trade: Trade<Currency, Currency, TradeType>
+  trade: InterfaceTrade
   slippageTolerance: Percent
 }
 

--- a/src/utils/prices.ts
+++ b/src/utils/prices.ts
@@ -1,7 +1,6 @@
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, CurrencyAmount, Fraction, Percent, TradeType } from '@uniswap/sdk-core'
-import { Pair } from '@uniswap/v2-sdk'
-import { FeeAmount } from '@uniswap/v3-sdk'
+import { Currency, CurrencyAmount, Fraction, Percent } from '@uniswap/sdk-core'
+import { Pair, Trade as V2Trade } from '@uniswap/v2-sdk'
+import { FeeAmount, Pool } from '@uniswap/v3-sdk'
 import {
   ALLOWED_PRICE_IMPACT_HIGH,
   ALLOWED_PRICE_IMPACT_LOW,
@@ -11,9 +10,10 @@ import {
   ZERO_PERCENT,
 } from 'constants/misc'
 import JSBI from 'jsbi'
+import { InterfaceTrade } from 'state/routing/types'
 
-const THIRTY_BIPS_FEE = new Percent(JSBI.BigInt(30), JSBI.BigInt(10000))
-const INPUT_FRACTION_AFTER_FEE = ONE_HUNDRED_PERCENT.subtract(THIRTY_BIPS_FEE)
+const V2_FEE_PERCENT = new Percent(FeeAmount.MEDIUM, JSBI.BigInt(1_000_000))
+const V2_INPUT_FRACTION_AFTER_FEE = ONE_HUNDRED_PERCENT.subtract(V2_FEE_PERCENT)
 
 export function largerPercentValue(a?: Percent, b?: Percent) {
   if (a && b) {
@@ -22,7 +22,7 @@ export function largerPercentValue(a?: Percent, b?: Percent) {
   return a || b
 }
 
-export function computeRealizedPriceImpact(trade: Trade<Currency, Currency, TradeType>): Percent {
+export function computeRealizedPriceImpact(trade: InterfaceTrade): Percent {
   const realizedLpFeePercent = computeRealizedLPFeePercent(trade)
   return trade.priceImpact.subtract(realizedLpFeePercent)
 }
@@ -34,16 +34,15 @@ export function getPriceImpactWarning(priceImpact?: Percent): 'warning' | 'error
 }
 
 // computes realized lp fee as a percent
-export function computeRealizedLPFeePercent(trade: Trade<Currency, Currency, TradeType>): Percent {
+export function computeRealizedLPFeePercent(trade: InterfaceTrade): Percent {
   let percent: Percent
 
-  // Since routes are either all v2 or all v3 right now, calculate separately
-  if (trade.swaps[0].route.pools instanceof Pair) {
+  if (trade instanceof V2Trade) {
     // for each hop in our trade, take away the x*y=k price impact from 0.3% fees
     // e.g. for 3 tokens/2 hops: 1 - ((1 - .03) * (1-.03))
     percent = ONE_HUNDRED_PERCENT.subtract(
-      trade.swaps.reduce<Percent>(
-        (currentFee: Percent): Percent => currentFee.multiply(INPUT_FRACTION_AFTER_FEE),
+      trade.route.pairs.reduce<Percent>(
+        (currentFee: Percent): Percent => currentFee.multiply(V2_INPUT_FRACTION_AFTER_FEE),
         ONE_HUNDRED_PERCENT
       )
     )
@@ -55,12 +54,8 @@ export function computeRealizedLPFeePercent(trade: Trade<Currency, Currency, Tra
 
       const routeRealizedLPFeePercent = overallPercent.multiply(
         ONE_HUNDRED_PERCENT.subtract(
-          swap.route.pools.reduce<Percent>((currentFee: Percent, pool): Percent => {
-            const fee =
-              pool instanceof Pair
-                ? // not currently possible given protocol check above, but not fatal
-                  FeeAmount.MEDIUM
-                : pool.fee
+          (swap.route.pools as (Pair | Pool)[]).reduce<Percent>((currentFee: Percent, pool: Pair | Pool): Percent => {
+            const fee = pool instanceof Pair ? FeeAmount.MEDIUM : pool.fee
             return currentFee.multiply(ONE_HUNDRED_PERCENT.subtract(new Fraction(fee, 1_000_000)))
           }, ONE_HUNDRED_PERCENT)
         )
@@ -74,9 +69,7 @@ export function computeRealizedLPFeePercent(trade: Trade<Currency, Currency, Tra
 }
 
 // computes price breakdown for the trade
-export function computeRealizedLPFeeAmount(
-  trade?: Trade<Currency, Currency, TradeType> | null
-): CurrencyAmount<Currency> | undefined {
+export function computeRealizedLPFeeAmount(trade?: InterfaceTrade): CurrencyAmount<Currency> | undefined {
   if (trade) {
     const realizedLPFee = computeRealizedLPFeePercent(trade)
 

--- a/src/utils/tradeMeaningFullyDiffer.ts
+++ b/src/utils/tradeMeaningFullyDiffer.ts
@@ -1,13 +1,10 @@
-import { Trade } from '@uniswap/router-sdk'
-import { Currency, TradeType } from '@uniswap/sdk-core'
+import { InterfaceTrade } from 'state/routing/types'
 
 /**
  * Returns true if the trade requires a confirmation of details before we can submit it
  * @param args either a pair of V2 trades or a pair of V3 trades
  */
-export function tradeMeaningfullyDiffers(
-  ...args: [Trade<Currency, Currency, TradeType>, Trade<Currency, Currency, TradeType>]
-): boolean {
+export function tradeMeaningfullyDiffers(...args: [InterfaceTrade, InterfaceTrade]): boolean {
   const [tradeA, tradeB] = args
   return (
     tradeA.tradeType !== tradeB.tradeType ||


### PR DESCRIPTION
Passes the optimized trade around state, instead of the routed trade. This is the trade (if any) for which a user has already approved the router.

This also sets up the code to propagate approvals from `useSwapInfo`, which will avoid querying approvals from different codepaths; and to use mixed routes in the routing diagram.