### PR TITLE
fix: show error when present (not approval)

### DIFF
--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -107,11 +107,11 @@ export default function SwapButton({
   }, [onReviewSwapClick])
 
   if (permit2Enabled) {
-    if (permit.state === PermitState.PERMIT_NEEDED) {
+    if (!disabled && permit.state === PermitState.PERMIT_NEEDED) {
       return <PermitButton color={color} onSubmit={onSubmit} trade={trade} {...permit} />
     }
   } else {
-    if (approval.state !== SwapApprovalState.APPROVED && !disabled) {
+    if (!disabled && approval.state !== SwapApprovalState.APPROVED) {
       return <ApproveButton color={color} onSubmit={onSubmit} trade={trade} {...approval} />
     }
   }


### PR DESCRIPTION
If there is insufficient balance (or other swap-disabling error), do not show the approve button, but instead show a disabled swap button.
This fixes a regression in permit2, to align it with the legacy behavior.