### PR TITLE
feat: chain errors

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -43,10 +43,6 @@ const InputColumn = styled(Column)<{ approved?: boolean }>`
   }
 `
 
-export interface InputProps {
-  disabled: boolean
-}
-
 interface UseFormattedFieldAmountArguments {
   currencyAmount?: CurrencyAmount<Currency>
   fieldAmount?: string
@@ -64,10 +60,11 @@ export function useFormattedFieldAmount({ currencyAmount, fieldAmount }: UseForm
   }, [currencyAmount, fieldAmount])
 }
 
-export default function Input({ disabled }: InputProps) {
+export default function Input() {
   const { i18n } = useLingui()
   const {
     [Field.INPUT]: { balance, amount: tradeCurrencyAmount, usdc },
+    error,
     trade: { state: tradeState },
   } = useSwapInfo()
 
@@ -79,7 +76,8 @@ export default function Input({ disabled }: InputProps) {
   // extract eagerly in case of reversal
   usePrefetchCurrencyColor(inputCurrency)
 
-  const isRouteLoading = disabled || tradeState === TradeState.LOADING
+  const isDisabled = error !== undefined
+  const isRouteLoading = isDisabled || tradeState === TradeState.LOADING
   const isDependentField = !useIsSwapFieldIndependent(Field.INPUT)
   const isLoading = isRouteLoading && isDependentField
 
@@ -118,7 +116,7 @@ export default function Input({ disabled }: InputProps) {
         ref={setInput}
         amount={amount}
         currency={inputCurrency}
-        disabled={disabled}
+        disabled={isDisabled}
         field={Field.INPUT}
         onChangeInput={updateInputAmount}
         onChangeCurrency={updateInputCurrency}

--- a/src/components/Swap/Output.tsx
+++ b/src/components/Swap/Output.tsx
@@ -7,7 +7,7 @@ import useCurrencyColor from 'hooks/useCurrencyColor'
 import { useBrandingSetting } from 'hooks/useSyncBrandingSetting'
 import { atom } from 'jotai'
 import { useAtomValue } from 'jotai/utils'
-import { PropsWithChildren } from 'react'
+import { ReactNode } from 'react'
 import { TradeState } from 'state/routing/types'
 import { Field } from 'state/swap'
 import styled from 'styled-components/macro'
@@ -16,7 +16,7 @@ import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import Column from '../Column'
 import Row from '../Row'
-import { Balance, InputProps, USDC, useFormattedFieldAmount } from './Input'
+import { Balance, USDC, useFormattedFieldAmount } from './Input'
 import TokenInput from './TokenInput'
 
 export const colorAtom = atom<string | undefined>(undefined)
@@ -41,13 +41,14 @@ const Footer = styled(Row)`
   height: 1em;
 `
 
-export default function Output({ disabled, children }: PropsWithChildren<InputProps>) {
+export default function Output({ children }: { children?: ReactNode }) {
   const { i18n } = useLingui()
 
   const disableBranding = useBrandingSetting()
 
   const {
     [Field.OUTPUT]: { balance, amount: outputCurrencyAmount, usdc: outputUSDC },
+    error,
     trade: { state: tradeState },
     impact,
   } = useSwapInfo()
@@ -55,7 +56,8 @@ export default function Output({ disabled, children }: PropsWithChildren<InputPr
   const [swapOutputAmount, updateSwapOutputAmount] = useSwapAmount(Field.OUTPUT)
   const [swapOutputCurrency, updateSwapOutputCurrency] = useSwapCurrency(Field.OUTPUT)
 
-  const isRouteLoading = disabled || tradeState === TradeState.LOADING
+  const isDisabled = error !== undefined
+  const isRouteLoading = isDisabled || tradeState === TradeState.LOADING
   const isDependentField = !useIsSwapFieldIndependent(Field.OUTPUT)
   const isLoading = isRouteLoading && isDependentField
 
@@ -82,7 +84,7 @@ export default function Output({ disabled, children }: PropsWithChildren<InputPr
         <TokenInput
           amount={amount}
           currency={swapOutputCurrency}
-          disabled={disabled}
+          disabled={isDisabled}
           field={Field.OUTPUT}
           onChangeInput={updateSwapOutputAmount}
           onChangeCurrency={updateSwapOutputCurrency}

--- a/src/components/Swap/ReverseButton.tsx
+++ b/src/components/Swap/ReverseButton.tsx
@@ -1,4 +1,4 @@
-import { useSwitchSwapCurrencies } from 'hooks/swap'
+import { useSwapInfo, useSwitchSwapCurrencies } from 'hooks/swap'
 import { ArrowDown as ArrowDownIcon, ArrowUp as ArrowUpIcon } from 'icons'
 import { useCallback, useState } from 'react'
 import styled from 'styled-components/macro'
@@ -46,9 +46,12 @@ const StyledReverseButton = styled(Button)<{ turns: number }>`
   }
 `
 
-export default function ReverseButton({ disabled }: { disabled?: boolean }) {
-  const [turns, setTurns] = useState(0)
+export default function ReverseButton() {
+  const { error } = useSwapInfo()
+  const isDisabled = error !== undefined
+
   const switchCurrencies = useSwitchSwapCurrencies()
+  const [turns, setTurns] = useState(0)
   const onClick = useCallback(() => {
     switchCurrencies()
     setTurns((turns) => ++turns)
@@ -57,7 +60,7 @@ export default function ReverseButton({ disabled }: { disabled?: boolean }) {
   return (
     <ReverseRow justify="center">
       <Overlay>
-        <StyledReverseButton disabled={disabled} onClick={onClick} turns={turns}>
+        <StyledReverseButton disabled={isDisabled} onClick={onClick} turns={turns}>
           <div>
             <ArrowUp strokeWidth={3} />
             <ArrowDown strokeWidth={3} />

--- a/src/components/Swap/Skeleton.tsx
+++ b/src/components/Swap/Skeleton.tsx
@@ -76,7 +76,7 @@ export function SwapWidgetSkeleton({ theme, width }: SwapWidgetSkeletonProps) {
               <FloatingDetails />
             </InputColumn>
             <div>
-              <ReverseButton disabled={true} />
+              <ReverseButton />
               <OutputColumn>
                 <FloatingDetails isModule />
                 <FloatingButton />

--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -1,9 +1,9 @@
 import { Trans } from '@lingui/macro'
-import { useWeb3React } from '@web3-react/core'
-import { useSwapInfo } from 'hooks/swap'
+import { SupportedChainId } from 'constants/chains'
+import { ChainError, useSwapInfo } from 'hooks/swap'
 import { ApproveOrPermitState, useApproveOrPermit } from 'hooks/swap/useSwapApproval'
 import { useIsWrap } from 'hooks/swap/useWrapCallback'
-import { memo, useMemo } from 'react'
+import { useMemo } from 'react'
 import { Field } from 'state/swap'
 import { useTheme } from 'styled-components/macro'
 
@@ -14,20 +14,14 @@ import SwitchChainButton from './SwitchChainButton'
 import useOnSubmit from './useOnSubmit'
 import WrapButton from './WrapButton'
 
-interface SwapButtonProps {
-  disabled?: boolean
-}
-
-export default memo(function SwapActionButton({ disabled }: SwapButtonProps) {
-  const { chainId } = useWeb3React()
+export default function SwapActionButton() {
   const {
     [Field.INPUT]: { currency: inputCurrency, amount: inputCurrencyAmount, balance: inputCurrencyBalance },
     [Field.OUTPUT]: { currency: outputCurrency },
+    error,
     trade: { trade },
     slippage,
   } = useSwapInfo()
-
-  const tokenChainId = inputCurrency?.chainId ?? outputCurrency?.chainId
 
   const approval = useApproveOrPermit(trade, slippage.allowed, useIsPendingApproval, inputCurrencyAmount)
   const onSubmit = useOnSubmit()
@@ -35,18 +29,18 @@ export default memo(function SwapActionButton({ disabled }: SwapButtonProps) {
   const isWrap = useIsWrap()
   const isDisabled = useMemo(
     () =>
-      disabled ||
-      !chainId ||
+      error !== undefined ||
       (!isWrap && !trade) ||
       !(inputCurrencyAmount && inputCurrencyBalance) ||
       inputCurrencyBalance.lessThan(inputCurrencyAmount),
-    [disabled, chainId, isWrap, trade, inputCurrencyAmount, inputCurrencyBalance]
+    [error, isWrap, trade, inputCurrencyAmount, inputCurrencyBalance]
   )
 
   const { tokenColorExtraction } = useTheme()
   const color = tokenColorExtraction ? 'interactive' : 'accent'
 
-  if (chainId && tokenChainId && chainId !== tokenChainId) {
+  if (error === ChainError.MISMATCHED_CHAINS) {
+    const tokenChainId = inputCurrency?.chainId ?? outputCurrency?.chainId ?? SupportedChainId.MAINNET
     return <SwitchChainButton color={color} chainId={tokenChainId} />
   } else if (isDisabled) {
     return (
@@ -61,4 +55,4 @@ export default memo(function SwapActionButton({ disabled }: SwapButtonProps) {
   } else {
     return <SwapButton color={color} onSubmit={onSubmit} signatureData={approval.signatureData} />
   }
-})
+}

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -1,6 +1,5 @@
 import { useWeb3React } from '@web3-react/core'
-import { ALL_SUPPORTED_CHAIN_IDS } from 'constants/chains'
-import { useIsAmountPopulated, useSwapInfo } from 'hooks/swap'
+import { ChainError, useIsAmountPopulated, useSwapInfo } from 'hooks/swap'
 import { useIsWrap } from 'hooks/swap/useWrapCallback'
 import { largeIconCss } from 'icons'
 import { memo, useMemo } from 'react'
@@ -18,32 +17,37 @@ const ToolbarRow = styled(Row)`
 `
 
 export default memo(function Toolbar() {
-  const { account, isActivating, chainId } = useWeb3React()
+  const { account } = useWeb3React()
   const {
     [Field.INPUT]: { currency: inputCurrency, balance: inputBalance, amount: inputAmount },
     [Field.OUTPUT]: { currency: outputCurrency, usdc: outputUSDC },
+    error,
     trade: { trade, state },
     impact,
   } = useSwapInfo()
-  const tokenChainId = inputCurrency?.chainId ?? outputCurrency?.chainId
   const isAmountPopulated = useIsAmountPopulated()
   const isWrap = useIsWrap()
   const caption = useMemo(() => {
+    switch (error) {
+      case ChainError.UNCONNECTED_CHAIN:
+        return <Caption.ConnectWallet />
+      case ChainError.ACTIVATING_CHAIN:
+        return <Caption.ConnectWallet />
+      case ChainError.UNSUPPORTED_CHAIN:
+        return <Caption.UnsupportedNetwork />
+      case ChainError.MISMATCHED_TOKEN_CHAINS:
+        return <Caption.Error />
+      case ChainError.MISMATCHED_CHAINS:
+        return <Caption.Empty />
+      default:
+    }
+
     if (state === TradeState.LOADING) {
       return <Caption.LoadingTrade />
     }
 
-    if (chainId && tokenChainId && chainId !== tokenChainId) {
-      return <Caption.Empty />
-    }
-
-    if (!account || !chainId) {
-      if (isActivating) return <Caption.Connecting />
+    if (!account) {
       return <Caption.ConnectWallet />
-    }
-
-    if (!ALL_SUPPORTED_CHAIN_IDS.includes(chainId)) {
-      return <Caption.UnsupportedNetwork />
     }
 
     if (inputCurrency && outputCurrency && isAmountPopulated) {
@@ -66,14 +70,12 @@ export default memo(function Toolbar() {
 
     return <Caption.Empty />
   }, [
+    error,
     state,
-    chainId,
-    tokenChainId,
     account,
     inputCurrency,
     outputCurrency,
     isAmountPopulated,
-    isActivating,
     inputBalance,
     inputAmount,
     isWrap,

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -38,7 +38,7 @@ export default memo(function Toolbar() {
       case ChainError.MISMATCHED_TOKEN_CHAINS:
         return <Caption.Error />
       case ChainError.MISMATCHED_CHAINS:
-        return <Caption.Empty />
+        return
       default:
     }
 

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -1,6 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Trans } from '@lingui/macro'
-import { useWeb3React } from '@web3-react/core'
 import { Provider as Eip1193Provider } from '@web3-react/types'
 import Wallet from 'components/ConnectWallet'
 import { SwapInfoProvider } from 'hooks/swap/useSwapInfo'
@@ -9,7 +8,6 @@ import useSyncConvenienceFee, { FeeOptions } from 'hooks/swap/useSyncConvenience
 import useSyncSwapEventHandlers, { SwapEventHandlers } from 'hooks/swap/useSyncSwapEventHandlers'
 import useSyncTokenDefaults, { TokenDefaults } from 'hooks/swap/useSyncTokenDefaults'
 import { usePendingTransactions } from 'hooks/transactions'
-import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
 import useSyncBrandingSetting, { BrandingSettings } from 'hooks/useSyncBrandingSetting'
 import useSyncWidgetEventHandlers, { WidgetEventHandlers } from 'hooks/useSyncWidgetEventHandlers'
 import { useAtom } from 'jotai'
@@ -49,30 +47,26 @@ export default function Swap(props: SwapProps) {
   useSyncWidgetEventHandlers(props as WidgetEventHandlers)
   useSyncBrandingSetting(props as BrandingSettings)
 
-  const { isActive } = useWeb3React()
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
 
   const [displayTxHash, setDisplayTxHash] = useAtom(displayTxHashAtom)
   const pendingTxs = usePendingTransactions()
   const displayTx = useMemo(() => displayTxHash && pendingTxs[displayTxHash], [displayTxHash, pendingTxs])
 
-  const onSupportedNetwork = useOnSupportedNetwork()
-  const isDisabled = !(isActive && onSupportedNetwork)
-
   return (
     <>
       <Header title={<Trans>Swap</Trans>}>
         <Wallet disabled={props.hideConnectionUI} />
-        <Settings disabled={isDisabled} />
+        <Settings />
       </Header>
       <div ref={setWrapper}>
         <BoundaryProvider value={wrapper}>
           <SwapInfoProvider routerUrl={props.routerUrl}>
-            <Input disabled={isDisabled} />
-            <ReverseButton disabled={isDisabled} />
-            <Output disabled={isDisabled}>
+            <Input />
+            <ReverseButton />
+            <Output>
               <Toolbar />
-              <SwapActionButton disabled={isDisabled} />
+              <SwapActionButton />
             </Output>
           </SwapInfoProvider>
         </BoundaryProvider>

--- a/src/hooks/swap/index.ts
+++ b/src/hooks/swap/index.ts
@@ -6,7 +6,7 @@ import { pickAtom } from 'state/atoms'
 import { Field, swapAtom, swapEventHandlersAtom } from 'state/swap'
 import { invertTradeType, toTradeType } from 'utils/tradeType'
 import tryParseCurrencyAmount from 'utils/tryParseCurrencyAmount'
-export { default as useSwapInfo } from './useSwapInfo'
+export { ChainError, default as useSwapInfo } from './useSwapInfo'
 
 function otherField(field: Field) {
   switch (field) {

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -59,7 +59,7 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
     if (chainIn && chainOut && chainIn !== chainOut) return ChainError.MISMATCHED_TOKEN_CHAINS
 
     const tokenChainId = chainIn || chainOut
-    if (chainId && chainId !== tokenChainId) return ChainError.MISMATCHED_CHAINS
+    if (chainId && tokenChainId && chainId !== tokenChainId) return ChainError.MISMATCHED_CHAINS
 
     return
   }, [chainId, currencyIn?.chainId, currencyOut?.chainId, isActivating, isActive, isSupported])

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -2,6 +2,7 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { RouterPreference, useRouterTrade } from 'hooks/routing/useRouterTrade'
 import { useCurrencyBalances } from 'hooks/useCurrencyBalance'
+import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
 import { PriceImpact, usePriceImpact } from 'hooks/usePriceImpact'
 import useSlippage, { DEFAULT_SLIPPAGE, Slippage } from 'hooks/useSlippage'
 import { useUSDCValue } from 'hooks/useUSDCPrice'
@@ -14,6 +15,13 @@ import tryParseCurrencyAmount from 'utils/tryParseCurrencyAmount'
 
 import { useIsWrap } from './useWrapCallback'
 
+enum ChainError {
+  UNCONNECTED_CHAIN = 1, // 1-indexed so that ChainError can be used as a boolean
+  UNSUPPORTED_CHAIN,
+  MISMATCHED_TOKEN_CHAINS,
+  MISMATCHED_CHAINS,
+}
+
 interface SwapField {
   currency?: Currency
   amount?: CurrencyAmount<Currency>
@@ -24,6 +32,7 @@ interface SwapField {
 interface SwapInfo {
   [Field.INPUT]: SwapField
   [Field.OUTPUT]: SwapField
+  error?: ChainError
   trade: {
     state: TradeState
     trade?: InterfaceTrade
@@ -35,8 +44,24 @@ interface SwapInfo {
 
 // from the current swap inputs, compute the best trade and return it.
 function useComputeSwapInfo(routerUrl?: string): SwapInfo {
-  const isWrap = useIsWrap()
+  const { account, chainId, isActive } = useWeb3React()
+  const isSupported = useOnSupportedNetwork()
   const { type, amount, [Field.INPUT]: currencyIn, [Field.OUTPUT]: currencyOut } = useAtomValue(swapAtom)
+  const isWrap = useIsWrap()
+
+  const error = useMemo(() => {
+    if (!isActive) return ChainError.UNCONNECTED_CHAIN
+    if (!isSupported) return ChainError.UNSUPPORTED_CHAIN
+
+    const chainIn = currencyIn?.chainId
+    const chainOut = currencyOut?.chainId
+    if (chainIn && chainOut && chainIn !== chainOut) return ChainError.MISMATCHED_TOKEN_CHAINS
+
+    const tokenChainId = chainIn || chainOut
+    if (chainId && chainId !== tokenChainId) return ChainError.MISMATCHED_CHAINS
+
+    return
+  }, [chainId, currencyIn?.chainId, currencyOut?.chainId, isActive, isSupported])
 
   const parsedAmount = useMemo(
     () => tryParseCurrencyAmount(amount, (isExactInput(type) ? currencyIn : currencyOut) ?? undefined),
@@ -60,7 +85,6 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
     [isWrap, parsedAmount, trade.trade?.outputAmount, type]
   )
 
-  const { account } = useWeb3React()
   const [balanceIn, balanceOut] = useCurrencyBalances(
     account,
     useMemo(() => [currencyIn, currencyOut], [currencyIn, currencyOut])
@@ -74,8 +98,8 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
 
   const impact = usePriceImpact(trade.trade, { inputUSDCValue, outputUSDCValue })
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    return {
       [Field.INPUT]: {
         currency: currencyIn,
         amount: amountIn,
@@ -88,29 +112,31 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
         balance: balanceOut,
         usdc: outputUSDCValue,
       },
+      error,
       trade,
       slippage,
       impact,
-    }),
-    [
-      amountIn,
-      amountOut,
-      balanceIn,
-      balanceOut,
-      currencyIn,
-      currencyOut,
-      impact,
-      inputUSDCValue,
-      outputUSDCValue,
-      slippage,
-      trade,
-    ]
-  )
+    }
+  }, [
+    amountIn,
+    amountOut,
+    balanceIn,
+    balanceOut,
+    currencyIn,
+    currencyOut,
+    error,
+    impact,
+    inputUSDCValue,
+    outputUSDCValue,
+    slippage,
+    trade,
+  ])
 }
 
 const DEFAULT_SWAP_INFO: SwapInfo = {
   [Field.INPUT]: {},
   [Field.OUTPUT]: {},
+  error: ChainError.UNCONNECTED_CHAIN,
   trade: { state: TradeState.INVALID, trade: undefined },
   slippage: DEFAULT_SLIPPAGE,
 }


### PR DESCRIPTION
- Propagates ChainError's through SwapInfo, so that checking for chain errors (which is error-prone) is not duplicated throughout the Widget.
- Refactors Toolbar and SwapActionButton to use ChainError to display errors:
  - Resolves WEB-1446: when "Switch network" is visible, disable all other widget click targets
  - Resolves WEB-1445: Clear toolbar when "Switch network" CTA is in Action Button