### PR TITLE
fix: improve responsiveness of useSwapInfo

### DIFF
--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -60,12 +60,12 @@ export function useRouterTrade(
   }, [fulfilledTimeStamp, isFetching, pollingInterval, queryArgs, trigger])
   useTimeout(request, 200)
 
-  const result = typeof data === 'object' ? data : undefined
+  const quote = typeof data === 'object' ? data : undefined
   const trade = useMemo(() => {
     const [currencyIn, currencyOut] = isExactInput(tradeType)
       ? [amountSpecified?.currency, otherCurrency]
       : [otherCurrency, amountSpecified?.currency]
-    const routes = computeRoutes(currencyIn, currencyOut, tradeType, result)
+    const routes = computeRoutes(currencyIn, currencyOut, tradeType, quote)
     if (!routes || routes.length === 0) return
     try {
       return transformRoutesToTrade(routes, tradeType)
@@ -73,10 +73,10 @@ export function useRouterTrade(
       console.debug('transformRoutesToTrade failed: ', e)
       return
     }
-  }, [amountSpecified?.currency, otherCurrency, result, tradeType])
-  const isValidBlock = useIsValidBlock(Number(result?.blockNumber))
+  }, [amountSpecified?.currency, otherCurrency, quote, tradeType])
+  const isValidBlock = useIsValidBlock(Number(quote?.blockNumber))
   const isLoading = currentData !== data || !isValidBlock
-  const gasUseEstimateUSD = useStablecoinAmountFromFiatValue(result?.gasUseEstimateUSD)
+  const gasUseEstimateUSD = useStablecoinAmountFromFiatValue(quote?.gasUseEstimateUSD)
 
   return useMemo(() => {
     if (queryArgs === skipToken) return TRADE_INVALID

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -72,7 +72,7 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
     type,
     hasAmounts ? parsedAmount : undefined,
     hasAmounts ? (isExactInput(type) ? currencyOut : currencyIn) : undefined,
-    RouterPreference.TRADE,
+    isWrap || error ? RouterPreference.SKIP : RouterPreference.TRADE,
     routerUrl
   )
 

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -5,9 +5,7 @@ import { useCurrencyBalances } from 'hooks/useCurrencyBalance'
 import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
 import { PriceImpact, usePriceImpact } from 'hooks/usePriceImpact'
 import useSlippage, { DEFAULT_SLIPPAGE, Slippage } from 'hooks/useSlippage'
-import useSwitchChain from 'hooks/useSwitchChain'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
-import useConnectors from 'hooks/web3/useConnectors'
 import { useAtomValue } from 'jotai/utils'
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
 import { InterfaceTrade, TradeState } from 'state/routing/types'
@@ -141,12 +139,7 @@ const SwapInfoContext = createContext(DEFAULT_SWAP_INFO)
 export function SwapInfoProvider({ children, routerUrl }: PropsWithChildren<{ routerUrl?: string }>) {
   const swap = useAtomValue(swapAtom)
   const swapInfo = useComputeSwapInfo(routerUrl)
-  const {
-    error,
-    trade,
-    [Field.INPUT]: { currency: currencyIn },
-    [Field.OUTPUT]: { currency: currencyOut },
-  } = swapInfo
+  const { trade } = swapInfo
 
   const { onInitialSwapQuote } = useAtomValue(swapEventHandlersAtom)
   useEffect(() => {
@@ -154,18 +147,6 @@ export function SwapInfoProvider({ children, routerUrl }: PropsWithChildren<{ ro
       onInitialSwapQuote?.(trade.trade)
     }
   }, [onInitialSwapQuote, swap, trade])
-
-  const { connector } = useWeb3React()
-  const switchChain = useSwitchChain()
-  const chainIn = currencyIn?.chainId
-  const chainOut = currencyOut?.chainId
-  const tokenChainId = chainIn || chainOut
-  const { network } = useConnectors()
-  // The network connector should be auto-switched, as it is a read-only interface that should "just work".
-  if (error === ChainError.MISMATCHED_CHAINS && tokenChainId && connector === network) {
-    delete swapInfo.error // avoids flashing an error whilst switching
-    switchChain(tokenChainId)
-  }
 
   return <SwapInfoContext.Provider value={swapInfo}>{children}</SwapInfoContext.Provider>
 }

--- a/src/hooks/usePriceImpact.ts
+++ b/src/hooks/usePriceImpact.ts
@@ -1,8 +1,10 @@
-import { CurrencyAmount, Percent, Token } from '@uniswap/sdk-core'
+import { Percent } from '@uniswap/sdk-core'
 import { useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import { computeFiatValuePriceImpact } from 'utils/computeFiatValuePriceImpact'
 import { computeRealizedPriceImpact, getPriceImpactWarning, largerPercentValue } from 'utils/prices'
+
+import { useUSDCValue } from './useUSDCPrice'
 
 export interface PriceImpact {
   percent: Percent
@@ -10,13 +12,8 @@ export interface PriceImpact {
   toString(): string
 }
 
-export function usePriceImpact(
-  trade: InterfaceTrade | undefined,
-  {
-    inputUSDCValue,
-    outputUSDCValue,
-  }: { inputUSDCValue: CurrencyAmount<Token> | undefined; outputUSDCValue: CurrencyAmount<Token> | undefined }
-) {
+export function usePriceImpact(trade?: InterfaceTrade) {
+  const [inputUSDCValue, outputUSDCValue] = [useUSDCValue(trade?.inputAmount), useUSDCValue(trade?.outputAmount)]
   return useMemo(() => {
     const fiatPriceImpact = computeFiatValuePriceImpact(inputUSDCValue, outputUSDCValue)
     const marketPriceImpact = trade ? computeRealizedPriceImpact(trade) : undefined

--- a/src/state/routing/args.ts
+++ b/src/state/routing/args.ts
@@ -35,19 +35,22 @@ export function serializeGetQuoteArgs({ endpointName, queryArgs }: { endpointNam
  * (this includes if the window is not visible).
  * NB: Input arguments do not need to be memoized, as they will be destructured.
  */
-export function useGetQuoteArgs({
-  provider,
-  tradeType,
-  amountSpecified,
-  otherCurrency,
-  routerUrl,
-}: Partial<{
-  provider: BaseProvider
-  tradeType: TradeType
-  amountSpecified: CurrencyAmount<Currency>
-  otherCurrency: Currency
-  routerUrl: string
-}>): GetQuoteArgs | SkipToken {
+export function useGetQuoteArgs(
+  {
+    provider,
+    tradeType,
+    amountSpecified,
+    otherCurrency,
+    routerUrl,
+  }: Partial<{
+    provider: BaseProvider
+    tradeType: TradeType
+    amountSpecified: CurrencyAmount<Currency>
+    otherCurrency: Currency
+    routerUrl: string
+  }>,
+  skip?: boolean
+): GetQuoteArgs | SkipToken {
   const args = useMemo(() => {
     if (!provider || !amountSpecified || tradeType === undefined) return null
 
@@ -73,5 +76,7 @@ export function useGetQuoteArgs({
   }, [provider, amountSpecified, tradeType, otherCurrency, routerUrl])
 
   const isWindowVisible = useIsWindowVisible()
-  return (isWindowVisible ? args : null) ?? skipToken
+  if (skip || !isWindowVisible) return skipToken
+
+  return args ?? skipToken
 }


### PR DESCRIPTION
- Adds a RouterPreference.SKIP, to avoid querying the router for wraps and mismatched chains
- Updates the variable names in useComputeSwapInfo to be more self-documenting
- Includes USDC values for wraps (for parity with interface)
- Improves responsiveness by fetching USDC values for parsed amounts, instead of waiting for a trade to load
- Omits invalid slippage/impact by only fetching them once a valid trade has loaded, instead of doing so on stale trades while syncing

---

NB: This is easiest reviewed commit-by-commit due to variable renaming which otherwise clutters the diff.