### PR TITLE
fix: consistently color balance

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -45,7 +45,6 @@ const InputColumn = styled(Column)<{ approved?: boolean }>`
 
 export interface InputProps {
   disabled: boolean
-  focused: boolean
 }
 
 interface UseFormattedFieldAmountArguments {
@@ -65,7 +64,7 @@ export function useFormattedFieldAmount({ currencyAmount, fieldAmount }: UseForm
   }, [currencyAmount, fieldAmount])
 }
 
-export default function Input({ disabled, focused }: InputProps) {
+export default function Input({ disabled }: InputProps) {
   const { i18n } = useLingui()
   const {
     [Field.INPUT]: { balance, amount: tradeCurrencyAmount, usdc },
@@ -130,7 +129,7 @@ export default function Input({ disabled, focused }: InputProps) {
             <USDC isLoading={isRouteLoading}>{usdc ? `$${formatCurrencyAmount(usdc, 6, 'en', 2)}` : ''}</USDC>
             {balance && (
               <Row gap={0.5}>
-                <Balance color={insufficientBalance ? 'error' : focused ? 'secondary' : 'hint'}>
+                <Balance color={insufficientBalance ? 'error' : 'secondary'}>
                   <Trans>Balance:</Trans> <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>
                 </Balance>
                 {max && (

--- a/src/components/Swap/Output.tsx
+++ b/src/components/Swap/Output.tsx
@@ -41,7 +41,7 @@ const Footer = styled(Row)`
   height: 1em;
 `
 
-export default function Output({ disabled, focused, children }: PropsWithChildren<InputProps>) {
+export default function Output({ disabled, children }: PropsWithChildren<InputProps>) {
   const { i18n } = useLingui()
 
   const disableBranding = useBrandingSetting()
@@ -95,7 +95,7 @@ export default function Output({ disabled, focused, children }: PropsWithChildre
                 {impact && <ThemedText.Body2 color={impact.warning}>({impact.toString()})</ThemedText.Body2>}
               </USDC>
               {balance && (
-                <Balance color={focused ? 'secondary' : 'hint'}>
+                <Balance color="secondary">
                   Balance: <span>{formatCurrencyAmount(balance, 4, i18n.locale)}</span>
                 </Balance>
               )}

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -60,8 +60,6 @@ export default function Swap(props: SwapProps) {
   const onSupportedNetwork = useOnSupportedNetwork()
   const isDisabled = !(isActive && onSupportedNetwork)
 
-  const focused = useHasFocus(wrapper)
-
   return (
     <>
       <Header title={<Trans>Swap</Trans>}>
@@ -71,9 +69,9 @@ export default function Swap(props: SwapProps) {
       <div ref={setWrapper}>
         <BoundaryProvider value={wrapper}>
           <SwapInfoProvider routerUrl={props.routerUrl}>
-            <Input disabled={isDisabled} focused={focused} />
+            <Input disabled={isDisabled} />
             <ReverseButton disabled={isDisabled} />
-            <Output disabled={isDisabled} focused={focused}>
+            <Output disabled={isDisabled}>
               <Toolbar />
               <SwapActionButton disabled={isDisabled} />
             </Output>

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -9,7 +9,6 @@ import useSyncConvenienceFee, { FeeOptions } from 'hooks/swap/useSyncConvenience
 import useSyncSwapEventHandlers, { SwapEventHandlers } from 'hooks/swap/useSyncSwapEventHandlers'
 import useSyncTokenDefaults, { TokenDefaults } from 'hooks/swap/useSyncTokenDefaults'
 import { usePendingTransactions } from 'hooks/transactions'
-import useHasFocus from 'hooks/useHasFocus'
 import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
 import useSyncBrandingSetting, { BrandingSettings } from 'hooks/useSyncBrandingSetting'
 import useSyncWidgetEventHandlers, { WidgetEventHandlers } from 'hooks/useSyncWidgetEventHandlers'


### PR DESCRIPTION
This is a simplification from a previous ticket.
Consistently color balances, instead of making them darker when the widget is in focus.