### PR TITLE
test: eliminate warnings in e2e testing

### DIFF
--- a/e2e/connect.test.tsx
+++ b/e2e/connect.test.tsx
@@ -7,22 +7,16 @@ import 'jest-environment-hardhat'
 
 import { SwapWidget } from 'index'
 import React, { ReactElement } from 'react'
-import { render, waitFor } from 'test'
+
+import { cleanup, render, waitFor } from './test'
 
 const HARDHAT_ACCOUNT_DISPLAY_STRING = `${hardhat.account.address?.substring(
   0,
   6
 )}...${hardhat.account.address?.substring(hardhat.account.address.length - 4)}`
 
-declare global {
-  // eslint-disable-next-line no-var
-  var IS_REACT_ACT_ENVIRONMENT: boolean
-}
-
-beforeAll(() => {
-  // End-to-end tests do not need to run in an act environment.
-  global.IS_REACT_ACT_ENVIRONMENT = false
-})
+// We are testing different configurations of the widget, so we must run cleanup between tests.
+afterEach(cleanup)
 
 describe('connect', () => {
   // MetaMask uses a 3000ms timeout to detect window.ethereum.

--- a/e2e/test/index.ts
+++ b/e2e/test/index.ts
@@ -1,0 +1,15 @@
+/**
+ * End-to-end tests import from pure, a non-act environment which does not run cleanup between tests.
+ * Using an act environment would require mocking out all asynchronous calls, which is too arduous.
+ *
+ * If they require cleanup, they should run it explicitly:
+ *
+ *     afterEach(cleanup)
+ */
+import { waitFor as waitForBase, waitForOptions } from '@testing-library/react'
+export * from '@testing-library/react/pure'
+
+export function waitFor(callback: () => unknown, options?: Omit<waitForOptions, 'timeout'>) {
+  // Increase the default timeout to the default L1 block interval (as tests will fork mainnet).
+  return waitForBase(callback, { ...options, timeout: 12000 })
+}

--- a/src/hooks/swap/useSyncController.ts
+++ b/src/hooks/swap/useSyncController.ts
@@ -1,7 +1,7 @@
-import { useUpdateAtom } from 'jotai/utils'
+import { useAtom } from 'jotai'
 import { useEffect, useRef } from 'react'
-import { controlledAtom as swapAtom, Swap } from 'state/swap'
-import { controlledAtom as settingsAtom, Settings } from 'state/swap/settings'
+import { controlledAtom as controlledSwapAtom, Swap } from 'state/swap'
+import { controlledAtom as controlledSettingsAtom, Settings } from 'state/swap/settings'
 
 export interface SwapController {
   value?: Swap
@@ -21,11 +21,15 @@ export default function useSyncController({ value, settings }: SwapController): 
     }
   }, [settings, value])
 
-  const setSwap = useUpdateAtom(swapAtom)
-  setSwap(() => value)
+  const [controlledSwap, setControlledSwap] = useAtom(controlledSwapAtom)
+  if (controlledSwap !== value) {
+    setControlledSwap(value)
+  }
 
-  const setSettings = useUpdateAtom(settingsAtom)
-  setSettings(() => settings)
+  const [controlledSettings, setControlledSettings] = useAtom(controlledSettingsAtom)
+  if (controlledSettings !== settings) {
+    setControlledSettings(settings)
+  }
 }
 
 function warnOnControlChange({ state, prop }: { state: string; prop: string }) {


### PR DESCRIPTION
- Uses a pure act-free environment for testing, so that state changes not wrapped in `act` are permissible
- Avoids settings controlled state when not used, to avoid the "called setState during render" warning