### PR TITLE
fix: error captions

### DIFF
--- a/src/hooks/routing/clientSideSmartOrderRouter.ts
+++ b/src/hooks/routing/clientSideSmartOrderRouter.ts
@@ -12,7 +12,7 @@ import {
   UniswapMulticallProvider,
 } from '@uniswap/smart-order-router'
 import JSBI from 'jsbi'
-import { GetQuoteArgs, GetQuoteResult, NO_ROUTE } from 'state/routing/types'
+import { GetQuoteArgs, GetQuoteResult, INITIALIZED, NO_ROUTE } from 'state/routing/types'
 import { isExactInput } from 'utils/tradeType'
 
 import { transformSwapRouteToGetQuoteResult } from './transformSwapRouteToGetQuoteResult'
@@ -103,7 +103,8 @@ async function getQuote(
   const amount = CurrencyAmount.fromRawAmount(baseCurrency, JSBI.BigInt(amountRaw ?? '1')) // a null amountRaw should initialize the route
   const route = await router.route(amount, quoteCurrency, tradeType, /*swapConfig=*/ undefined, routerConfig)
 
-  if (amountRaw === null || !route) return NO_ROUTE
+  if (!amountRaw) return INITIALIZED
+  if (!route) return NO_ROUTE
 
   return transformSwapRouteToGetQuoteResult({ ...route, routeString: routeAmountsToString(route.route) })
 }

--- a/src/hooks/swap/index.ts
+++ b/src/hooks/swap/index.ts
@@ -63,9 +63,9 @@ export function useIsSwapFieldIndependent(field: Field): boolean {
 
 const amountAtom = pickAtom(swapAtom, 'amount')
 
-// check if any amount has been entered by user
+/** Returns true if the user has entered a non-zero amount. */
 export function useIsAmountPopulated() {
-  return Boolean(useAtomValue(amountAtom))
+  return Boolean(Number(useAtomValue(amountAtom)))
 }
 
 export function useSwapAmount(field: Field): [string | undefined, (amount: string, origin?: 'max') => void] {

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -74,9 +74,9 @@ export const routing = createApi({
         try {
           const quote = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
           return { data: quote }
-        } catch (error: unknown) {
+        } catch (error: any) {
           console.warn(`GetQuote failed on client: ${error}`)
-          return { error: { status: 'CUSTOM_ERROR', error: error instanceof Error ? error.message : error } }
+          return { error: { status: 'CUSTOM_ERROR', error: error?.message ?? error?.detail ?? error } }
         }
       },
       keepUnusedDataFor: ms`10s`,

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -18,8 +18,6 @@ const baseQuery: BaseQueryFn<GetQuoteArgs, GetQuoteResult> = () => {
   return { error: { reason: 'Unimplemented baseQuery' } }
 }
 
-export const INITIALIZATION = Symbol()
-
 export const routing = createApi({
   reducerPath: 'routing',
   baseQuery,
@@ -30,9 +28,9 @@ export const routing = createApi({
         if (args === skipToken) return { error: { status: 'CUSTOM_ERROR', error: 'Skipped' } }
 
         if (
-          // If enabled, try routing API, falling back to client-side SOR.
+          // If enabled, try the routing API, falling back to client-side routing.
           Boolean(args.routerUrl) &&
-          // A null amount may be passed to initialize the client-side SOR.
+          // A null amount may be passed to initialize the client-side routing.
           args.amount !== null
         ) {
           try {
@@ -71,7 +69,6 @@ export const routing = createApi({
           }
         }
 
-        // If integrator did not provide a routing API URL param, use clientside SOR.
         // Lazy-load the client-side router to improve initial pageload times.
         const clientSideSmartOrderRouter = await import('../../hooks/routing/clientSideSmartOrderRouter')
         try {

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -82,8 +82,9 @@ export interface QuoteResult {
   routeString: string
 }
 
+export const INITIALIZED = 'Initialized'
 export const NO_ROUTE = 'No Route'
 
-export type GetQuoteResult = QuoteResult | typeof NO_ROUTE
+export type GetQuoteResult = QuoteResult | typeof INITIALIZED | typeof NO_ROUTE
 
 export class InterfaceTrade extends Trade<Currency, Currency, TradeType> {}


### PR DESCRIPTION
- Correctly parse `0(.0*)+` as unpopulated amounts. This fixes a bug where entering `0` displayed the error caption.
- Disambiguate initialization in the client-side router. This fixes a bug where the toolbar displayed the insufficient liquidity caption on first load.