### PR TITLE
revert: keep Caption font size at 12

### DIFF
--- a/src/theme/type.tsx
+++ b/src/theme/type.tsx
@@ -61,7 +61,7 @@ export function Body2(props: TextProps) {
 }
 
 export function Caption(props: TextProps) {
-  return <TextWrapper className="caption" fontSize={14} fontWeight={400} lineHeight="16px" {...props} />
+  return <TextWrapper className="caption" fontSize={12} fontWeight={400} lineHeight="16px" {...props} />
 }
 
 export function Badge(props: TextProps) {


### PR DESCRIPTION
Reduces the Caption font size to prevent overflow from occuring for some captions. See WEB-1514 for details.