### PR TITLE
fix: disable ActionButton whilst awaiting wallet action

### DIFF
--- a/src/components/Swap/SwapActionButton/SwitchChainButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwitchChainButton.tsx
@@ -35,10 +35,13 @@ export default function ChainSwitchButton({ color, chainId }: { color: keyof Col
         : {
             message: <Trans>Switch network</Trans>,
             onClick: onSwitchChain,
-            children: <Trans>Switch</Trans>,
           },
     [account, isPending, onSwitchChain]
   )
 
-  return <ActionButton color={color} action={actionProps} />
+  return (
+    <ActionButton color={color} disabled={isPending} action={actionProps}>
+      <Trans>Switch</Trans>
+    </ActionButton>
+  )
 }

--- a/src/components/Swap/SwapActionButton/WrapButton.tsx
+++ b/src/components/Swap/SwapActionButton/WrapButton.tsx
@@ -56,7 +56,7 @@ export default function WrapButton({
   )
 
   return (
-    <ActionButton color={color} {...actionProps} disabled={disabled}>
+    <ActionButton color={color} {...actionProps} disabled={disabled || isPending}>
       <Trans>
         {wrapType === TransactionType.WRAP ? 'Wrap' : 'Unwrap'} {inputCurrency?.symbol}
       </Trans>


### PR DESCRIPTION
Prevents a user from double-sending transactions to their wallet (or the UX from implying that this is desirable given our UX flow).