### PR TITLE
fix: improve routing experience

### DIFF
--- a/src/constants/jsonRpcEndpoints.ts
+++ b/src/constants/jsonRpcEndpoints.ts
@@ -39,11 +39,6 @@ export const JSON_RPC_FALLBACK_ENDPOINTS: Record<SupportedChainId, string[]> = {
   [SupportedChainId.POLYGON]: [
     // "Safe" URLs
     'https://polygon-rpc.com/',
-    'https://rpc-mainnet.matic.network',
-    'https://matic-mainnet.chainstacklabs.com',
-    'https://rpc-mainnet.maticvigil.com',
-    'https://rpc-mainnet.matic.quiknode.pro',
-    'https://matic-mainnet-full-rpc.bwarelabs.com',
   ],
   [SupportedChainId.POLYGON_MUMBAI]: [
     // "Safe" URLs

--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -62,17 +62,17 @@ export function useRouterTrade(
 
   // Get the cached state *immediately* to update the UI without sending a request - using useGetQuoteQueryState -
   // but debounce the actual request - using useLazyGetQuoteQuery - to avoid flooding the router / JSON-RPC endpoints.
-  const { isError, isFetching, data, currentData, fulfilledTimeStamp } = useGetQuoteQueryState(queryArgs)
+  const { isError, data, currentData, fulfilledTimeStamp } = useGetQuoteQueryState(queryArgs)
 
   // An already-fetched value should be refetched if it is older than the pollingInterval.
   // Without explicit refetch, it would not be refetched until another pollingInterval has elapsed.
   const [trigger] = useLazyGetQuoteQuery({ pollingInterval })
   const request = useCallback(() => {
     const { refetch } = trigger(queryArgs, /*preferCacheValue=*/ true)
-    if (!isFetching && fulfilledTimeStamp && Date.now() - fulfilledTimeStamp > pollingInterval) {
+    if (fulfilledTimeStamp && Date.now() - fulfilledTimeStamp > pollingInterval) {
       refetch()
     }
-  }, [fulfilledTimeStamp, isFetching, pollingInterval, queryArgs, trigger])
+  }, [fulfilledTimeStamp, pollingInterval, queryArgs, trigger])
   useTimeout(request, 200)
 
   const quote = typeof data === 'object' ? data : undefined

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -10,5 +10,5 @@ export default function useTimeout(callback: () => void, delay: null | number) {
     if (delay === null) return
     const timeout = setTimeout(callback, delay)
     return () => clearTimeout(timeout)
-  })
+  }, [callback, delay])
 }


### PR DESCRIPTION
- Omits rate-limited polygon RPC endpoints
- Fixes useTimeout to only trigger a callback once, after the timeout
- Fixes useRouterTrade to avoid infinite retries when erring