### PR TITLE
fix: hexlify tx value from SwapRouter

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -2,7 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionResponse } from '@ethersproject/providers'
 import { Percent } from '@uniswap/sdk-core'
 import { SwapRouter, UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
-import { FeeOptions } from '@uniswap/v3-sdk'
+import { FeeOptions, toHex } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
@@ -35,19 +35,13 @@ export function useUniversalRouterSwapCallback(trade: InterfaceTrade | undefined
         inputTokenPermit: options.permit,
         fee: options.feeOptions,
       })
-      const tx =
-        value && !isZero(value)
-          ? {
-              from: account,
-              to: UNIVERSAL_ROUTER_ADDRESS(chainId),
-              data,
-              value,
-            }
-          : {
-              from: account,
-              to: UNIVERSAL_ROUTER_ADDRESS(chainId),
-              data,
-            }
+      const tx = {
+        from: account,
+        to: UNIVERSAL_ROUTER_ADDRESS(chainId),
+        data,
+        // TODO: universal-router-sdk returns a non-hexlified value.
+        ...(value && !isZero(value) ? { value: toHex(value) } : {}),
+      }
 
       let gasEstimate: BigNumber
       try {


### PR DESCRIPTION
Hexlifies the value returned from universal-router-sdk, which is required for ethers to accept it as input.
Fixes an error thrown by ethers (RE: un-hexlified data).
See https://github.com/Uniswap/universal-router-sdk/issues/92 (fixed in https://github.com/Uniswap/universal-router-sdk/pull/93 but not yet released).