### PR TITLE
fix: simplify swap disabled state

### DIFF
--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -100,11 +100,7 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
 
   return (
     <>
-      <ActionButton
-        color={color}
-        onClick={onClick}
-        disabled={disabled || (permit2Enabled && allowance.state === AllowanceState.LOADING)}
-      >
+      <ActionButton color={color} onClick={onClick} disabled={disabled}>
         <Trans>Review swap</Trans>
       </ActionButton>
       {open && trade && (

--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -27,7 +27,7 @@ export default function SwapActionButton() {
   const permit2Enabled = usePermit2Enabled()
   const isDisabled = useMemo(
     () =>
-      (permit2Enabled && allowance.state === AllowanceState.REQUIRED) ||
+      (permit2Enabled && allowance.state !== AllowanceState.ALLOWED) ||
       (!permit2Enabled && approval.state !== SwapApprovalState.APPROVED) ||
       error !== undefined ||
       (!isWrap && !trade) ||


### PR DESCRIPTION
Removes approval logic from the SwapButton, now that buttons are separated/decoupled in the UI.