### PR TITLE
feat: Convert settings into popover

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,6 +1,6 @@
 import 'wicg-inert'
 
-import { useCloseOnEscape } from 'hooks/useCloseOnEscape'
+import { useOnEscapeHandler } from 'hooks/useOnEscapeHandler'
 import { ChevronLeft } from 'icons'
 import { largeIconCss } from 'icons'
 import { createContext, ReactElement, ReactNode, useContext, useEffect, useRef, useState } from 'react'
@@ -136,7 +136,7 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
     return (context.element?.childElementCount ?? 0) > 1 ? Animation.PAGING : Animation.CLOSING
   })
 
-  useCloseOnEscape(onClose)
+  useOnEscapeHandler(onClose)
 
   return (
     context.element &&

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,5 +1,6 @@
 import 'wicg-inert'
 
+import { useCloseOnEscape } from 'hooks/useCloseOnEscape'
 import { ChevronLeft } from 'icons'
 import { largeIconCss } from 'icons'
 import { createContext, ReactElement, ReactNode, useContext, useEffect, useRef, useState } from 'react'
@@ -135,11 +136,8 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
     return (context.element?.childElementCount ?? 0) > 1 ? Animation.PAGING : Animation.CLOSING
   })
 
-  useEffect(() => {
-    const close = (e: KeyboardEvent) => e.key === 'Escape' && onClose?.()
-    document.addEventListener('keydown', close, true)
-    return () => document.removeEventListener('keydown', close, true)
-  }, [onClose])
+  useCloseOnEscape(onClose)
+
   return (
     context.element &&
     createPortal(

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,10 +10,6 @@ const HeaderRow = styled(Row)`
   margin: 0 0.75em 1em;
   padding-top: 0.25em;
   ${largeIconCss}
-
-  button {
-    height: ${({ iconSize }) => iconSize}em;
-  }
 `
 
 export interface HeaderProps {

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -8,7 +8,8 @@ import { Layer } from 'theme'
 
 const BoundaryContext = createContext<HTMLDivElement | null>(null)
 
-export const BoundaryProvider = BoundaryContext.Provider
+/** Defines a boundary component past which a Popover should not overflow. */
+export const PopoverBoundaryProvider = BoundaryContext.Provider
 
 const PopoverContainer = styled.div<{ show: boolean }>`
   background-color: ${({ theme }) => theme.dialog};

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -85,9 +85,18 @@ export interface PopoverProps {
   placement: Placement
   offset?: number
   contained?: true
+  showArrow?: boolean
 }
 
-export default function Popover({ content, show, children, placement, offset, contained }: PopoverProps) {
+export default function Popover({
+  content,
+  show,
+  children,
+  placement,
+  offset,
+  contained,
+  showArrow = true,
+}: PopoverProps) {
   const boundary = useContext(BoundaryContext)
   const reference = useRef<HTMLDivElement>(null)
 
@@ -138,12 +147,14 @@ export default function Popover({ content, show, children, placement, offset, co
         createPortal(
           <PopoverContainer show={show} ref={setPopover} style={styles.popper} {...attributes.popper}>
             {content}
-            <Arrow
-              className={`arrow-${attributes.popper?.['data-popper-placement'] ?? ''}`}
-              ref={setArrow}
-              style={styles.arrow}
-              {...attributes.arrow}
-            />
+            {showArrow && (
+              <Arrow
+                className={`arrow-${attributes.popper?.['data-popper-placement'] ?? ''}`}
+                ref={setArrow}
+                style={styles.arrow}
+                {...attributes.arrow}
+              />
+            )}
           </PopoverContainer>,
           boundary
         )}

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -8,7 +8,7 @@ import { Layer } from 'theme'
 
 const BoundaryContext = createContext<HTMLDivElement | null>(null)
 
-/** Defines a boundary component past which a Popover should not overflow. */
+/* Defines a boundary component past which a Popover should not overflow. */
 export const PopoverBoundaryProvider = BoundaryContext.Provider
 
 const PopoverContainer = styled.div<{ show: boolean }>`

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -1,3 +1,4 @@
+import { useCloseOnEscape } from 'hooks/useCloseOnEscape'
 import { Settings as SettingsIcon } from 'icons'
 import { useState } from 'react'
 import styled from 'styled-components/macro'
@@ -11,6 +12,7 @@ import TransactionTtlInput from './TransactionTtlInput'
 export function SettingsPopover() {
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
 
+  // TODO: add back reset settings functionality
   return (
     <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
       <PopoverBoundaryProvider value={boundary}>
@@ -31,6 +33,8 @@ const SettingsButton = styled(IconButton)`
 export default function Settings() {
   const [open, setOpen] = useState(false)
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
+
+  useCloseOnEscape(() => setOpen(false))
 
   return (
     <div ref={setWrapper}>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { useCloseOnEscape } from 'hooks/useCloseOnEscape'
+import { useOnEscapeHandler } from 'hooks/useOnEscapeHandler'
 import { Settings as SettingsIcon } from 'icons'
 import { useState } from 'react'
 import styled from 'styled-components/macro'
@@ -34,7 +34,7 @@ export default function Settings() {
   const [open, setOpen] = useState(false)
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
 
-  useCloseOnEscape(() => setOpen(false))
+  useOnEscapeHandler(() => setOpen(false))
 
   return (
     <div ref={setWrapper}>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -30,7 +30,7 @@ const SettingsButton = styled(IconButton)`
   }
 
   ${SettingsIcon} {
-    transform: rotate(-45deg);
+    transform: rotate(0);
     transition: transform 0.25s;
   }
 `

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -12,7 +12,7 @@ import TransactionTtlInput from './TransactionTtlInput'
 export function SettingsPopover() {
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
 
-  // TODO: add back reset settings functionality
+  // TODO (WEB-2754): add back reset settings functionality
   return (
     <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
       <PopoverBoundaryProvider value={boundary}>
@@ -26,6 +26,11 @@ export function SettingsPopover() {
 const SettingsButton = styled(IconButton)`
   ${SettingsIcon}:hover {
     transform: rotate(45deg);
+    transition: transform 0.25s;
+  }
+
+  ${SettingsIcon} {
+    transform: rotate(-45deg);
     transition: transform 0.25s;
   }
 `

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components/macro'
 
 import { IconButton } from '../../Button'
 import Column from '../../Column'
-import Popover, { BoundaryProvider } from '../../Popover'
+import Popover, { PopoverBoundaryProvider } from '../../Popover'
 import MaxSlippageSelect from './MaxSlippageSelect'
 import TransactionTtlInput from './TransactionTtlInput'
 
@@ -13,10 +13,10 @@ export function SettingsPopover() {
 
   return (
     <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
-      <BoundaryProvider value={boundary}>
+      <PopoverBoundaryProvider value={boundary}>
         <MaxSlippageSelect />
         <TransactionTtlInput />
-      </BoundaryProvider>
+      </PopoverBoundaryProvider>
     </Column>
   )
 }
@@ -34,11 +34,11 @@ export default function Settings() {
 
   return (
     <div ref={setWrapper}>
-      <BoundaryProvider value={wrapper}>
+      <PopoverBoundaryProvider value={wrapper}>
         <Popover showArrow={false} offset={10} show={open} placement="top-end" content={<SettingsPopover />}>
           <SettingsButton onClick={() => setOpen(!open)} icon={SettingsIcon} />
         </Popover>
-      </BoundaryProvider>
+      </PopoverBoundaryProvider>
     </div>
   )
 }

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -1,72 +1,44 @@
-import { Trans } from '@lingui/macro'
 import { Settings as SettingsIcon } from 'icons'
-import { useAtomValue, useResetAtom } from 'jotai/utils'
-import { useCallback, useState } from 'react'
-import { swapEventHandlersAtom } from 'state/swap'
-import { settingsAtom } from 'state/swap/settings'
+import { useState } from 'react'
 import styled from 'styled-components/macro'
-import { ThemedText } from 'theme'
 
-import { IconButton, TextButton } from '../../Button'
+import { IconButton } from '../../Button'
 import Column from '../../Column'
-import Dialog, { Header } from '../../Dialog'
-import { BoundaryProvider } from '../../Popover'
+import Popover, { BoundaryProvider } from '../../Popover'
 import MaxSlippageSelect from './MaxSlippageSelect'
 import TransactionTtlInput from './TransactionTtlInput'
 
-export function SettingsDialog() {
+export function SettingsPopover() {
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
-  const { onSettingsReset } = useAtomValue(swapEventHandlersAtom)
-  const resetSettingsBase = useResetAtom(settingsAtom)
-  const resetSettings = useCallback(() => {
-    onSettingsReset?.()
-    resetSettingsBase()
-  }, [onSettingsReset, resetSettingsBase])
+
   return (
-    <>
-      <Header title={<Trans>Settings</Trans>} ruled>
-        <TextButton onClick={resetSettings}>
-          <ThemedText.ButtonSmall>
-            <Trans>Reset</Trans>
-          </ThemedText.ButtonSmall>
-        </TextButton>
-      </Header>
-      <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
-        <BoundaryProvider value={boundary}>
-          <MaxSlippageSelect />
-          <TransactionTtlInput />
-        </BoundaryProvider>
-      </Column>
-    </>
+    <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
+      <BoundaryProvider value={boundary}>
+        <MaxSlippageSelect />
+        <TransactionTtlInput />
+      </BoundaryProvider>
+    </Column>
   )
 }
 
-const SettingsButton = styled(IconButton)<{ hover: boolean }>`
-  ${SettingsIcon} {
-    transform: ${({ hover }) => hover && 'rotate(45deg)'};
-    transition: ${({ hover }) => hover && 'transform 0.25s'};
-    will-change: transform;
+const SettingsButton = styled(IconButton)`
+  ${SettingsIcon}:hover {
+    transform: rotate(45deg);
+    transition: transform 0.25s;
   }
 `
 
-export default function Settings({ disabled }: { disabled?: boolean }) {
+export default function Settings() {
   const [open, setOpen] = useState(false)
-  const [hover, setHover] = useState(false)
+  const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
+
   return (
-    <>
-      <SettingsButton
-        disabled={disabled}
-        hover={hover}
-        onClick={() => setOpen(true)}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
-        icon={SettingsIcon}
-      />
-      {open && (
-        <Dialog color="module" onClose={() => setOpen(false)}>
-          <SettingsDialog />
-        </Dialog>
-      )}
-    </>
+    <div ref={setWrapper}>
+      <BoundaryProvider value={wrapper}>
+        <Popover showArrow={false} offset={10} show={open} placement="top-end" content={<SettingsPopover />}>
+          <SettingsButton onClick={() => setOpen(!open)} icon={SettingsIcon} />
+        </Popover>
+      </BoundaryProvider>
+    </div>
   )
 }

--- a/src/components/Swap/index.tsx
+++ b/src/components/Swap/index.tsx
@@ -15,7 +15,7 @@ import { displayTxHashAtom } from 'state/swap'
 
 import Dialog from '../Dialog'
 import Header from '../Header'
-import { BoundaryProvider } from '../Popover'
+import { PopoverBoundaryProvider } from '../Popover'
 import Input from './Input'
 import Output from './Output'
 import ReverseButton from './ReverseButton'
@@ -55,7 +55,7 @@ export default function Swap(props: SwapProps) {
         <Settings />
       </Header>
       <div ref={setWrapper}>
-        <BoundaryProvider value={wrapper}>
+        <PopoverBoundaryProvider value={wrapper}>
           <SwapInfoProvider routerUrl={props.routerUrl}>
             <Input />
             <ReverseButton />
@@ -64,7 +64,7 @@ export default function Swap(props: SwapProps) {
             <SwapActionButton />
             {useBrandedFooter() && <BrandedFooter />}
           </SwapInfoProvider>
-        </BoundaryProvider>
+        </PopoverBoundaryProvider>
       </div>
       {displayTx && (
         <Dialog color="dialog">

--- a/src/hooks/useCloseOnEscape.tsx
+++ b/src/hooks/useCloseOnEscape.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+
+export function useCloseOnEscape(onClose?: () => void) {
+  useEffect(() => {
+    if (!onClose) return
+
+    const close = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
+    document.addEventListener('keydown', close, true)
+    return () => document.removeEventListener('keydown', close, true)
+  }, [onClose])
+}

--- a/src/hooks/useOnEscapeHandler.tsx
+++ b/src/hooks/useOnEscapeHandler.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 
-export function useCloseOnEscape(onClose?: () => void) {
+export function useOnEscapeHandler(onClose?: () => void) {
   useEffect(() => {
     if (!onClose) return
 


### PR DESCRIPTION
This PR converts the settings menu from a slide-in dialogue to a popover menu

https://user-images.githubusercontent.com/59578595/211571182-0b35482d-f415-4fe0-8e22-46b9b68efee5.mov

Some other notes:
- removed a `Header button` css property that was effecting sizing of all child buttons - we should define these at an individual level
- followup to do mobile-friendly modal view 
- followup to add drop shadows

 Questions:
- should we add a min-width for the menu?