### PR TITLE
fix: omit token select transition

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -29,13 +29,13 @@ const transitionCss = css`
   transition: background-color 0.125s linear, border-color 0.125s linear, filter 0.125s linear;
 `
 
-export default styled(BaseButton)<{ color?: Color; transition?: boolean }>`
+export default styled(BaseButton)<{ color?: Color }>`
   background-color: ${({ color = 'interactive', theme }) => theme[color]};
   border: 1px solid transparent;
   color: ${({ color = 'interactive', theme }) => color === 'interactive' && theme.onInteractive};
 
   :enabled {
-    ${({ transition = true }) => transition && transitionCss};
+    ${transitionCss};
   }
 
   :enabled:hover {

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -1,24 +1,19 @@
 import { Trans } from '@lingui/macro'
 import { Currency } from '@uniswap/sdk-core'
 import { ChevronDown } from 'icons'
-import { useEffect, useMemo, useState } from 'react'
-import styled, { css } from 'styled-components/macro'
+import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
 import Button from '../Button'
 import Row from '../Row'
 import TokenImg from '../TokenImg'
 
-const transitionCss = css`
-  transition: background-color 0.125s linear, border-color 0.125s linear, filter 0.125s linear, width 0.125s ease-out;
-`
-
 const StyledTokenButton = styled(Button)<{ approved?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius}em;
   padding: 0.25em;
 
   :enabled {
-    ${({ transition }) => transition && transitionCss};
+    transition: none;
   }
 
   ${TokenImg} {
@@ -47,46 +42,16 @@ interface TokenButtonProps {
 }
 
 export default function TokenButton({ value, approved, disabled, onClick }: TokenButtonProps) {
-  const buttonBackgroundColor = value ? 'interactive' : 'accent'
-  const contentColor = buttonBackgroundColor === 'accent' ? 'onAccent' : 'currentColor'
-
-  // Transition the button only if transitioning from a disabled state.
-  // This makes initialization cleaner without adding distracting UX to normal swap flows.
-  const [shouldTransition, setShouldTransition] = useState(disabled)
-  useEffect(() => {
-    if (disabled) {
-      setShouldTransition(true)
-    }
-  }, [disabled])
-
-  // width must have an absolute value in order to transition, so it is taken from the row ref.
-  const [row, setRow] = useState<HTMLDivElement | null>(null)
-  const style = useMemo(() => {
-    if (!shouldTransition) return
-    return { width: row ? row.clientWidth + /* padding= */ 8 + /* border= */ 2 : undefined }
-  }, [row, shouldTransition])
-
   return (
     <StyledTokenButton
       onClick={onClick}
-      color={buttonBackgroundColor}
+      color={value ? 'interactive' : 'accent'}
       approved={approved}
       disabled={disabled}
-      style={style}
-      transition={shouldTransition}
-      onTransitionEnd={() => setShouldTransition(false)}
       data-testid="token-select"
     >
-      <ThemedText.ButtonLarge color={contentColor}>
-        <TokenButtonRow
-          empty={!value}
-          flex
-          gap={0.4}
-          // ref is used to set an absolute width, so it must be reset for each value passed.
-          // To force this, value?.symbol is passed as a key.
-          ref={setRow}
-          key={value?.wrapped.address}
-        >
+      <ThemedText.ButtonLarge color={value ? 'currentColor' : 'onAccent'}>
+        <TokenButtonRow empty={!value} flex gap={0.4}>
           {value ? (
             <>
               <TokenImg token={value} size={1.2} />
@@ -95,7 +60,7 @@ export default function TokenButton({ value, approved, disabled, onClick }: Toke
           ) : (
             <Trans>Select a token</Trans>
           )}
-          <ChevronDown color={contentColor} strokeWidth={2} />
+          <ChevronDown strokeWidth={2} />
         </TokenButtonRow>
       </ThemedText.ButtonLarge>
     </StyledTokenButton>


### PR DESCRIPTION
Removes transitions between disabled token selector and enabled selection.
This is rarely used, and impedes the clean look of a widget initialized to a specific token.

WEB-1821