### PR TITLE
feat: preload client side routes

### DIFF
--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -59,7 +59,7 @@ function Fixture() {
     USDC: USDC_MAINNET.address,
   }
   const defaultInputToken = useOption('defaultInputToken', { options: currencies, defaultValue: 'Native' })
-  const [defaultInputAmount] = useValue('defaultInputAmount', { defaultValue: 1 })
+  const [defaultInputAmount] = useValue('defaultInputAmount', { defaultValue: 0 })
   const defaultOutputToken = useOption('defaultOutputToken', { options: currencies })
   const [defaultOutputAmount] = useValue('defaultOutputAmount', { defaultValue: 0 })
 

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -5,7 +5,7 @@ import { useCurrencyBalances } from 'hooks/useCurrencyBalance'
 import useOnSupportedNetwork from 'hooks/useOnSupportedNetwork'
 import { PriceImpact, usePriceImpact } from 'hooks/usePriceImpact'
 import useSlippage, { DEFAULT_SLIPPAGE, Slippage } from 'hooks/useSlippage'
-import { useUSDCValue } from 'hooks/useUSDCPrice'
+import useUSDCPrice, { useUSDCValue } from 'hooks/useUSDCPrice'
 import { useAtomValue } from 'jotai/utils'
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef } from 'react'
 import { InterfaceTrade, TradeState } from 'state/routing/types'
@@ -87,6 +87,9 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
   const currencies = useMemo(() => [currencyIn, currencyOut], [currencyIn, currencyOut])
   const [balanceIn, balanceOut] = useCurrencyBalances(account, currencies)
   const [usdcIn, usdcOut] = [useUSDCValue(amountIn), useUSDCValue(amountOut)]
+
+  // Initialize USDC prices for otherCurrency so that it is available sooner after the trade loads.
+  useUSDCPrice(isExactInput(type) ? currencyOut : currencyIn)
 
   // Compute slippage and impact off of the trade so that it refreshes with the trade.
   // Wait until the trade is valid to avoid displaying incorrect intermediate values.

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -64,13 +64,14 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
   }, [chainId, chainIdIn, chainIdOut, isActivating, isActive, isSupported, tokenChainId])
 
   const parsedAmount = useMemo(
-    () => tryParseCurrencyAmount(amount, (isExactInput(type) ? currencyIn : currencyOut) ?? undefined),
+    () => tryParseCurrencyAmount(amount, isExactInput(type) ? currencyIn : currencyOut),
     [amount, currencyIn, currencyOut, type]
   )
   const trade = useRouterTrade(
     type,
     parsedAmount,
-    isExactInput(type) ? currencyOut : currencyIn,
+    currencyIn,
+    currencyOut,
     isWrap || error ? RouterPreference.SKIP : RouterPreference.TRADE,
     routerUrl
   )

--- a/src/hooks/useUSDCPrice.ts
+++ b/src/hooks/useUSDCPrice.ts
@@ -14,7 +14,7 @@ export default function useUSDCPrice(currency?: Currency): Price<Currency, Token
   const amountOut = chainId ? STABLECOIN_AMOUNT_OUT[chainId] : undefined
   const stablecoin = amountOut?.currency
 
-  const trade = useRouterTrade(TradeType.EXACT_OUTPUT, amountOut, currency, RouterPreference.PRICE)
+  const trade = useRouterTrade(TradeType.EXACT_OUTPUT, amountOut, currency, stablecoin, RouterPreference.PRICE)
 
   const price = useMemo(() => {
     if (!currency || !stablecoin) {

--- a/src/state/routing/args.ts
+++ b/src/state/routing/args.ts
@@ -4,7 +4,6 @@ import { SkipToken, skipToken } from '@reduxjs/toolkit/query/react'
 import { Currency, CurrencyAmount, TradeType } from '@uniswap/sdk-core'
 import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { useMemo } from 'react'
-import { isExactInput } from 'utils/tradeType'
 
 import { GetQuoteArgs } from './types'
 
@@ -40,27 +39,25 @@ export function useGetQuoteArgs(
     provider,
     tradeType,
     amountSpecified,
-    otherCurrency,
+    currencyIn,
+    currencyOut,
     routerUrl,
   }: Partial<{
     provider: BaseProvider
     tradeType: TradeType
     amountSpecified: CurrencyAmount<Currency>
-    otherCurrency: Currency
+    currencyIn: Currency
+    currencyOut: Currency
     routerUrl: string
   }>,
   skip?: boolean
 ): GetQuoteArgs | SkipToken {
   const args = useMemo(() => {
-    if (!provider || !amountSpecified || tradeType === undefined) return null
-
-    const [currencyIn, currencyOut] = isExactInput(tradeType)
-      ? [amountSpecified?.currency, otherCurrency]
-      : [otherCurrency, amountSpecified?.currency]
+    if (!provider || tradeType === undefined) return null
     if (!currencyIn || !currencyOut || currencyIn.equals(currencyOut)) return null
 
     return {
-      amount: amountSpecified.quotient.toString(),
+      amount: amountSpecified?.quotient.toString() ?? null,
       tokenInAddress: currencyIn.wrapped.address,
       tokenInChainId: currencyIn.wrapped.chainId,
       tokenInDecimals: currencyIn.wrapped.decimals,
@@ -73,7 +70,7 @@ export function useGetQuoteArgs(
       tradeType,
       provider,
     }
-  }, [provider, amountSpecified, tradeType, otherCurrency, routerUrl])
+  }, [provider, amountSpecified, tradeType, currencyIn, currencyOut, routerUrl])
 
   const isWindowVisible = useIsWindowVisible()
   if (skip || !isWindowVisible) return skipToken

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -27,8 +27,11 @@ export const routing = createApi({
       async queryFn(args: GetQuoteArgs | SkipToken) {
         if (args === skipToken) return { error: { status: 'CUSTOM_ERROR', error: 'Skipped' } }
 
-        // If enabled, try routing API, falling back to clientside SOR.
+        // If enabled, try routing API, falling back to client-side SOR.
         if (Boolean(args.routerUrl)) {
+          // amount may be null to initialize the client-side SOR. This should be skipped for the server.
+          if (args.amount === undefined) return { error: { status: 'CUSTOM_ERROR', error: 'Skipped' } }
+
           try {
             const { tokenInAddress, tokenInChainId, tokenOutAddress, tokenOutChainId, amount, tradeType } = args
             const type = isExactInput(tradeType) ? 'exactIn' : 'exactOut'

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -57,7 +57,7 @@ export interface GetQuoteArgs {
   tokenOutChainId: ChainId
   tokenOutDecimals: number
   tokenOutSymbol?: string
-  amount: string
+  amount: string | null // passing null will initialize the client-side SOR
   routerUrl?: string
   tradeType: TradeType
   provider: BaseProvider


### PR DESCRIPTION
Prices (and routes, if no routerUrl is specified) are loaded using the client-side router, which must initialize a route before it can fetch prices for it. Currently, this initialization is only done _after_ a swap is fetched (ie a waterfall pattern).

Updates the routing code to initialize a route as soon as its Token is selected. This has two important consequences: client-fetched swaps are significantly faster, since the delay is mostly initialization; prices show up (nearly) at the same time as the swap, since (again) the delay is mostly initialization.

Compare these two experiences for loading the DAI price (note the latter is instant):

https://user-images.githubusercontent.com/5403956/200449717-15747b84-2d1f-4c1c-b547-81388f968ff1.mov

_Before_


https://user-images.githubusercontent.com/5403956/200449744-0d016842-242c-4389-a200-2c8c911b7aba.mov

_After_

Compare these two experiences for loading the ETH/DAI swap using a client-side router (note the latter is faster):


https://user-images.githubusercontent.com/5403956/200450271-fcf2f3ab-2305-447a-b89b-8ade71e6eeaf.mov


_Before_


https://user-images.githubusercontent.com/5403956/200450148-4232be41-3c32-4e47-b2ff-6a9ebd6c5d37.mov

_After_