### PR TITLE
fix: check for logoURI on currency

### DIFF
--- a/src/components/TokenImg.tsx
+++ b/src/components/TokenImg.tsx
@@ -29,9 +29,9 @@ type TokenImgProps = BaseProps & Omit<React.ImgHTMLAttributes<HTMLImageElement>,
 
 function TokenImg({ token, size, ...rest }: TokenImgProps) {
   // Use the wrapped token info so that it includes the logoURI.
-  const tokenInfo = useToken(token.isToken ? token.wrapped.address : undefined) ?? token
-  const srcs = useCurrencyLogoURIs(tokenInfo)
-  const alt = tokenInfo.name || tokenInfo.symbol
+  const currency = useToken(token.isToken ? token.wrapped.address : undefined) ?? token
+  const srcs = useCurrencyLogoURIs(currency)
+  const alt = currency.name || currency.symbol
 
   const [attempt, setAttempt] = useState(0)
   const src = useMemo(() => {
@@ -52,7 +52,7 @@ function TokenImg({ token, size, ...rest }: TokenImgProps) {
     return (
       <MissingTokenImg {...rest}>
         <MissingTokenSymbol size={size}>
-          {tokenInfo.symbol?.toUpperCase().replace('$', '').replace(/\s+/g, '').slice(0, 3)}
+          {currency.symbol?.toUpperCase().replace('$', '').replace(/\s+/g, '').slice(0, 3)}
         </MissingTokenSymbol>
       </MissingTokenImg>
     )

--- a/src/hooks/useCurrencyLogoURIs.ts
+++ b/src/hooks/useCurrencyLogoURIs.ts
@@ -4,7 +4,6 @@ import MaticLogo from 'assets/svg/matic-token-icon.svg'
 import { SupportedChainId } from 'constants/chains'
 import useHttpLocations from 'hooks/useHttpLocations'
 import { useMemo } from 'react'
-import { WrappedTokenInfo } from 'state/lists/wrappedTokenInfo'
 
 type Network = 'ethereum' | 'arbitrum' | 'optimism'
 
@@ -40,7 +39,9 @@ function getTokenLogoURI(address: string, chainId: SupportedChainId = SupportedC
 }
 
 export default function useCurrencyLogoURIs(currency?: Currency | null): string[] {
-  const locations = useHttpLocations(currency instanceof WrappedTokenInfo ? currency.logoURI : undefined)
+  const locations = useHttpLocations(
+    currency && 'logoURI' in currency ? (currency as { logoURI: string }).logoURI : undefined
+  )
   return useMemo(() => {
     const logoURIs = [...locations]
     if (currency) {


### PR DESCRIPTION
Checks for logoURI so that non-standard Currencies passed in by an integrator may still have a logo displayed.