### PR TITLE
fix: add space between usd, impact

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -19,11 +19,12 @@ import Column from '../Column'
 import Row from '../Row'
 import TokenInput, { TokenInputHandle } from './TokenInput'
 
-export const USDC = styled(Row)`
+const USDC = styled(Row)`
   ${loadingTransitionCss};
+  gap: 0.25em;
 `
 
-export const Balance = styled(ThemedText.Body2)`
+const Balance = styled(ThemedText.Body2)`
   transition: color 0.25s ease-in-out;
 `
 
@@ -154,7 +155,11 @@ export function FieldWrapper({
           <Row>
             <USDC isLoading={isRouteLoading}>
               {usdc && `${formatCurrencyAmount({ amount: usdc, isUsdPrice: true })}`}
-              {impact && <ThemedText.Body2 color={impact.warning}> ({impact.toString()})</ThemedText.Body2>}
+              {impact && (
+                <ThemedText.Body2 userSelect={false} color={impact.warning}>
+                  ({impact.toString()})
+                </ThemedText.Body2>
+              )}
             </USDC>
             {balance && (
               <Row gap={0.5}>

--- a/src/theme/type.tsx
+++ b/src/theme/type.tsx
@@ -5,16 +5,16 @@ import type { Color } from './theme'
 
 type TextProps = Omit<TextPropsWithCss, 'css' | 'color' | 'userSelect'> & {
   color?: Color
-  userSelect?: true
+  userSelect?: boolean
 }
 
-const TextWrapper = styled(Text)<{ color?: Color; lineHeight: string; noWrap?: true; userSelect?: true }>`
+const TextWrapper = styled(Text)<{ color?: Color; lineHeight: string; noWrap?: true; userSelect?: boolean }>`
   color: ${({ color = 'currentColor', theme }) => theme[color as Color]};
   // Avoid the need for placeholders by setting min-height to line-height.
   min-height: ${({ lineHeight }) => lineHeight};
   // user-select is set to 'none' at the root element (Widget), but is desired for displayed data.
   // user-select must be configured through styled-components for cross-browser compat (eg to auto-generate prefixed properties).
-  user-select: ${({ userSelect }) => userSelect && 'text'};
+  user-select: ${({ userSelect }) => (userSelect === true ? 'text' : userSelect === false ? 'none' : undefined)};
   white-space: ${({ noWrap }) => noWrap && 'nowrap'};
 `
 


### PR DESCRIPTION
- Adds space between usd and impact using a gap, as it was not being respected as html
- Makes impact non-selectable (to further distinguish it from price)