### PR TITLE
fix: observe submitted allowance immediately

### DIFF
--- a/src/hooks/usePermitAllowance.ts
+++ b/src/hooks/usePermitAllowance.ts
@@ -11,6 +11,8 @@ import { useWeb3React } from '@web3-react/core'
 import ms from 'ms.macro'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import useBlockNumber from './useBlockNumber'
+
 const PERMIT_EXPIRATION = ms`30d`
 const PERMIT_SIG_EXPIRATION = ms`30m`
 
@@ -22,6 +24,10 @@ export function usePermitAllowance(token?: Token, spender?: string) {
   const { account, provider } = useWeb3React()
   const allowanceProvider = useMemo(() => provider && new AllowanceProvider(provider, PERMIT2_ADDRESS), [provider])
   const [allowanceData, setAllowanceData] = useState<AllowanceData>()
+
+  // If there is no allowanceData, recheck every block so a submitted allowance is immediately observed.
+  const blockNumber = useBlockNumber()
+  const shouldUpdate = allowanceData ? false : blockNumber
 
   useEffect(() => {
     if (!account || !token || !spender) return
@@ -40,7 +46,7 @@ export function usePermitAllowance(token?: Token, spender?: string) {
     return () => {
       stale = true
     }
-  }, [account, allowanceProvider, spender, token])
+  }, [account, allowanceProvider, shouldUpdate, spender, token])
 
   return allowanceData
 }


### PR DESCRIPTION
Fixes a bug where a user could submit a transaction, but would be required to re-sign a permit for a subsequent transaction, because the prior transaction's modification of allowance was not detected.