### PR TITLE
feat: move i18n initialization logic to the Context Provider

### DIFF
--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -1,7 +1,7 @@
 import { TokenInfo } from '@uniswap/token-lists'
 import { Animation, Modal, Provider as DialogProvider } from 'components/Dialog'
 import ErrorBoundary, { OnError } from 'components/Error/ErrorBoundary'
-import { DEFAULT_LOCALE, SUPPORTED_LOCALES, SupportedLocale } from 'constants/locales'
+import { SupportedLocale } from 'constants/locales'
 import { TransactionEventHandlers, TransactionsUpdater } from 'hooks/transactions'
 import { Provider as BlockNumberProvider } from 'hooks/useBlockNumber'
 import { Flags, useInitialFlags } from 'hooks/useSyncFlags'
@@ -107,19 +107,13 @@ export default function Widget(props: PropsWithChildren<WidgetProps>) {
     }
     return props.width ?? 360
   }, [props.width])
-  const locale = useMemo(() => {
-    if (props.locale && ![...SUPPORTED_LOCALES, 'pseudo'].includes(props.locale)) {
-      console.warn(`Unsupported locale: ${props.locale}. Falling back to ${DEFAULT_LOCALE}.`)
-      return DEFAULT_LOCALE
-    }
-    return props.locale ?? DEFAULT_LOCALE
-  }, [props.locale])
+
   const [dialog, setDialog] = useState<HTMLDivElement | null>(props.dialog || null)
   return (
     <StrictMode>
       <ThemeProvider theme={props.theme}>
         <WidgetWrapper width={width} className={props.className}>
-          <I18nProvider locale={locale}>
+          <I18nProvider locale={props.locale}>
             <DialogWrapper ref={setDialog} />
             <DialogProvider value={props.dialog || dialog}>
               <ErrorBoundary onError={props.onError}>

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -1,6 +1,6 @@
 import { i18n } from '@lingui/core'
 import { I18nProvider } from '@lingui/react'
-import { DEFAULT_LOCALE, SupportedLocale } from 'constants/locales'
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, SupportedLocale } from 'constants/locales'
 import {
   af,
   ar,
@@ -34,7 +34,7 @@ import {
   zh,
 } from 'make-plural/plurals'
 import { PluralCategory } from 'make-plural/plurals'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useMemo } from 'react'
 
 type LocalePlural = {
   [key in SupportedLocale]: (n: number | string, ord?: boolean) => PluralCategory
@@ -87,7 +87,7 @@ export async function dynamicActivate(locale: SupportedLocale) {
 }
 
 interface ProviderProps {
-  locale: SupportedLocale
+  locale?: SupportedLocale
   forceRenderAfterLocaleChange?: boolean
   onActivate?: (locale: SupportedLocale) => void
   children: ReactNode
@@ -98,13 +98,21 @@ export function TestableProvider({ locale, forceRenderAfterLocaleChange, childre
 }
 
 export function Provider({ locale, forceRenderAfterLocaleChange = true, onActivate, children }: ProviderProps) {
+  const processedLocale = useMemo(() => {
+    if (locale && ![...SUPPORTED_LOCALES, 'pseudo'].includes(locale)) {
+      console.warn(`Unsupported locale: ${locale}. Falling back to ${DEFAULT_LOCALE}.`)
+      return DEFAULT_LOCALE
+    }
+    return locale ?? DEFAULT_LOCALE
+  }, [locale])
+
   useEffect(() => {
-    dynamicActivate(locale)
-      .then(() => onActivate?.(locale))
+    dynamicActivate(processedLocale)
+      .then(() => onActivate?.(processedLocale))
       .catch((error) => {
-        console.error('Failed to activate locale', locale, error)
+        console.error('Failed to activate locale', processedLocale, error)
       })
-  }, [locale, onActivate])
+  }, [processedLocale, onActivate])
 
   // Initialize the locale immediately if it is DEFAULT_LOCALE, so that keys are shown while the translation messages load.
   // This renders the translation _keys_, not the translation _messages_, which is only acceptable while loading the DEFAULT_LOCALE,


### PR DESCRIPTION
simply moving the i18n initialization logic to the `I18nProvider` since it doesn't need to exist in the top level `Widget`. Tested and verified that the behavior is unchanged.