### PR TITLE
fix: center button and toolbar text with relevant icons

### DIFF
--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -27,7 +27,7 @@ interface CaptionProps {
 function Caption({ icon: Icon = AlertTriangle, caption }: CaptionProps) {
   return (
     <>
-      <Icon color="secondary" size={16.67 / 14} />
+      <Icon color="secondary" />
       <ThemedText.Caption lineHeight="14px">{caption}</ThemedText.Caption>
     </>
   )

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -27,8 +27,8 @@ interface CaptionProps {
 function Caption({ icon: Icon = AlertTriangle, caption }: CaptionProps) {
   return (
     <>
-      <Icon color="secondary" />
-      <ThemedText.Caption>{caption}</ThemedText.Caption>
+      <Icon color="secondary" size={16.67 / 14} />
+      <ThemedText.Caption lineHeight="14px">{caption}</ThemedText.Caption>
     </>
   )
 }

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -86,7 +86,7 @@ export default memo(function Toolbar() {
   ])
 
   return (
-    <ToolbarRow justify="flex-start" data-testid="toolbar" gap={3 / 8}>
+    <ToolbarRow flex justify="flex-start" data-testid="toolbar" gap={3 / 8} align="flex-end">
       {caption}
     </ToolbarRow>
   )

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -23,7 +23,7 @@ const StyledTokenButton = styled(Button)`
 `
 
 const TokenButtonRow = styled(Row)<{ empty: boolean }>`
-  float: right;
+  flex-direction: row;
   height: 1.2em;
   max-width: 12em;
   overflow: hidden;
@@ -73,17 +73,19 @@ export default function TokenButton({ value, disabled, onClick }: TokenButtonPro
     >
       <ThemedText.ButtonLarge color={contentColor}>
         <TokenButtonRow
-          gap={0.4}
+          align="flex-end"
           empty={!value}
+          flex
+          gap={0.4}
           // ref is used to set an absolute width, so it must be reset for each value passed.
           // To force this, value?.symbol is passed as a key.
           ref={setRow}
-          key={value?.symbol}
+          key={value?.wrapped.address}
         >
           {value ? (
             <>
               <TokenImg token={value} size={1.2} />
-              {value.symbol}
+              <span>{value.symbol}</span>
             </>
           ) : (
             <Trans>Select a token</Trans>


### PR DESCRIPTION
## before
![image](https://user-images.githubusercontent.com/5773490/195205239-d2d80e57-e695-436c-accf-98027e83cff4.png)

## after
![image](https://user-images.githubusercontent.com/5773490/195205262-f82f19bd-e877-4d6a-b01c-2de0c6d6cfba.png)
