### PR TITLE
fix: simplify async error throwing

### DIFF
--- a/src/components/Error/ErrorBoundary.tsx
+++ b/src/components/Error/ErrorBoundary.tsx
@@ -1,10 +1,8 @@
 import { DEFAULT_ERROR_ACTION, DEFAULT_ERROR_HEADER, WidgetError } from 'errors'
-import { Component, createContext, ErrorInfo, PropsWithChildren, useContext } from 'react'
+import { Component, ErrorInfo, PropsWithChildren, useCallback, useState } from 'react'
 
 import Dialog from '../Dialog'
 import ErrorDialog from './ErrorDialog'
-
-const ErrorContext = createContext<{ setError: (e: WidgetError) => void }>({ setError: () => undefined })
 
 export type OnError = (error: Error, info?: ErrorInfo) => void
 
@@ -16,8 +14,28 @@ type ErrorBoundaryState = {
   error?: Error
 }
 
-export function useSetError() {
-  return useContext(ErrorContext).setError
+/**
+ * Throws an error from outside of the React lifecycle.
+ * Errors thrown through this method will correctly trigger the ErrorBoundary.
+ *
+ * @example
+ * const throwError = useAsyncError()
+ * useEffect(() => {
+ *   fetch('http://example.com')
+ *     .catch((e: Error) => {
+ *       throwError(toWidgetError(e))
+ *     })
+ * }, [throwError])
+ */
+export function useAsyncError() {
+  const [, setError] = useState()
+  return useCallback(
+    (e: WidgetError) =>
+      setError(() => {
+        throw e
+      }),
+    []
+  )
 }
 
 export default class ErrorBoundary extends Component<PropsWithChildren<ErrorBoundaryProps>, ErrorBoundaryState> {
@@ -53,6 +71,6 @@ export default class ErrorBoundary extends Component<PropsWithChildren<ErrorBoun
     if (this.state.error) {
       return this.renderErrorDialog(this.state.error)
     }
-    return <ErrorContext.Provider value={{ setError: this.setError }}>{this.props.children}</ErrorContext.Provider>
+    return this.props.children
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,11 +3,17 @@ import { t } from '@lingui/macro'
 export const DEFAULT_ERROR_HEADER = t`Please refresh the page and try again.`
 export const DEFAULT_ERROR_ACTION = t`Reload the page`
 
+interface WidgetErrorConfig {
+  header?: string
+  action?: string
+  message?: string
+}
+
 export abstract class WidgetError extends Error {
   header: string
   action: string
 
-  constructor(config: { header?: string; action?: string; message?: string }) {
+  constructor(config: WidgetErrorConfig) {
     super(config.message)
     this.header = config.header ?? DEFAULT_ERROR_HEADER
     this.action = config.action ?? DEFAULT_ERROR_ACTION
@@ -17,11 +23,16 @@ export abstract class WidgetError extends Error {
 export class IntegrationError extends WidgetError {
   constructor(message: string) {
     super({ message })
-    this.name = 'Integration Error'
+    this.name = 'IntegrationError'
   }
 }
 
-class ConnectionError extends WidgetError {}
+class ConnectionError extends WidgetError {
+  constructor(config: WidgetErrorConfig) {
+    super(config)
+    this.name = 'ConnectionError'
+  }
+}
 
 export class MetaMaskConnectionError extends ConnectionError {
   constructor() {


### PR DESCRIPTION
Simplifies async error throwing using the method detailed in https://medium.com/trabe/catching-asynchronous-errors-in-react-using-error-boundaries-5e8a5fd7b971.

Follow-ups:
- [ ] Convert async errors to use this method.
- [ ] Convert EIP-1193 error codes (constants/eip1193.ts) to use WidgetError.
- [ ] Convert utils/swapErrorToUserReadableMessage.tsx to use WidgetError.