### PR TITLE
fix: allow empty token list

### DIFF
--- a/src/hooks/useTokenList/index.tsx
+++ b/src/hooks/useTokenList/index.tsx
@@ -11,7 +11,8 @@ import { validateTokens } from './validateTokenList'
 
 export { useQueryTokens } from './useQueryTokens'
 
-export const DEFAULT_TOKEN_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
+export const UNISWAP_TOKEN_LIST = 'https://gateway.ipfs.io/ipns/tokens.uniswap.org'
+export const EMPTY_TOKEN_LIST = []
 
 const MISSING_PROVIDER = Symbol()
 const ChainTokenMapContext = createContext<ChainTokenMap | undefined | typeof MISSING_PROVIDER>(MISSING_PROVIDER)
@@ -54,7 +55,7 @@ export function useTokenMap(): TokenMap {
 }
 
 export function TokenListProvider({
-  list = DEFAULT_TOKEN_LIST,
+  list = UNISWAP_TOKEN_LIST,
   children,
 }: PropsWithChildren<{ list?: string | TokenInfo[] }>) {
   // Error boundaries will not catch (non-rendering) async errors, but it should still be shown

--- a/src/hooks/useTokenList/index.tsx
+++ b/src/hooks/useTokenList/index.tsx
@@ -93,7 +93,9 @@ export function TokenListProvider({
         if (typeof list === 'string') {
           tokens = await fetchTokenList(list, resolver)
         } else {
-          tokens = await validateTokens(list)
+          // Empty lists will fail validation, but are valid (eg EMPTY_TOKEN_LIST)
+          // for integrators using their own token selection UI.
+          tokens = list.length > 0 ? await validateTokens(list) : EMPTY_TOKEN_LIST
         }
         // tokensToChainTokenMap also caches the fetched tokens, so it must be invoked even if stale.
         const map = tokensToChainTokenMap(tokens)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ export type { FeeOptions } from 'hooks/swap/useSyncConvenienceFee'
 export type { DefaultAddress, TokenDefaults } from 'hooks/swap/useSyncTokenDefaults'
 export type { OnTxFail, OnTxSubmit, OnTxSuccess, TransactionEventHandlers } from 'hooks/transactions'
 export type { OnConnectWalletClick, WidgetEventHandlers } from 'hooks/useSyncWidgetEventHandlers'
+export { EMPTY_TOKEN_LIST, UNISWAP_TOKEN_LIST } from 'hooks/useTokenList'
 export type { JsonRpcConnectionMap } from 'hooks/web3/useJsonRpcUrlsMap'
 export type {
   OnAmountChange,


### PR DESCRIPTION
Allow an empty token list to prevent any token list fetching.
Exports `UNISWAP_TOKEN_LIST` and `EMPTY_TOKEN_LIST`.