### PR TITLE
fix: use an opaque underlayer for reverse button

### DIFF
--- a/src/components/Swap/ReverseButton.tsx
+++ b/src/components/Swap/ReverseButton.tsx
@@ -1,30 +1,30 @@
 import { useSwapInfo, useSwitchSwapCurrencies } from 'hooks/swap'
 import { ArrowDown, LargeIcon } from 'icons'
-import { transparentize } from 'polished'
 import styled from 'styled-components/macro'
 import { Layer } from 'theme'
 
 import Button from '../Button'
 
+const Underlayer = styled.div`
+  background-color: ${({ theme }) => theme.container};
+  border-radius: ${({ theme }) => theme.borderRadius}em;
+  height: 48px;
+  left: 50%;
+  position: absolute;
+  /* Adjust by 2px to account for border display. */
+  transform: translate(-50%, calc(-50% - 2px));
+  width: 48px;
+  z-index: ${Layer.OVERLAY};
+`
+
 const StyledReverseButton = styled(Button)`
   align-items: center;
   background-color: ${({ theme }) => theme.interactive};
-  border: 4px solid;
-  border-color: ${({ theme }) => theme.container};
+  border: 4px solid ${({ theme }) => theme.container};
   border-radius: ${({ theme }) => theme.borderRadius}em;
   display: flex;
-  height: 48px;
   justify-content: center;
-  left: 50%;
-  position: absolute;
-  /* Adjust by 2px to account for border display */
-  transform: translate(-50%, calc(-50% - 2px));
-  transition: 125ms ease background-color;
-  width: 48px;
-  z-index: ${Layer.OVERLAY};
-  :hover {
-    background-color: ${({ theme }) => transparentize(0.2, theme.module)};
-  }
+  width: 100%;
 `
 
 export default function ReverseButton() {
@@ -33,8 +33,10 @@ export default function ReverseButton() {
   const switchCurrencies = useSwitchSwapCurrencies()
 
   return (
-    <StyledReverseButton disabled={isDisabled} onClick={switchCurrencies}>
-      <LargeIcon icon={ArrowDown} />
-    </StyledReverseButton>
+    <Underlayer>
+      <StyledReverseButton disabled={isDisabled} onClick={switchCurrencies}>
+        <LargeIcon icon={ArrowDown} />
+      </StyledReverseButton>
+    </Underlayer>
   )
 }


### PR DESCRIPTION
Adds an opaque underlayer to the ReverseButton to prevent leaking the underlying elements through when it is transparent.

This can be tested by viewing the widget with a wallet connection on the wrong chain. It is only visibly different when the ReverseButton is disabled.

_Before_
![image](https://user-images.githubusercontent.com/5403956/204953071-0b913cc0-1353-48df-aa7e-1357a3c4f550.png)

_After_
![image](https://user-images.githubusercontent.com/5403956/204953152-b08e5c11-cd86-4839-9442-996e66cb587d.png)
