### PR TITLE
feat: styling updates to widget input step

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -56,7 +56,7 @@ const actionCss = css`
 export const Overlay = styled(Row)<{ hasAction: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius}em;
   flex-direction: row-reverse;
-  margin-top: 12px;
+  margin-top: 0.75em;
   min-height: 3.5em;
   transition: padding 0.25s ease-out;
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,5 +1,3 @@
-import { loadingOpacity } from 'css/loading'
-import { transparentize } from 'polished'
 import { ChangeEvent, forwardRef, HTMLProps, useCallback } from 'react'
 import styled, { css } from 'styled-components/macro'
 
@@ -34,20 +32,11 @@ const Input = styled.input`
   }
 
   ::placeholder {
-    color: ${({ theme }) => theme.secondary};
+    color: ${({ theme }) => theme.hint};
   }
 
   :enabled {
     transition: color 0.125s linear;
-  }
-
-  :disabled {
-    // Overrides WebKit's override of input:disabled color.
-    -webkit-text-fill-color: ${({ theme }) => transparentize(1 - loadingOpacity, theme.primary)};
-    color: ${({ theme }) => transparentize(1 - loadingOpacity, theme.primary)};
-    ::placeholder {
-      color: ${({ theme }) => transparentize(1 - loadingOpacity, theme.primary)};
-    }
   }
 `
 

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -1,4 +1,4 @@
-import { Trans } from '@lingui/macro'
+import { t, Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import { TextButton } from 'components/Button'
 import { loadingTransitionCss } from 'css/loading'
@@ -33,12 +33,12 @@ const InputColumn = styled(Column)<{ disableHover?: boolean; isWide: boolean }>`
   background-color: ${({ theme }) => theme.module};
   border-radius: ${({ theme }) => theme.borderRadius - 0.25}em;
   margin-bottom: 4px;
-  padding: ${({ isWide }) => (isWide ? '1rem 0' : '1rem 0 1.5rem')};
+  padding: ${({ isWide }) => (isWide ? '1em 0' : '1em 0 1.5em')};
   position: relative;
 
   &:before {
     background-size: 100%;
-    border: 1px solid ${({ theme }) => theme.module};
+    border: 1px solid transparent;
     border-radius: inherit;
     box-sizing: border-box;
     content: '';
@@ -58,7 +58,7 @@ const InputColumn = styled(Column)<{ disableHover?: boolean; isWide: boolean }>`
       }
 
       &:focus-within:before {
-        border-color: ${theme.outline};
+        border-color: ${theme.networkDefaultShadow};
       }`}
 `
 
@@ -86,6 +86,7 @@ interface FieldWrapperProps {
   isSufficientBalance?: boolean
   approved?: boolean
   impact?: PriceImpact
+  subheader: string
 }
 
 export function FieldWrapper({
@@ -95,6 +96,7 @@ export function FieldWrapper({
   approved,
   impact,
   className,
+  subheader,
 }: FieldWrapperProps & { className?: string }) {
   const {
     [field]: { balance, amount: currencyAmount, usdc },
@@ -146,6 +148,9 @@ export function FieldWrapper({
       onClick={onClick}
       className={className}
     >
+      <Row pad={1 /* em */}>
+        <ThemedText.Subhead2 color={'secondary'}>{subheader}</ThemedText.Subhead2>
+      </Row>
       <TokenInput
         ref={setInput}
         field={field}
@@ -214,6 +219,7 @@ export default function Input() {
       maxAmount={maxAmount}
       isSufficientBalance={isSufficientBalance}
       approved={approvalState === SwapApprovalState.APPROVED}
+      subheader={t`You Pay`}
     />
   )
 }

--- a/src/components/Swap/Output.tsx
+++ b/src/components/Swap/Output.tsx
@@ -1,3 +1,4 @@
+import { t } from '@lingui/macro'
 import { useSwapCurrency, useSwapInfo } from 'hooks/swap'
 import useCurrencyColor from 'hooks/useCurrencyColor'
 import { useIsWideWidget } from 'hooks/useWidgetWidth'
@@ -15,8 +16,8 @@ const OutputWrapper = styled(FieldWrapper)<{ hasColor?: boolean | null; isWide: 
   border-bottom: 1px solid ${({ theme }) => theme.container};
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  margin-bottom: 0;
-  padding: ${({ isWide }) => (isWide ? '1rem 0' : '1.5rem 0 1rem')};
+  padding: ${({ isWide }) => (isWide ? '1em 0' : '1.5em 0 1em')};
+  margin-bottom: 0.75em;
 
   // Set transitions to reduce color flashes when switching color/token.
   // When color loads, transition the background so that it transitions from the empty or last state, but not _to_ the empty state.
@@ -40,7 +41,13 @@ export default function Output() {
 
   return (
     <DynamicThemeProvider color={color}>
-      <OutputWrapper isWide={isWideWidget} field={Field.OUTPUT} impact={impact} hasColor={hasColor} />
+      <OutputWrapper
+        isWide={isWideWidget}
+        field={Field.OUTPUT}
+        impact={impact}
+        hasColor={hasColor}
+        subheader={t`You receive`}
+      />
     </DynamicThemeProvider>
   )
 }

--- a/src/components/Swap/ReverseButton.tsx
+++ b/src/components/Swap/ReverseButton.tsx
@@ -19,7 +19,7 @@ const Underlayer = styled.div`
 
 const StyledReverseButton = styled(Button)`
   align-items: center;
-  background-color: ${({ theme }) => theme.interactive};
+  background-color: ${({ theme }) => theme.module};
   border: 4px solid ${({ theme }) => theme.container};
   border-radius: ${({ theme }) => theme.borderRadius}em;
   display: flex;

--- a/src/components/Swap/TokenInput.tsx
+++ b/src/components/Swap/TokenInput.tsx
@@ -25,7 +25,7 @@ const ValueInput = styled(DecimalInput)`
 `
 
 const TokenInputColumn = styled(Column)`
-  margin: 0 16px;
+  margin: 0.5em 1em 0;
 `
 
 export interface TokenInputHandle {

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -11,8 +11,7 @@ import * as Caption from './Caption'
 
 const ToolbarRow = styled(Row)`
   background-color: ${({ theme }) => theme.module};
-  border-bottom-left-radius: ${({ theme }) => theme.borderRadius - 0.25}em;
-  border-bottom-right-radius: ${({ theme }) => theme.borderRadius - 0.25}em;
+  border-radius: ${({ theme }) => theme.borderRadius - 0.25}em;
   gap: 0.5em;
   min-height: 44px;
   padding: 14px 16px;

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -23,7 +23,6 @@ const StyledTokenButton = styled(Button)<{ approved?: boolean }>`
 
 const TokenButtonRow = styled(Row)<{ empty: boolean }>`
   flex-direction: row;
-  height: 1.2em;
   max-width: 12em;
   overflow: hidden;
   padding-left: ${({ empty }) => empty && 0.5}em;
@@ -54,7 +53,7 @@ export default function TokenButton({ value, approved, disabled, onClick }: Toke
         <TokenButtonRow empty={!value} flex gap={0.4}>
           {value ? (
             <>
-              <TokenImg token={value} size={1.2} />
+              <TokenImg token={value} size={1.75} />
               <span>{value.symbol}</span>
             </>
           ) : (

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -11,7 +11,9 @@ const StyledWidgetWrapper = styled.div<{ width: number | string }>`
   -webkit-font-smoothing: antialiased;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   background-color: ${({ theme }) => theme.container};
+  border: ${({ theme }) => `1px solid ${theme.outline}`};
   border-radius: ${({ theme }) => theme.borderRadius}em;
+  box-shadow: ${({ theme }) => `0px 40px 120px 0px ${theme.networkDefaultShadow}`};
   box-sizing: border-box;
   color: ${({ theme }) => theme.primary};
   display: flex;

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -15,7 +15,7 @@ export * as ThemedText from './type'
 const white = 'hsl(0, 0%, 100%)'
 const black = 'hsl(0, 0%, 0%)'
 
-const brandLight = 'hsl(331.3, 100%, 50%)'
+const brandLight = 'hsl(328, 97%, 53%)'
 const brandDark = 'hsl(221, 96%, 64%)'
 export const brand = brandLight
 
@@ -29,18 +29,20 @@ const stateColors = {
 export const lightTheme: Colors = {
   // surface
   accent: brandLight,
-  container: 'hsl(220, 23%, 97.5%)',
-  module: 'hsl(231, 14%, 90%)',
-  interactive: 'hsl(229, 13%, 83%)',
-  outline: 'hsl(225, 7%, 78%)',
+  container: 'hsl(0, 0%, 100%)',
+  module: 'hsl(231, 54%, 97%)',
+  interactive: 'hsl(227, 70%, 95%)',
+  outline: 'hsla(225, 18%, 44%, 0.24)',
   dialog: white,
 
   // text
   onAccent: white,
-  primary: black,
-  secondary: 'hsl(227, 10%, 37.5%)',
-  hint: 'hsl(224, 9%, 57%)',
+  primary: 'hsl(224, 37%, 8%)',
+  secondary: 'hsl(227, 18%, 55%)',
+  hint: 'hsl(226, 24%, 67%)',
   onInteractive: black,
+
+  networkDefaultShadow: 'hsla(328, 97%, 53%, 0.12)',
 
   // state
   ...stateColors,
@@ -51,10 +53,10 @@ export const lightTheme: Colors = {
 export const darkTheme: Colors = {
   // surface
   accent: brandDark,
-  container: 'hsl(225, 30%, 8%)',
+  container: 'hsla(224, 37%, 8%, 1)',
   module: 'hsl(222, 37%, 12%)',
-  interactive: 'hsl(223, 28%, 22%)',
-  outline: 'hsl(227, 10%, 37.5%)',
+  interactive: 'hsla(223, 28%, 22%, 1)',
+  outline: 'hsl(224, 33%, 16%)',
   dialog: black,
 
   // text
@@ -63,6 +65,8 @@ export const darkTheme: Colors = {
   secondary: 'hsl(227, 21%, 67%)',
   hint: 'hsl(225, 10%, 47.1%)',
   onInteractive: white,
+
+  networkDefaultShadow: 'hsla(221, 96%, 64%, 0.16)',
 
   // state
   ...stateColors,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -20,6 +20,8 @@ export interface Colors {
   warning: string
   error: string
 
+  networkDefaultShadow: string
+
   currentColor: 'currentColor'
 }
 

--- a/src/theme/type.tsx
+++ b/src/theme/type.tsx
@@ -48,7 +48,7 @@ export function Subhead1(props: TextProps) {
 
 export function Subhead2(props: TextProps) {
   return (
-    <TextWrapper className="subhead subhead-2" fontSize={14} fontWeight={500} lineHeight="14px" noWrap {...props} />
+    <TextWrapper className="subhead subhead-2" fontSize={14} fontWeight={500} lineHeight="20px" noWrap {...props} />
   )
 }
 
@@ -82,7 +82,7 @@ export function ButtonMedium(props: TextProps) {
 
 export function ButtonSmall(props: TextProps) {
   return (
-    <TextWrapper className="button button-small" fontSize={14} fontWeight={500} lineHeight="14px" noWrap {...props} />
+    <TextWrapper className="button button-small" fontSize={14} fontWeight={600} lineHeight="14px" noWrap {...props} />
   )
 }
 


### PR DESCRIPTION
design spec: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=10575%3A115233&t=VFd894XSQCCzBYD0-4


updates sizings, spacings, and colors for the main widget root component, and the input/output fields. This PR focuses on the "input" step, which includes the initial view with and without tokens selected.
this also updates the colors in the theme to match the new design.

<img width="382" alt="image" src="https://user-images.githubusercontent.com/66155195/210455366-7d235c71-6962-43a8-b713-562a3953c219.png">
<img width="382" alt="image" src="https://user-images.githubusercontent.com/66155195/210455462-e5485a88-5c1e-41d3-9990-27cb24b88298.png">

