### PR TITLE
fix: better sequencing to handle rejections

### DIFF
--- a/src/hooks/usePermit2.ts
+++ b/src/hooks/usePermit2.ts
@@ -35,11 +35,7 @@ export default function usePermit(amount?: CurrencyAmount<Token>, spender?: stri
   const updatePermitAllowance = useUpdatePermitAllowance(amount?.currency, spender, allowanceData?.nonce, setSignature)
 
   const updateTokenAndPermitAllowance = useCallback(async () => {
-    // Queue both transactions.
-    const info = updateTokenAllowance()
-    // Delay the permit allowance to ensure the approval is prompted for first;
-    // but do not wait until token allowance resolves, to avoid some wallets closing their modal in between prompts (eg MetaMask).
-    await new Promise((resolve) => setTimeout(resolve, 500))
+    const info = await updateTokenAllowance()
     await updatePermitAllowance()
     return info
   }, [updatePermitAllowance, updateTokenAllowance])


### PR DESCRIPTION
Leaving info un-awaited caused unhandled rejections if the user did not accept the tx.
This correctly catches rejections.