### PR TITLE
feat: move max ui

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -128,7 +128,7 @@ export default function Input({ disabled, focused }: InputProps) {
             {balance && (
               <Row gap={0.5}>
                 <Balance color={insufficientBalance ? 'error' : focused ? 'secondary' : 'hint'}>
-                  Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>
+                  <Trans>Balance:</Trans> <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>
                 </Balance>
                 {max && (
                   <TextButton onClick={onClickMax}>

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -108,7 +108,6 @@ export default function Input({ disabled, focused }: InputProps) {
         currency={inputCurrency}
         disabled={disabled}
         field={Field.INPUT}
-        max={max}
         onChangeInput={updateInputAmount}
         onChangeCurrency={updateInputCurrency}
         loading={isLoading}

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -1,5 +1,7 @@
+import { Trans } from '@lingui/macro'
 import { useLingui } from '@lingui/react'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
+import { TextButton } from 'components/Button'
 import { loadingTransitionCss } from 'css/loading'
 import {
   useIsSwapFieldIndependent,
@@ -9,11 +11,12 @@ import {
   useSwapInfo,
 } from 'hooks/swap'
 import { usePrefetchCurrencyColor } from 'hooks/useCurrencyColor'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { TradeState } from 'state/routing/types'
 import { Field } from 'state/swap'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
+import invariant from 'tiny-invariant'
 import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 import { maxAmountSpend } from 'utils/maxAmountSpend'
 
@@ -80,14 +83,13 @@ export default function Input({ disabled, focused }: InputProps) {
   const isDependentField = !useIsSwapFieldIndependent(Field.INPUT)
   const isLoading = isRouteLoading && isDependentField
 
+  const amount = useFormattedFieldAmount({
+    currencyAmount: tradeCurrencyAmount,
+    fieldAmount: inputAmount,
+  })
+
   //TODO(ianlapham): mimic logic from app swap page
   const mockApproved = true
-
-  // account for gas needed if using max on native token
-  const max = useMemo(() => {
-    const maxAmount = maxAmountSpend(balance)
-    return maxAmount?.greaterThan(0) ? maxAmount.toExact() : undefined
-  }, [balance])
 
   const insufficientBalance = useMemo(
     () =>
@@ -96,10 +98,18 @@ export default function Input({ disabled, focused }: InputProps) {
     [balance, inputCurrencyAmount, tradeCurrencyAmount]
   )
 
-  const amount = useFormattedFieldAmount({
-    currencyAmount: tradeCurrencyAmount,
-    fieldAmount: inputAmount,
-  })
+  const max = useMemo(() => {
+    // account for gas needed if using max on native token
+    const max = maxAmountSpend(balance)
+    if (!max || !balance) return
+    if (max.equalTo(0) || balance.lessThan(max)) return
+    if (inputCurrencyAmount && max.equalTo(inputCurrencyAmount)) return
+    return max.toExact()
+  }, [balance, inputCurrencyAmount])
+  const onClickMax = useCallback(() => {
+    invariant(max)
+    updateInputAmount(max)
+  }, [max, updateInputAmount])
 
   return (
     <InputColumn gap={0.5} approved={mockApproved}>
@@ -116,9 +126,18 @@ export default function Input({ disabled, focused }: InputProps) {
           <Row>
             <USDC isLoading={isRouteLoading}>{usdc ? `$${formatCurrencyAmount(usdc, 6, 'en', 2)}` : ''}</USDC>
             {balance && (
-              <Balance color={insufficientBalance ? 'error' : focused ? 'secondary' : 'hint'}>
-                Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>
-              </Balance>
+              <Row gap={0.5}>
+                <Balance color={insufficientBalance ? 'error' : focused ? 'secondary' : 'hint'}>
+                  Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>
+                </Balance>
+                {max && (
+                  <TextButton onClick={onClickMax}>
+                    <ThemedText.ButtonSmall>
+                      <Trans>Max</Trans>
+                    </ThemedText.ButtonSmall>
+                  </TextButton>
+                )}
+              </Row>
             )}
           </Row>
         </ThemedText.Body2>

--- a/src/components/Swap/TokenInput.tsx
+++ b/src/components/Swap/TokenInput.tsx
@@ -1,14 +1,12 @@
 import 'setimmediate'
 
-import { Trans } from '@lingui/macro'
 import { Currency } from '@uniswap/sdk-core'
 import { loadingTransitionCss } from 'css/loading'
-import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { PropsWithChildren, useCallback, useRef } from 'react'
 import { Field } from 'state/swap'
-import styled, { keyframes } from 'styled-components/macro'
+import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
-import Button from '../Button'
 import Column from '../Column'
 import { DecimalInput } from '../Input'
 import Row from '../Row'
@@ -34,24 +32,6 @@ const ValueInput = styled(DecimalInput)`
   ${loadingTransitionCss}
 `
 
-const delayedFadeIn = keyframes`
-  0% {
-    opacity: 0;
-  }
-  25% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-`
-
-const MaxButton = styled(Button)`
-  animation: ${delayedFadeIn} 0.25s linear;
-  border-radius: 0.75em;
-  padding: 0.5em;
-`
-
 interface TokenInputProps {
   amount: string
   currency?: Currency
@@ -68,7 +48,6 @@ export default function TokenInput({
   currency,
   disabled,
   field,
-  max,
   onChangeInput,
   onChangeCurrency,
   loading,
@@ -83,48 +62,19 @@ export default function TokenInput({
     [onChangeCurrency]
   )
 
-  const maxButton = useRef<HTMLButtonElement>(null)
-  const hasMax = useMemo(() => Boolean(max && max !== amount), [max, amount])
-  const [showMax, setShowMax] = useState<boolean>(hasMax)
-  useEffect(() => setShowMax((hasMax && input.current?.contains(document.activeElement)) ?? false), [hasMax])
-  const onBlur = useCallback((e) => {
-    // Filters out clicks on input or maxButton, because onBlur fires before onClickMax.
-    if (!input.current?.contains(e.relatedTarget) && !maxButton.current?.contains(e.relatedTarget)) {
-      setShowMax(false)
-    }
-  }, [])
-  const onClickMax = useCallback(() => {
-    onChangeInput(max || '')
-    setShowMax(false)
-    setImmediate(() => {
-      input.current?.focus()
-      // Brings the start of the input into view. NB: This only works for clicks, not eg keyboard interactions.
-      input.current?.setSelectionRange(0, null)
-    })
-  }, [max, onChangeInput])
-
   return (
     <Column gap={0.25}>
-      <TokenInputRow gap={0.5} onBlur={onBlur}>
+      <TokenInputRow gap={0.5}>
         <ThemedText.H2>
           <ValueInput
             value={amount}
-            onFocus={() => setShowMax(hasMax)}
             onChange={onChangeInput}
             disabled={disabled || !currency}
             isLoading={Boolean(loading)}
             ref={input}
           ></ValueInput>
         </ThemedText.H2>
-        {showMax && (
-          <MaxButton onClick={onClickMax} ref={maxButton}>
-            {/* Without a tab index, Safari would not populate the FocusEvent.relatedTarget needed by onBlur. */}
-            <ThemedText.ButtonMedium tabIndex={-1}>
-              <Trans>Max</Trans>
-            </ThemedText.ButtonMedium>
-          </MaxButton>
-        )}
-        <TokenSelect value={currency} collapsed={showMax} disabled={disabled} onSelect={onSelect} field={field} />
+        <TokenSelect value={currency} disabled={disabled} onSelect={onSelect} field={field} />
       </TokenInputRow>
       {children}
     </Column>

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -22,15 +22,13 @@ const StyledTokenButton = styled(Button)`
   }
 `
 
-const TokenButtonRow = styled(Row)<{ empty: boolean; collapsed: boolean }>`
+const TokenButtonRow = styled(Row)<{ empty: boolean }>`
   float: right;
   height: 1.2em;
-  // max-width must have an absolute value in order to transition.
-  max-width: ${({ collapsed }) => (collapsed ? '1.2em' : '12em')};
+  max-width: 12em;
+  overflow: hidden;
   padding-left: ${({ empty }) => empty && 0.5}em;
   width: fit-content;
-  overflow: hidden;
-  transition: max-width 0.25s linear;
 
   img {
     min-width: 1.2em;
@@ -39,12 +37,11 @@ const TokenButtonRow = styled(Row)<{ empty: boolean; collapsed: boolean }>`
 
 interface TokenButtonProps {
   value?: Currency
-  collapsed: boolean
   disabled?: boolean
   onClick: () => void
 }
 
-export default function TokenButton({ value, collapsed, disabled, onClick }: TokenButtonProps) {
+export default function TokenButton({ value, disabled, onClick }: TokenButtonProps) {
   const buttonBackgroundColor = value ? 'interactive' : 'accent'
   const contentColor = buttonBackgroundColor === 'accent' ? 'onAccent' : 'currentColor'
 
@@ -78,7 +75,6 @@ export default function TokenButton({ value, collapsed, disabled, onClick }: Tok
         <TokenButtonRow
           gap={0.4}
           empty={!value}
-          collapsed={collapsed}
           // ref is used to set an absolute width, so it must be reset for each value passed.
           // To force this, value?.symbol is passed as a key.
           ref={setRow}

--- a/src/components/TokenSelect/index.test.tsx
+++ b/src/components/TokenSelect/index.test.tsx
@@ -16,7 +16,7 @@ describe('TokenSelect.tsx', () => {
       const onTokenSelectorClick = jest.fn()
 
       const component = renderWidget(
-        <TokenSelect field={Field.INPUT} value={undefined} collapsed disabled={false} onSelect={jest.fn()} />,
+        <TokenSelect field={Field.INPUT} value={undefined} disabled={false} onSelect={jest.fn()} />,
         {
           initialAtomValues: [[swapEventHandlersAtom, { onTokenSelectorClick }]],
         }
@@ -31,7 +31,7 @@ describe('TokenSelect.tsx', () => {
       const onTokenSelectorClick = jest.fn().mockResolvedValueOnce(true)
 
       const component = renderWidget(
-        <TokenSelect field={Field.INPUT} value={undefined} collapsed={false} disabled={false} onSelect={jest.fn()} />,
+        <TokenSelect field={Field.INPUT} value={undefined} disabled={false} onSelect={jest.fn()} />,
         {
           initialAtomValues: [[swapEventHandlersAtom, { onTokenSelectorClick }]],
         }
@@ -46,7 +46,7 @@ describe('TokenSelect.tsx', () => {
       const onTokenSelectorClick = jest.fn().mockResolvedValueOnce(false)
 
       const component = renderWidget(
-        <TokenSelect field={Field.INPUT} value={undefined} collapsed={false} disabled={false} onSelect={jest.fn()} />,
+        <TokenSelect field={Field.INPUT} value={undefined} disabled={false} onSelect={jest.fn()} />,
         {
           initialAtomValues: [[swapEventHandlersAtom, { onTokenSelectorClick }]],
         }
@@ -61,7 +61,7 @@ describe('TokenSelect.tsx', () => {
       const onTokenSelectorClick = jest.fn().mockRejectedValueOnce(false)
 
       const component = renderWidget(
-        <TokenSelect field={Field.INPUT} value={undefined} collapsed={false} disabled={false} onSelect={jest.fn()} />,
+        <TokenSelect field={Field.INPUT} value={undefined} disabled={false} onSelect={jest.fn()} />,
         {
           initialAtomValues: [[swapEventHandlersAtom, { onTokenSelectorClick }]],
         }

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -121,14 +121,13 @@ export function TokenSelectDialog({ value, onSelect, onClose }: TokenSelectDialo
 }
 
 interface TokenSelectProps {
-  collapsed: boolean
   disabled?: boolean
   field: Field
   onSelect: (value: Currency) => void
   value?: Currency
 }
 
-export default memo(function TokenSelect({ collapsed, disabled, field, onSelect, value }: TokenSelectProps) {
+export default memo(function TokenSelect({ disabled, field, onSelect, value }: TokenSelectProps) {
   usePrefetchBalances()
 
   const [open, setOpen] = useState(false)
@@ -145,7 +144,7 @@ export default memo(function TokenSelect({ collapsed, disabled, field, onSelect,
   )
   return (
     <>
-      <TokenButton value={value} collapsed={collapsed} disabled={disabled} onClick={onOpen} />
+      <TokenButton value={value} disabled={disabled} onClick={onOpen} />
       {open && <TokenSelectDialog value={value} onSelect={selectAndClose} onClose={() => setOpen(false)} />}
     </>
   )


### PR DESCRIPTION
Moves max UI from the token button to the balance row.
Updating UX (ie setting focus after updating amount) will be done in a follow-up PR.

WEB-790