### PR TITLE
feat: change reverse icon

### DIFF
--- a/src/assets/svg/reverse.svg
+++ b/src/assets/svg/reverse.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="20" viewBox="0 0 14 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.33317 5.41663L9.08317 1.66663M9.08317 1.66663L12.8332 5.41663M9.08317 1.66663V9.99996M8.6665 14.5833L4.9165 18.3333M4.9165 18.3333L1.1665 14.5833M4.9165 18.3333L4.9165 10.8333" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Swap/ReverseButton.tsx
+++ b/src/components/Swap/ReverseButton.tsx
@@ -1,5 +1,5 @@
 import { useSwapInfo, useSwitchSwapCurrencies } from 'hooks/swap'
-import { ArrowDown, LargeIcon } from 'icons'
+import { LargeIcon, Reverse } from 'icons'
 import styled from 'styled-components/macro'
 import { Layer } from 'theme'
 
@@ -35,7 +35,7 @@ export default function ReverseButton() {
   return (
     <Underlayer>
       <StyledReverseButton disabled={isDisabled} onClick={switchCurrencies}>
-        <LargeIcon icon={ArrowDown} />
+        <LargeIcon icon={Reverse} />
       </StyledReverseButton>
     </Underlayer>
   )

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as CheckIcon } from 'assets/svg/check.svg'
 import { ReactComponent as ExpandoIcon } from 'assets/svg/expando.svg'
 import { ReactComponent as InlineSpinnerIcon } from 'assets/svg/inline_spinner.svg'
 import { ReactComponent as LogoIcon } from 'assets/svg/logo.svg'
+import { ReactComponent as ReverseIcon } from 'assets/svg/reverse.svg'
 import { ReactComponent as SpinnerIcon } from 'assets/svg/spinner.svg'
 import { ReactComponent as WalletIcon } from 'assets/svg/wallet.svg'
 import { ReactComponent as WalletDisconnectIcon } from 'assets/svg/wallet_disconnect.svg'
@@ -100,6 +101,7 @@ export const Trash2 = icon(Trash2Icon)
 export const Wallet = icon(WalletIcon)
 export const X = icon(XIcon)
 export const XOctagon = icon(XOctagonIcon)
+export const Reverse = icon(ReverseIcon)
 
 export const Check = styled(icon(CheckIcon))`
   circle {


### PR DESCRIPTION
updates the "reverse input/output currencies" icon to match design

design file: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=10381%3A101862&t=VFd894XSQCCzBYD0-4

verified that this correctly flips colors between light and dark mode