### PR TITLE
fix: [Widget] change the "reload" button

### DIFF
--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -74,7 +74,9 @@ export default function ErrorDialog({ header, error, action, onClick }: ErrorDia
             {error.message ? `: ${error.message}` : ''}
           </ThemedText.Code>
         </Expando>
-        <ActionButton onClick={onClick}>{action}</ActionButton>
+        <ActionButton color={'interactive'} onClick={onClick}>
+          {action}
+        </ActionButton>
       </Column>
     </Column>
   )

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -74,7 +74,7 @@ export default function ErrorDialog({ header, error, action, onClick }: ErrorDia
             {error.message ? `: ${error.message}` : ''}
           </ThemedText.Code>
         </Expando>
-        <ActionButton color={'interactive'} onClick={onClick}>
+        <ActionButton color="interactive" onClick={onClick}>
           {action}
         </ActionButton>
       </Column>

--- a/src/components/Expando.tsx
+++ b/src/components/Expando.tsx
@@ -3,7 +3,7 @@ import Column, { ColumnProps } from 'components/Column'
 import Row from 'components/Row'
 import Rule from 'components/Rule'
 import useScrollbar from 'hooks/useScrollbar'
-import { Expando as ExpandoIcon } from 'icons'
+import { Expando as ExpandoIcon, Info as InfoIcon } from 'icons'
 import { PropsWithChildren, ReactNode, useState } from 'react'
 import styled from 'styled-components/macro'
 
@@ -13,7 +13,17 @@ const HeaderColumn = styled(Column)`
 `
 
 const TitleRow = styled(Row)`
+  color: ${({ theme }) => theme.secondary};
   cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+`
+
+const TitleHeader = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: center;
 `
 
 const ExpandoColumn = styled(Column)<{ height: number; open: boolean }>`
@@ -55,7 +65,10 @@ export default function Expando({ title, open, onExpand, height, children, ...re
       <HeaderColumn gap={open ? 0.5 : 0.75} onClick={onExpand}>
         <Rule />
         <TitleRow>
-          {title}
+          <TitleHeader>
+            <InfoIcon style={{ marginRight: '5px' }} color="secondary" />
+            {title}
+          </TitleHeader>
           <IconButton color="secondary" icon={ExpandoIcon} iconProps={{ open }} />
         </TitleRow>
         {open && <Rule />}


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-1301?atlOrigin=eyJpIjoiOGFmOWQ0MTdlZjdjNGMxNDliNGQwMjg5N2EyOGFkNjkiLCJwIjoiaiJ9

<img width="346" alt="Screen Shot 2022-10-07 at 11 37 34 AM" src="https://user-images.githubusercontent.com/41491154/194593180-c30856e7-7416-4b36-8a2f-3d43e25ab69b.png">

the colors look off because our theme file is off from figma. i'll update all the colors in a separate pr. 

