### PR TITLE
fix: disable swap while permit loading

### DIFF
--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -48,22 +48,22 @@ export default function SwapButton({
   const deadline = useTransactionDeadline()
   const feeOptions = useAtomValue(feeOptionsAtom)
 
-  const permit2 = usePermit2()
+  const permit2Enabled = usePermit2()
   const { callback: swapRouterCallback } = useSwapCallback({
-    trade: permit2 ? undefined : trade,
+    trade: permit2Enabled ? undefined : trade,
     allowedSlippage: slippage.allowed,
     recipientAddressOrName: account ?? null,
     signatureData: approval?.signatureData,
     deadline,
     feeOptions,
   })
-  const universalRouterSwapCallback = useUniversalRouterSwapCallback(permit2 ? trade : undefined, {
+  const universalRouterSwapCallback = useUniversalRouterSwapCallback(permit2Enabled ? trade : undefined, {
     slippageTolerance: slippage.allowed,
     deadline,
     permit: permit.signature,
     feeOptions,
   })
-  const swapCallback = permit2 ? universalRouterSwapCallback : swapRouterCallback
+  const swapCallback = permit2Enabled ? universalRouterSwapCallback : swapRouterCallback
 
   const [open, setOpen] = useState(false)
   // Close the review modal if there is no available trade.
@@ -106,8 +106,8 @@ export default function SwapButton({
     setOpen(await onReviewSwapClick())
   }, [onReviewSwapClick])
 
-  if (usePermit2()) {
-    if (![PermitState.UNKNOWN, PermitState.PERMITTED].includes(permit.state)) {
+  if (permit2Enabled) {
+    if (permit.state === PermitState.PERMIT_NEEDED) {
       return <PermitButton color={color} onSubmit={onSubmit} trade={trade} {...permit} />
     }
   } else {
@@ -118,7 +118,11 @@ export default function SwapButton({
 
   return (
     <>
-      <ActionButton color={color} onClick={onClick} disabled={disabled}>
+      <ActionButton
+        color={color}
+        onClick={onClick}
+        disabled={disabled || (permit2Enabled && permit.state === PermitState.LOADING)}
+      >
         <Trans>Review swap</Trans>
       </ActionButton>
       {open && trade && (

--- a/src/hooks/swap/useSwapInfo.tsx
+++ b/src/hooks/swap/useSwapInfo.tsx
@@ -101,15 +101,15 @@ function useComputeSwapInfo(routerUrl?: string): SwapInfo {
   const slippage = useSlippage(trade)
   const impact = usePriceImpact(trade.trade)
 
-  const permit2 = usePermit2()
+  const permit2Enabled = usePermit2()
   const maximumAmountIn = useMemo(() => {
     const maximumAmountIn = trade.trade?.maximumAmountIn(slippage.allowed)
     return maximumAmountIn?.currency.isToken ? (maximumAmountIn as CurrencyAmount<Token>) : undefined
   }, [slippage.allowed, trade.trade])
-  const approval = useSwapApproval(permit2 ? undefined : maximumAmountIn)
+  const approval = useSwapApproval(permit2Enabled ? undefined : maximumAmountIn)
   const permit = usePermit(
-    permit2 ? maximumAmountIn : undefined,
-    permit2 && chainId ? UNIVERSAL_ROUTER_ADDRESS(chainId) : undefined
+    permit2Enabled ? maximumAmountIn : undefined,
+    permit2Enabled && chainId ? UNIVERSAL_ROUTER_ADDRESS(chainId) : undefined
   )
 
   return useMemo(() => {
@@ -157,7 +157,7 @@ const DEFAULT_SWAP_INFO: SwapInfo = {
   error: ChainError.UNCONNECTED_CHAIN,
   trade: { state: TradeState.INVALID, trade: undefined },
   approval: { state: SwapApprovalState.APPROVED },
-  permit: { state: PermitState.UNKNOWN },
+  permit: { state: PermitState.INVALID },
   slippage: DEFAULT_SLIPPAGE,
 }
 

--- a/src/hooks/usePermit2.ts
+++ b/src/hooks/usePermit2.ts
@@ -10,7 +10,8 @@ import { PermitSignature, usePermitAllowance, useUpdatePermitAllowance } from '.
 import { useTokenAllowance, useUpdateTokenAllowance } from './useTokenAllowance'
 
 export enum PermitState {
-  UNKNOWN,
+  INVALID,
+  LOADING,
   PERMIT_NEEDED,
   PERMITTED,
 }
@@ -81,8 +82,10 @@ export default function usePermit(amount?: CurrencyAmount<Token>, spender?: stri
   )
 
   return useMemo(() => {
-    if (!amount || !tokenAllowance) {
-      return { state: PermitState.UNKNOWN }
+    if (!amount) {
+      return { state: PermitState.INVALID }
+    } else if (!tokenAllowance || !permitAllowance) {
+      return { state: PermitState.LOADING }
     } else if (isAllowed) {
       if (isPermitted) {
         return { state: PermitState.PERMITTED }
@@ -91,5 +94,5 @@ export default function usePermit(amount?: CurrencyAmount<Token>, spender?: stri
       }
     }
     return { state: PermitState.PERMIT_NEEDED, callback }
-  }, [amount, callback, isAllowed, isPermitted, isSigned, signature, tokenAllowance])
+  }, [amount, callback, isAllowed, isPermitted, isSigned, permitAllowance, signature, tokenAllowance])
 }


### PR DESCRIPTION
Adds a PermitState.LOADING to avoid initiating a swap before PermitState is known.
This prevents swaps from failing because they have not yet been permitted.