### PR TITLE
fix: initialize atoms with ui config for initial render

### DIFF
--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -7,7 +7,7 @@ import useSyncConvenienceFee, { FeeOptions } from 'hooks/swap/useSyncConvenience
 import useSyncSwapEventHandlers, { SwapEventHandlers } from 'hooks/swap/useSyncSwapEventHandlers'
 import useSyncTokenDefaults, { TokenDefaults } from 'hooks/swap/useSyncTokenDefaults'
 import { usePendingTransactions } from 'hooks/transactions'
-import useSyncBrandingSetting, { BrandingSettings, useBrandingSetting } from 'hooks/useSyncBrandingSetting'
+import { useBrandingSetting } from 'hooks/useSyncBrandingSetting'
 import { useAtom } from 'jotai'
 import { useMemo, useState } from 'react'
 import { displayTxHashAtom } from 'state/swap'
@@ -27,7 +27,7 @@ import useValidate from './useValidate'
 // SwapProps also currently includes props needed for wallet connection (eg hideConnectionUI),
 // since the wallet connection component exists within the Swap component.
 // TODO(zzmp): refactor WalletConnection into Widget component
-export interface SwapProps extends BrandingSettings, FeeOptions, SwapController, SwapEventHandlers, TokenDefaults {
+export interface SwapProps extends FeeOptions, SwapController, SwapEventHandlers, TokenDefaults {
   hideConnectionUI?: boolean
   routerUrl?: string
 }
@@ -38,7 +38,6 @@ export default function Swap(props: SwapProps) {
   useSyncConvenienceFee(props as FeeOptions)
   useSyncSwapEventHandlers(props as SwapEventHandlers)
   useSyncTokenDefaults(props as TokenDefaults)
-  useSyncBrandingSetting(props as BrandingSettings)
 
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
 

--- a/src/hooks/swap/useSyncController.ts
+++ b/src/hooks/swap/useSyncController.ts
@@ -1,3 +1,4 @@
+import { Atom } from 'jotai'
 import { useUpdateAtom } from 'jotai/utils'
 import { useEffect, useRef } from 'react'
 import { controlledAtom as swapAtom, Swap } from 'state/swap'
@@ -6,6 +7,10 @@ import { controlledAtom as settingsAtom, Settings } from 'state/swap/settings'
 export interface SwapController {
   value?: Swap
   settings?: Settings
+}
+
+export function useInitialController({ value }: SwapController): [Atom<Swap | undefined>, Swap | undefined] {
+  return [swapAtom, value]
 }
 
 export default function useSyncController({ value, settings }: SwapController): void {

--- a/src/hooks/useInitialAtomValues.ts
+++ b/src/hooks/useInitialAtomValues.ts
@@ -1,0 +1,13 @@
+import { Atom } from 'jotai'
+
+import { useInitialController } from './swap/useSyncController'
+import { useInitialBrandingSettings } from './useSyncBrandingSetting'
+
+export default function useInitialAtomValues(props: any): [Atom<unknown>, unknown][] {
+  const brandingSettings = useInitialBrandingSettings(props)
+
+  // TODO: Use a separate AtomProvider within Swap so that its configuration can be separated from general Widget configuration.
+  const controller = useInitialController(props)
+
+  return [brandingSettings, controller]
+}

--- a/src/hooks/useSyncBrandingSetting.ts
+++ b/src/hooks/useSyncBrandingSetting.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai'
+import { Atom, atom } from 'jotai'
 import { useAtomValue, useUpdateAtom } from 'jotai/utils'
 import { useEffect } from 'react'
 
@@ -10,6 +10,10 @@ export function useBrandingSetting() {
 
 export interface BrandingSettings {
   disableBranding?: boolean
+}
+
+export function useInitialBrandingSettings({ disableBranding }: BrandingSettings): [Atom<boolean>, boolean] {
+  return [disableBrandingAtom, disableBranding ?? false]
 }
 
 export default function useSyncBrandingSetting({ disableBranding }: BrandingSettings): void {


### PR DESCRIPTION
Avoids rendering branding or initial state for controlled widgets.