### PR TITLE
fix: track approval even if signature is rejected

### DIFF
--- a/src/components/Swap/SwapActionButton/AllowanceButton.tsx
+++ b/src/components/Swap/SwapActionButton/AllowanceButton.tsx
@@ -6,20 +6,18 @@ import { usePendingApproval } from 'hooks/transactions'
 import { AllowanceRequired } from 'hooks/usePermit2Allowance'
 import { Spinner } from 'icons'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ApprovalTransactionInfo } from 'state/transactions'
 import { Colors } from 'theme'
 import { ExplorerDataType } from 'utils/getExplorerLink'
 
 interface AllowanceButtonProps extends AllowanceRequired {
   color: keyof Colors
-  onSubmit: (submit: () => Promise<ApprovalTransactionInfo | void>) => Promise<void>
 }
 
 /**
  * An approving AllowanceButton.
  * Should only be rendered if a valid trade exists that is not yet allowed.
  */
-export default function AllowanceButton({ token, isApprovalLoading, callback, color, onSubmit }: AllowanceButtonProps) {
+export default function AllowanceButton({ token, isApprovalLoading, callback, color }: AllowanceButtonProps) {
   const [isPending, setIsPending] = useState(false)
   const [isFailed, setIsFailed] = useState(false)
   const pendingApproval = usePendingApproval(token, PERMIT2_ADDRESS)
@@ -32,7 +30,7 @@ export default function AllowanceButton({ token, isApprovalLoading, callback, co
   const onClick = useCallback(async () => {
     setIsPending(true)
     try {
-      await onSubmit(async () => await callback?.())
+      await callback?.()
       setIsFailed(false)
     } catch (e) {
       console.error(e)
@@ -40,7 +38,7 @@ export default function AllowanceButton({ token, isApprovalLoading, callback, co
     } finally {
       setIsPending(false)
     }
-  }, [callback, onSubmit])
+  }, [callback])
 
   const action = useMemo(() => {
     if (isPending) {

--- a/src/components/Swap/SwapActionButton/AllowanceButton.tsx
+++ b/src/components/Swap/SwapActionButton/AllowanceButton.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { PERMIT2_ADDRESS } from '@uniswap/permit2-sdk'
 import ActionButton from 'components/ActionButton'
 import EtherscanLink from 'components/EtherscanLink'
-import { useAddTransactionInfo, usePendingApproval } from 'hooks/transactions'
+import { usePendingApproval } from 'hooks/transactions'
 import { AllowanceRequired } from 'hooks/usePermit2Allowance'
 import { Spinner } from 'icons'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -27,11 +27,10 @@ export default function AllowanceButton({ token, isApprovalLoading, approveAndPe
     setIsFailed(false)
   }, [token])
 
-  const addTransactionInfo = useAddTransactionInfo()
   const onClick = useCallback(async () => {
     setIsPending(true)
     try {
-      await approveAndPermit?.(addTransactionInfo)
+      await approveAndPermit?.()
       setIsFailed(false)
     } catch (e) {
       console.error(e)
@@ -39,7 +38,7 @@ export default function AllowanceButton({ token, isApprovalLoading, approveAndPe
     } finally {
       setIsPending(false)
     }
-  }, [addTransactionInfo, approveAndPermit])
+  }, [approveAndPermit])
 
   const action = useMemo(() => {
     if (isPending) {

--- a/src/components/Swap/SwapActionButton/AllowanceButton.tsx
+++ b/src/components/Swap/SwapActionButton/AllowanceButton.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { PERMIT2_ADDRESS } from '@uniswap/permit2-sdk'
 import ActionButton from 'components/ActionButton'
 import EtherscanLink from 'components/EtherscanLink'
-import { usePendingApproval } from 'hooks/transactions'
+import { useAddTransactionInfo, usePendingApproval } from 'hooks/transactions'
 import { AllowanceRequired } from 'hooks/usePermit2Allowance'
 import { Spinner } from 'icons'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -17,7 +17,7 @@ interface AllowanceButtonProps extends AllowanceRequired {
  * An approving AllowanceButton.
  * Should only be rendered if a valid trade exists that is not yet allowed.
  */
-export default function AllowanceButton({ token, isApprovalLoading, callback, color }: AllowanceButtonProps) {
+export default function AllowanceButton({ token, isApprovalLoading, approveAndPermit, color }: AllowanceButtonProps) {
   const [isPending, setIsPending] = useState(false)
   const [isFailed, setIsFailed] = useState(false)
   const pendingApproval = usePendingApproval(token, PERMIT2_ADDRESS)
@@ -27,10 +27,11 @@ export default function AllowanceButton({ token, isApprovalLoading, callback, co
     setIsFailed(false)
   }, [token])
 
+  const addTransactionInfo = useAddTransactionInfo()
   const onClick = useCallback(async () => {
     setIsPending(true)
     try {
-      await callback?.()
+      await approveAndPermit?.(addTransactionInfo)
       setIsFailed(false)
     } catch (e) {
       console.error(e)
@@ -38,7 +39,7 @@ export default function AllowanceButton({ token, isApprovalLoading, callback, co
     } finally {
       setIsPending(false)
     }
-  }, [callback])
+  }, [addTransactionInfo, approveAndPermit])
 
   const action = useMemo(() => {
     if (isPending) {

--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -108,7 +108,7 @@ export default function SwapButton({
 
   if (permit2Enabled) {
     if (!disabled && allowance.state === AllowanceState.REQUIRED) {
-      return <AllowanceButton color={color} onSubmit={onSubmit} {...allowance} />
+      return <AllowanceButton color={color} {...allowance} />
     }
   } else {
     if (!disabled && approval.state !== SwapApprovalState.APPROVED) {

--- a/src/hooks/usePermit2Allowance.ts
+++ b/src/hooks/usePermit2Allowance.ts
@@ -2,12 +2,11 @@ import { PERMIT2_ADDRESS } from '@uniswap/permit2-sdk'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import { STANDARD_L1_BLOCK_TIME } from 'constants/chainInfo'
-import { usePendingApproval } from 'hooks/transactions'
+import { useAddTransactionInfo, usePendingApproval } from 'hooks/transactions'
 import useInterval from 'hooks/useInterval'
 import { PermitSignature, usePermitAllowance, useUpdatePermitAllowance } from 'hooks/usePermitAllowance'
 import { useTokenAllowance, useUpdateTokenAllowance } from 'hooks/useTokenAllowance'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ApprovalTransactionInfo } from 'state/transactions'
 
 enum ApprovalState {
   PENDING,
@@ -25,7 +24,7 @@ export interface AllowanceRequired {
   state: AllowanceState.REQUIRED
   token: Token
   isApprovalLoading: boolean
-  callback: () => Promise<ApprovalTransactionInfo | void>
+  callback: () => Promise<void>
 }
 
 export type Allowance =
@@ -86,16 +85,18 @@ export default function usePermit2Allowance(amount?: CurrencyAmount<Token>, spen
     return (permitAllowance.greaterThan(amount) || permitAllowance.equalTo(amount)) && permitExpiration >= now
   }, [amount, now, permitAllowance, permitExpiration])
 
+  const shouldRequestApproval = !(isApproved || isApprovalLoading)
+  const shouldRequestSignature = !(isPermitted || isSigned)
+  const addTransactionInfo = useAddTransactionInfo()
   const callback = useCallback(async () => {
-    let info: ApprovalTransactionInfo | undefined
-    if (!(isApproved || isApprovalLoading)) {
-      info = await updateTokenAllowance()
+    if (shouldRequestApproval) {
+      const info = await updateTokenAllowance()
+      addTransactionInfo(info)
     }
-    if (!(isPermitted || isSigned)) {
+    if (shouldRequestSignature) {
       await updatePermitAllowance()
     }
-    return info
-  }, [isApprovalLoading, isApproved, isPermitted, isSigned, updatePermitAllowance, updateTokenAllowance])
+  }, [addTransactionInfo, shouldRequestApproval, shouldRequestSignature, updatePermitAllowance, updateTokenAllowance])
 
   return useMemo(() => {
     if (token) {


### PR DESCRIPTION
Moves approval tracking into its callback, so that a rejection of signing does not discard tracking the approval.