### PR TITLE
fix: min-height

### DIFF
--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -36,6 +36,7 @@ export const WidgetWrapper = styled.div<{ width?: number | string }>`
   font-size: 16px;
   font-smooth: always;
   font-variant: none;
+  min-height: 360px;
   min-width: 300px;
   padding: 8px;
   position: relative;


### PR DESCRIPTION
Always render to a minimum height. This ensures that dynamically sized screens stay visible (eg the error screen).
Fixes WEB-1515.