### PR TITLE
revert: "fix: add background color for swap Input"

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -31,10 +31,7 @@ export const Balance = styled(ThemedText.Body2)`
 `
 
 const InputColumn = styled(Column)<{ approved?: boolean }>`
-  background-color: ${({ theme }) => theme.module};
-  border-radius: ${({ theme }) => theme.borderRadius - 0.25}em;
-  margin-bottom: 0.25em;
-  padding: 0.75em;
+  margin: 0.75em;
   position: relative;
 
   ${TokenImg} {


### PR DESCRIPTION
Reverts Uniswap/widgets#236 due to a visual regression - it adds height to the initial screen without extending the widget or modals' heights