### PR TITLE
fix: await syncing allowance to update permit state

### DIFF
--- a/src/components/Swap/SwapActionButton/Permit2Button.tsx
+++ b/src/components/Swap/SwapActionButton/Permit2Button.tsx
@@ -17,12 +17,14 @@ import { ExplorerDataType } from 'utils/getExplorerLink'
 export default function PermitButton({
   color,
   trade,
+  pending: isPendingApproval,
   callback,
   onSubmit,
 }: {
   color: keyof Colors
   trade?: InterfaceTrade
-  callback?: (isPendingApproval: boolean) => Promise<ApprovalTransactionInfo | void>
+  pending?: boolean
+  callback?: () => Promise<ApprovalTransactionInfo | void>
   onSubmit: (submit: () => Promise<ApprovalTransactionInfo | void>) => Promise<void>
 }) {
   const currency = trade?.inputAmount?.currency
@@ -38,7 +40,7 @@ export default function PermitButton({
   const onClick = useCallback(async () => {
     setIsPending(true)
     try {
-      await onSubmit(async () => await callback?.(Boolean(pendingApproval)))
+      await onSubmit(async () => await callback?.())
       setIsFailed(false)
     } catch (e) {
       console.error(e)
@@ -46,7 +48,7 @@ export default function PermitButton({
     } finally {
       setIsPending(false)
     }
-  }, [callback, onSubmit, pendingApproval])
+  }, [callback, onSubmit])
 
   const action = useMemo(() => {
     if (isPending) {
@@ -54,13 +56,15 @@ export default function PermitButton({
         icon: Spinner,
         message: t`Approve in your wallet`,
       }
-    } else if (pendingApproval) {
+    } else if (isPendingApproval) {
       return {
         icon: Spinner,
-        message: (
+        message: pendingApproval ? (
           <EtherscanLink type={ExplorerDataType.TRANSACTION} data={pendingApproval}>
             <Trans>Approval pending</Trans>
           </EtherscanLink>
+        ) : (
+          <Trans>Approval pending</Trans>
         ),
       }
     } else if (isFailed) {
@@ -75,7 +79,7 @@ export default function PermitButton({
         onClick,
       }
     }
-  }, [currency?.symbol, isFailed, isPending, onClick, pendingApproval])
+  }, [currency?.symbol, isFailed, isPending, isPendingApproval, onClick, pendingApproval])
 
   return (
     <ActionButton color={color} disabled={!action?.onClick} action={action}>

--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -108,7 +108,7 @@ export default function SwapButton({
 
   if (permit2Enabled) {
     if (!disabled && permit.state === PermitState.PERMIT_NEEDED) {
-      return <PermitButton color={color} onSubmit={onSubmit} trade={trade} {...permit} />
+      return <PermitButton color={color} onSubmit={onSubmit} {...permit} />
     }
   } else {
     if (!disabled && approval.state !== SwapApprovalState.APPROVED) {

--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -22,22 +22,22 @@ export function useApprovalStateForSpender(
   const { account } = useWeb3React()
   const token = amountToApprove?.currency?.isToken ? amountToApprove.currency : undefined
 
-  const { amount: currentAllowance } = useTokenAllowance(token, account ?? undefined, spender)
+  const { tokenAllowance } = useTokenAllowance(token, account ?? undefined, spender)
   const pendingApproval = useIsPendingApproval(token, spender)
 
   return useMemo(() => {
     if (!amountToApprove || !spender) return ApprovalState.UNKNOWN
     if (amountToApprove.currency.isNative) return ApprovalState.APPROVED
     // we might not have enough data to know whether or not we need to approve
-    if (!currentAllowance) return ApprovalState.UNKNOWN
+    if (!tokenAllowance) return ApprovalState.UNKNOWN
 
-    // amountToApprove will be defined if currentAllowance is
-    return currentAllowance.lessThan(amountToApprove)
+    // amountToApprove will be defined if tokenAllowance is
+    return tokenAllowance.lessThan(amountToApprove)
       ? pendingApproval
         ? ApprovalState.PENDING
         : ApprovalState.NOT_APPROVED
       : ApprovalState.APPROVED
-  }, [amountToApprove, currentAllowance, pendingApproval, spender])
+  }, [amountToApprove, pendingApproval, spender, tokenAllowance])
 }
 
 export function useApproval(

--- a/src/hooks/useApproval.ts
+++ b/src/hooks/useApproval.ts
@@ -22,7 +22,7 @@ export function useApprovalStateForSpender(
   const { account } = useWeb3React()
   const token = amountToApprove?.currency?.isToken ? amountToApprove.currency : undefined
 
-  const currentAllowance = useTokenAllowance(token, account ?? undefined, spender)
+  const { amount: currentAllowance } = useTokenAllowance(token, account ?? undefined, spender)
   const pendingApproval = useIsPendingApproval(token, spender)
 
   return useMemo(() => {

--- a/src/hooks/useTokenAllowance.ts
+++ b/src/hooks/useTokenAllowance.ts
@@ -12,18 +12,18 @@ export function useTokenAllowance(
   owner?: string,
   spender?: string
 ): {
-  amount: CurrencyAmount<Token> | undefined
-  syncing: boolean
+  tokenAllowance: CurrencyAmount<Token> | undefined
+  isSyncing: boolean
 } {
   const contract = useTokenContract(token?.address, false)
 
   const inputs = useMemo(() => [owner, spender], [owner, spender])
-  const { result, syncing } = useSingleCallResult(contract, 'allowance', inputs)
+  const { result, syncing: isSyncing } = useSingleCallResult(contract, 'allowance', inputs)
 
   return useMemo(() => {
-    const amount = token && result && CurrencyAmount.fromRawAmount(token, result.toString())
-    return { amount, syncing }
-  }, [result, syncing, token])
+    const tokenAllowance = token && result && CurrencyAmount.fromRawAmount(token, result.toString())
+    return { tokenAllowance, isSyncing }
+  }, [isSyncing, result, token])
 }
 
 export function useUpdateTokenAllowance(amount: CurrencyAmount<Token> | undefined, spender: string) {

--- a/src/hooks/useTokenAllowance.ts
+++ b/src/hooks/useTokenAllowance.ts
@@ -7,16 +7,23 @@ import { calculateGasMargin } from 'utils/calculateGasMargin'
 
 import { useTokenContract } from './useContract'
 
-export function useTokenAllowance(token?: Token, owner?: string, spender?: string): CurrencyAmount<Token> | undefined {
+export function useTokenAllowance(
+  token?: Token,
+  owner?: string,
+  spender?: string
+): {
+  amount: CurrencyAmount<Token> | undefined
+  syncing: boolean
+} {
   const contract = useTokenContract(token?.address, false)
 
   const inputs = useMemo(() => [owner, spender], [owner, spender])
-  const allowance = useSingleCallResult(contract, 'allowance', inputs).result
+  const { result, syncing } = useSingleCallResult(contract, 'allowance', inputs)
 
-  return useMemo(
-    () => (token && allowance ? CurrencyAmount.fromRawAmount(token, allowance.toString()) : undefined),
-    [token, allowance]
-  )
+  return useMemo(() => {
+    const amount = token && result && CurrencyAmount.fromRawAmount(token, result.toString())
+    return { amount, syncing }
+  }, [result, syncing, token])
 }
 
 export function useUpdateTokenAllowance(amount: CurrencyAmount<Token> | undefined, spender: string) {


### PR DESCRIPTION
Add a `pending` state to `permit` which, once an approval is submitted, will flip to `true` and not flip back to `false` until the allowance has re-synced. This ensures that the UI stays in a pending state until an approval is processed, without re-prompting for approval.