### PR TITLE
build: upgrade universal-router-sdk to fix instanceof checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/smart-order-router": "^2.10.0",
     "@uniswap/token-lists": "^1.0.0-beta.30",
-    "@uniswap/universal-router-sdk": "^1.2.3",
+    "@uniswap/universal-router-sdk": "^1.3.0",
     "@uniswap/v2-sdk": "^3.0.1",
     "@uniswap/v3-sdk": "^3.8.2",
     "@web3-react/core": "8.0.35-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3597,10 +3597,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.30.tgz#2103ca23b8007c59ec71718d34cdc97861c409e5"
   integrity sha512-HwY2VvkQ8lNR6ks5NqQfAtg+4IZqz3KV1T8d2DlI8emIn9uMmaoFbIOg0nzjqAVKKnZSbMTRRtUoAh6mmjRvog==
 
-"@uniswap/universal-router-sdk@^1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.2.3.tgz#5df1c9cd9b36b271c6760c4e5258f5bedb6bb9a7"
-  integrity sha512-rb7ZYLKbV8xGHBHaA9hPDlRX4JWdhsAPgj7SCZUk+XQ6M7UvLhx2SapUoVzup+ylh8W66u6QqCuVoLruNboXHg==
+"@uniswap/universal-router-sdk@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.3.0.tgz#f44262eafe729651d383f46a647399658d45baf7"
+  integrity sha512-Q7/Gw059JQDO7exxV791QzghEOiWomdvxvqidozDvkiZE7paIlSWq1vDVF4H3zB2GYy5Hu7HM8krl2l0KS9X5g==
   dependencies:
     "@uniswap/permit2-sdk" "^1.2.0"
     "@uniswap/router-sdk" "^1.4.0"


### PR DESCRIPTION
universal-router-sdk had used `instanceof` checks, which were failing for unknown reasons.
See https://github.com/Uniswap/universal-router-sdk/pull/94.