### PR TITLE
feat: toolbar updates for price impacts

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
 
     // Jest does not always resolve src/test (probably because of babel's TypeScript transpilation):
     '^test/*': '<rootDir>/src/test',
+    '@uniswap/conedison/format': '@uniswap/conedison/dist/format.js',
   },
   setupFiles: ['<rootDir>/test/setup.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/setup-jest.ts'],

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@fontsource/inter": "^4.5.1",
     "@popperjs/core": "^2.4.4",
     "@reduxjs/toolkit": "^1.6.1",
+    "@uniswap/conedison": "^1.1.1",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/redux-multicall": "^1.1.8",
     "@uniswap/router-sdk": "^1.3.0",

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -166,9 +166,9 @@ export function FieldWrapper({
           <Row>
             <USDC isLoading={isRouteLoading}>
               {usdc && `${formatCurrencyAmount({ amount: usdc, isUsdPrice: true })}`}
-              {impact?.percent && (
+              {impact && (
                 <ThemedText.Body2 userSelect={false} color="hint">
-                  ({impact.percent.toFixed(1)}%)
+                  ({impact.toString()})
                 </ThemedText.Body2>
               )}
             </USDC>

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -166,9 +166,9 @@ export function FieldWrapper({
           <Row>
             <USDC isLoading={isRouteLoading}>
               {usdc && `${formatCurrencyAmount({ amount: usdc, isUsdPrice: true })}`}
-              {impact && (
-                <ThemedText.Body2 userSelect={false} color={impact.warning}>
-                  ({impact.toString()})
+              {impact?.percent && (
+                <ThemedText.Body2 userSelect={false} color="hint">
+                  ({impact.percent.toFixed(1)}%)
                 </ThemedText.Body2>
               )}
             </USDC>

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -167,7 +167,7 @@ export function FieldWrapper({
             <USDC isLoading={isRouteLoading}>
               {usdc && `${formatCurrencyAmount({ amount: usdc, isUsdPrice: true })}`}
               {impact && (
-                <ThemedText.Body2 userSelect={false} color="hint">
+                <ThemedText.Body2 userSelect={false} color={impact.warning ?? 'hint'}>
                   ({impact.toString()})
                 </ThemedText.Body2>
               )}

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -1,9 +1,7 @@
 import { Trans } from '@lingui/macro'
 import { Placement } from '@popperjs/core'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
-import Column from 'components/Column'
 import Row from 'components/Row'
-import Rule from 'components/Rule'
 import Tooltip from 'components/Tooltip'
 import { loadingCss } from 'css/loading'
 import { PriceImpact } from 'hooks/usePriceImpact'
@@ -183,32 +181,44 @@ export function WrapCurrency({ inputCurrency, outputCurrency, gasUseEstimateUSD 
 export interface TradeProps extends GasEstimateProps {
   trade: InterfaceTrade
   outputUSDC?: CurrencyAmount<Currency>
-  impact?: PriceImpact
 }
 
-export function Trade({ trade, outputUSDC, impact, gasUseEstimateUSD }: TradeProps) {
+export function Trade({ trade, outputUSDC, gasUseEstimateUSD }: TradeProps) {
   return (
     <>
       <Caption
-        icon={impact?.warning ? AlertTriangle : Info}
+        icon={Info}
         caption={<Price trade={trade} outputUSDC={outputUSDC} />}
         tooltip={{
-          content: (
-            <Column gap={0.75}>
-              {impact?.warning && (
-                <>
-                  <ThemedText.Caption>
-                    The output amount is estimated at {impact.toString()} less than the input amount due to impact
-                  </ThemedText.Caption>
-                  <Rule />
-                </>
-              )}
-              <RoutingDiagram trade={trade} />
-            </Column>
-          ),
+          content: <RoutingDiagram trade={trade} />,
         }}
       />
       <GasEstimate gasUseEstimateUSD={gasUseEstimateUSD} />
+    </>
+  )
+}
+
+type PriceImpactWarningProps = Omit<TradeProps, 'gasUseEstimateUSD'> & { impact: PriceImpact }
+
+export function PriceImpactWarning({ impact }: PriceImpactWarningProps) {
+  return (
+    <>
+      <Caption
+        icon={AlertTriangle}
+        caption="High price impact"
+        color={impact.warning}
+        tooltip={{
+          placement: 'right',
+          content: (
+            <ThemedText.Caption>
+              There will be a large difference between your input and output values due to current liquidity.
+            </ThemedText.Caption>
+          ),
+        }}
+      />
+      <ThemedText.Body2 userSelect={false} color={impact.warning}>
+        {impact.percent.toFixed(1)}%
+      </ThemedText.Body2>
     </>
   )
 }

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -5,7 +5,7 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
 import { loadingCss } from 'css/loading'
-import { PriceImpact as PriceImpactValue } from 'hooks/usePriceImpact'
+import { PriceImpact as PriceImpactType } from 'hooks/usePriceImpact'
 import { useIsWideWidget } from 'hooks/useWidgetWidth'
 import { AlertTriangle, Gas, Icon, Info, LargeIcon, Spinner } from 'icons'
 import { ReactNode, useCallback } from 'react'
@@ -151,16 +151,12 @@ export function LoadingTrade({ gasUseEstimateUSD }: GasEstimateProps) {
   )
 }
 
-interface WrapCurrencyProps {
+interface WrapProps {
   inputCurrency: Currency
   outputCurrency: Currency
 }
 
-export function WrapCurrency({
-  inputCurrency,
-  outputCurrency,
-  gasUseEstimateUSD,
-}: WrapCurrencyProps & GasEstimateProps) {
+export function Wrap({ inputCurrency, outputCurrency, gasUseEstimateUSD }: WrapProps & GasEstimateProps) {
   const isWideWidget = useIsWideWidget()
   const Text = useCallback(
     () =>
@@ -205,10 +201,10 @@ export function Trade({ trade, outputUSDC, gasUseEstimateUSD }: TradeProps & Gas
 }
 
 interface PriceImpactProps {
-  impact: PriceImpactValue
+  impact: PriceImpactType
 }
 
-export function PriceImpact({ impact }: TradeProps & PriceImpactProps) {
+export function PriceImpact({ impact }: PriceImpactProps) {
   return (
     <>
       <Caption

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -1,5 +1,6 @@
 import { Trans } from '@lingui/macro'
 import { Placement } from '@popperjs/core'
+import { formatCurrencyAmount, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
@@ -11,7 +12,6 @@ import { ReactNode, useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { Color, ThemedText } from 'theme'
-import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import Price from '../Price'
 import RoutingDiagram from '../RoutingDiagram'
@@ -60,9 +60,7 @@ function Caption({ icon: Icon = AlertTriangle, caption, color = 'secondary', too
 
 function GasEstimate({ gasUseEstimateUSD }: GasEstimateProps) {
   const isWideWidget = useIsWideWidget()
-  const displayEstimate = !gasUseEstimateUSD
-    ? '-'
-    : formatCurrencyAmount({ amount: gasUseEstimateUSD, isUsdPrice: true })
+  const displayEstimate = formatCurrencyAmount(gasUseEstimateUSD, NumberType.FiatGasPrice)
   return (
     <CaptionRow gap={0.25}>
       {isWideWidget ? (
@@ -217,7 +215,7 @@ export function PriceImpactWarning({ impact }: PriceImpactWarningProps) {
         }}
       />
       <ThemedText.Body2 userSelect={false} color={impact.warning}>
-        {impact.percent.toFixed(1)}%
+        {formatPriceImpact(impact?.percent)}
       </ThemedText.Body2>
     </>
   )

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -1,17 +1,18 @@
 import { Trans } from '@lingui/macro'
 import { Placement } from '@popperjs/core'
-import { formatCurrencyAmount, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
+import { formatPriceImpact } from '@uniswap/conedison/format'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
 import { loadingCss } from 'css/loading'
-import { PriceImpact } from 'hooks/usePriceImpact'
+import { PriceImpact as PriceImpactValue } from 'hooks/usePriceImpact'
 import { useIsWideWidget } from 'hooks/useWidgetWidth'
 import { AlertTriangle, Gas, Icon, Info, LargeIcon, Spinner } from 'icons'
 import { ReactNode, useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { Color, ThemedText } from 'theme'
+import { formatCurrencyAmount } from 'utils/formatCurrencyAmount'
 
 import Price from '../Price'
 import RoutingDiagram from '../RoutingDiagram'
@@ -60,7 +61,10 @@ function Caption({ icon: Icon = AlertTriangle, caption, color = 'secondary', too
 
 function GasEstimate({ gasUseEstimateUSD }: GasEstimateProps) {
   const isWideWidget = useIsWideWidget()
-  const displayEstimate = formatCurrencyAmount(gasUseEstimateUSD, NumberType.FiatGasPrice)
+  // TODO(just-toby): use formatCurrencyAmount from conedison
+  const displayEstimate = !gasUseEstimateUSD
+    ? '-'
+    : formatCurrencyAmount({ amount: gasUseEstimateUSD, isUsdPrice: true })
   return (
     <CaptionRow gap={0.25}>
       {isWideWidget ? (
@@ -147,12 +151,16 @@ export function LoadingTrade({ gasUseEstimateUSD }: GasEstimateProps) {
   )
 }
 
-interface WrapCurrencyProps extends GasEstimateProps {
+interface WrapCurrencyProps {
   inputCurrency: Currency
   outputCurrency: Currency
 }
 
-export function WrapCurrency({ inputCurrency, outputCurrency, gasUseEstimateUSD }: WrapCurrencyProps) {
+export function WrapCurrency({
+  inputCurrency,
+  outputCurrency,
+  gasUseEstimateUSD,
+}: WrapCurrencyProps & GasEstimateProps) {
   const isWideWidget = useIsWideWidget()
   const Text = useCallback(
     () =>
@@ -176,12 +184,12 @@ export function WrapCurrency({ inputCurrency, outputCurrency, gasUseEstimateUSD 
   )
 }
 
-export interface TradeProps extends GasEstimateProps {
+export interface TradeProps {
   trade: InterfaceTrade
   outputUSDC?: CurrencyAmount<Currency>
 }
 
-export function Trade({ trade, outputUSDC, gasUseEstimateUSD }: TradeProps) {
+export function Trade({ trade, outputUSDC, gasUseEstimateUSD }: TradeProps & GasEstimateProps) {
   return (
     <>
       <Caption
@@ -196,9 +204,11 @@ export function Trade({ trade, outputUSDC, gasUseEstimateUSD }: TradeProps) {
   )
 }
 
-type PriceImpactWarningProps = Omit<TradeProps, 'gasUseEstimateUSD'> & { impact: PriceImpact }
+interface PriceImpactProps {
+  impact: PriceImpactValue
+}
 
-export function PriceImpactWarning({ impact }: PriceImpactWarningProps) {
+export function PriceImpact({ impact }: TradeProps & PriceImpactProps) {
   return (
     <>
       <Caption

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -71,8 +71,10 @@ export default memo(function Toolbar() {
         return <Caption.InsufficientLiquidity />
       }
       if (trade?.inputAmount && trade.outputAmount) {
-        return (
-          <Caption.Trade trade={trade} outputUSDC={outputUSDC} impact={impact} gasUseEstimateUSD={gasUseEstimateUSD} />
+        return impact ? (
+          <Caption.PriceImpactWarning impact={impact} trade={trade} />
+        ) : (
+          <Caption.Trade trade={trade} outputUSDC={outputUSDC} gasUseEstimateUSD={gasUseEstimateUSD} />
         )
       }
       if (state === TradeState.INVALID) {

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -60,7 +60,7 @@ export default memo(function Toolbar() {
       }
       if (isWrap) {
         return (
-          <Caption.WrapCurrency
+          <Caption.Wrap
             inputCurrency={inputCurrency}
             outputCurrency={outputCurrency}
             gasUseEstimateUSD={gasUseEstimateUSD}
@@ -72,7 +72,7 @@ export default memo(function Toolbar() {
       }
       if (trade?.inputAmount && trade.outputAmount) {
         return impact?.warning ? (
-          <Caption.PriceImpact impact={impact} trade={trade} />
+          <Caption.PriceImpact impact={impact} />
         ) : (
           <Caption.Trade trade={trade} outputUSDC={outputUSDC} gasUseEstimateUSD={gasUseEstimateUSD} />
         )

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -71,7 +71,7 @@ export default memo(function Toolbar() {
         return <Caption.InsufficientLiquidity />
       }
       if (trade?.inputAmount && trade.outputAmount) {
-        return impact ? (
+        return impact?.warning ? (
           <Caption.PriceImpactWarning impact={impact} trade={trade} />
         ) : (
           <Caption.Trade trade={trade} outputUSDC={outputUSDC} gasUseEstimateUSD={gasUseEstimateUSD} />

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -72,7 +72,7 @@ export default memo(function Toolbar() {
       }
       if (trade?.inputAmount && trade.outputAmount) {
         return impact?.warning ? (
-          <Caption.PriceImpactWarning impact={impact} trade={trade} />
+          <Caption.PriceImpact impact={impact} trade={trade} />
         ) : (
           <Caption.Trade trade={trade} outputUSDC={outputUSDC} gasUseEstimateUSD={gasUseEstimateUSD} />
         )

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -23,7 +23,6 @@ const stateColors = {
   active: 'hsl(221, 96%, 64%)',
   success: 'hsl(145, 63.4%, 41.8%)',
   warningSoft: 'hsla(44, 86%, 51%, 0.24)',
-  error: 'hsl(0, 98%, 62.2%)',
 }
 
 export const lightTheme: Colors = {
@@ -48,6 +47,7 @@ export const lightTheme: Colors = {
   // state
   ...stateColors,
   warning: 'hsla(41, 100%, 35%, 1)',
+  error: 'hsla(356, 95%, 57%, 1)',
 
   currentColor: 'currentColor',
 }
@@ -74,6 +74,7 @@ export const darkTheme: Colors = {
   // state
   ...stateColors,
   warning: 'hsl(44, 86%, 51%)',
+  error: 'hsla(5, 97%, 71%, 1)',
 
   currentColor: 'currentColor',
 }

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -6,6 +6,8 @@ import fetch from 'jest-fetch-mock'
 
 fetch.enableMocks()
 
+jest.mock('@uniswap/conedison/format', () => ({}))
+
 beforeEach(() => {
   fetchMock.mockIf('https://gateway.ipfs.io/ipns/tokens.uniswap.org', JSON.stringify(tokenList))
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,6 +3516,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@uniswap/conedison@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.1.1.tgz#affec246613d1f52da3cdd0571ef8195b7b54d17"
+  integrity sha512-xFHAcWRrU+/+/BInXy6SRiiNwUG0vxLWsoYgod66wWifUvnjfpItzlvJHUer1OOpLDsz0CL5Fb70vFJOGAGi8w==
+
 "@uniswap/default-token-list@^2.0.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-2.2.0.tgz#d85a5c2520f57f4920bd989dfc9f01e1b701a567"


### PR DESCRIPTION
- use a new Caption type for price impacts
- update colors for price impact messages
- fix bug with displaying price impact below the output field

<img width="375" alt="image" src="https://user-images.githubusercontent.com/66155195/211682944-7ff87c76-6cdd-49cd-8ce3-cb14ea77cb45.png">

<img width="375" alt="image" src="https://user-images.githubusercontent.com/66155195/211682958-171d5d34-9319-4d86-acca-41ad641f2657.png">

<img width="375" alt="image" src="https://user-images.githubusercontent.com/66155195/211683003-8c9d6539-56d9-4e1f-9f5b-d8b4bc89d517.png">

<img width="375" alt="image" src="https://user-images.githubusercontent.com/66155195/211683028-43e26955-a120-40ad-92c4-faf54926482a.png">
