### PR TITLE
fix: token button row alignment and width

### DIFF
--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -28,7 +28,7 @@ const TokenButtonRow = styled(Row)<{ empty: boolean }>`
   max-width: 12em;
   overflow: hidden;
   padding-left: ${({ empty }) => empty && 0.5}em;
-  width: fit-content;
+  width: max-content;
 
   img {
     min-width: 1.2em;
@@ -73,7 +73,6 @@ export default function TokenButton({ value, disabled, onClick }: TokenButtonPro
     >
       <ThemedText.ButtonLarge color={contentColor}>
         <TokenButtonRow
-          align="flex-end"
           empty={!value}
           flex
           gap={0.4}


### PR DESCRIPTION
- Fixes the alignment of the token button, so that text is centered
- Fixes the widget of the alignment button, so that the chevron does not break onto the next line

Before:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/5403956/195661165-80dd44fe-e67f-48df-ab42-f6b197146aba.png">

After:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/5403956/195661067-8085ea4e-f3e1-4eb9-888b-0a9e8cdacc97.png">
