### PR TITLE
lint: type multicall usage

### DIFF
--- a/src/hooks/useArgentWalletContract.ts
+++ b/src/hooks/useArgentWalletContract.ts
@@ -8,9 +8,9 @@ import useIsArgentWallet from './useIsArgentWallet'
 export function useArgentWalletContract(): ArgentWalletContract | null {
   const { account } = useWeb3React()
   const isArgentWallet = useIsArgentWallet()
-  return useContract(
+  return useContract<ArgentWalletContract>(
     isArgentWallet ? account ?? undefined : undefined,
     ArgentWalletContractABI,
     true
-  ) as ArgentWalletContract
+  )
 }

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -7,7 +7,7 @@ import ENS_PUBLIC_RESOLVER_ABI from 'abis/ens-public-resolver.json'
 import ENS_ABI from 'abis/ens-registrar.json'
 import ERC20_ABI from 'abis/erc20.json'
 import ERC20_BYTES32_ABI from 'abis/erc20_bytes32.json'
-import { ArgentWalletDetector, EnsPublicResolver, EnsRegistrar, Erc20, Weth } from 'abis/types'
+import { ArgentWalletDetector, Eip2612, EnsPublicResolver, EnsRegistrar, Erc20, Erc20Bytes32, Weth } from 'abis/types'
 import WETH_ABI from 'abis/weth.json'
 import { ARGENT_WALLET_DETECTOR_ADDRESS, ENS_REGISTRAR_ADDRESSES, MULTICALL_ADDRESS } from 'constants/addresses'
 import { WRAPPED_NATIVE_CURRENCY } from 'constants/tokens'
@@ -18,7 +18,7 @@ import { getContract } from 'utils'
 const { abi: MulticallABI } = UniswapInterfaceMulticallJson
 
 // returns null on errors
-export function useContract<T extends Contract = Contract>(
+export function useContract<T extends Contract>(
   addressOrAddressMap: string | { [chainId: number]: string } | undefined,
   ABI: any,
   withSignerIfPossible = true
@@ -65,12 +65,12 @@ export function useENSResolverContract(address: string | undefined, withSignerIf
   return useContract<EnsPublicResolver>(address, ENS_PUBLIC_RESOLVER_ABI, withSignerIfPossible)
 }
 
-export function useBytes32TokenContract(tokenAddress?: string, withSignerIfPossible?: boolean): Contract | null {
-  return useContract(tokenAddress, ERC20_BYTES32_ABI, withSignerIfPossible)
+export function useBytes32TokenContract(tokenAddress?: string, withSignerIfPossible?: boolean) {
+  return useContract<Erc20Bytes32>(tokenAddress, ERC20_BYTES32_ABI, withSignerIfPossible)
 }
 
-export function useEIP2612Contract(tokenAddress?: string): Contract | null {
-  return useContract(tokenAddress, EIP_2612, false)
+export function useEIP2612Contract(tokenAddress?: string) {
+  return useContract<Eip2612>(tokenAddress, EIP_2612, false)
 }
 
 export function useInterfaceMulticall() {

--- a/src/hooks/useCurrencyBalance.ts
+++ b/src/hooks/useCurrencyBalance.ts
@@ -2,7 +2,7 @@ import { Interface } from '@ethersproject/abi'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
 import ERC20ABI from 'abis/erc20.json'
-import { Erc20Interface } from 'abis/types/Erc20'
+import { Erc20, Erc20Interface } from 'abis/types/Erc20'
 import { nativeOnChain } from 'constants/tokens'
 import { useMultipleContractSingleData, useSingleContractMultipleData } from 'hooks/multicall'
 import { useInterfaceMulticall } from 'hooks/useContract'
@@ -61,7 +61,7 @@ export function useTokenBalancesWithLoadingIndicator(
   )
   const validatedTokenAddresses = useMemo(() => validatedTokens.map((vt) => vt.address), [validatedTokens])
 
-  const balances = useMultipleContractSingleData(
+  const balances = useMultipleContractSingleData<Erc20, 'balanceOf'>(
     validatedTokenAddresses,
     ERC20Interface,
     'balanceOf',

--- a/src/hooks/usePermitAllowance.ts
+++ b/src/hooks/usePermitAllowance.ts
@@ -22,9 +22,7 @@ export function usePermitAllowance(token?: Token, owner?: string, spender?: stri
   // If there is no allowance yet, re-check next observed block.
   // This guarantees that the permitAllowance is synced upon submission and updated upon being synced.
   const [blocksPerFetch, setBlocksPerFetch] = useState<1>()
-  const result = useSingleCallResult(contract, 'allowance', inputs, {
-    blocksPerFetch,
-  }).result as Awaited<ReturnType<Permit2['allowance']>> | undefined
+  const result = useSingleCallResult(contract, 'allowance', inputs, { blocksPerFetch }).result
 
   const rawAmount = result?.amount.toString() // convert to a string before using in a hook, to avoid spurious rerenders
   const allowance = useMemo(

--- a/src/hooks/useTokenAllowance.ts
+++ b/src/hooks/useTokenAllowance.ts
@@ -1,6 +1,5 @@
 import { BigNumberish } from '@ethersproject/bignumber'
 import { CurrencyAmount, MaxUint256, Token } from '@uniswap/sdk-core'
-import { Erc20 } from 'abis/types'
 import { useSingleCallResult } from 'hooks/multicall'
 import { useTokenContract } from 'hooks/useContract'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -21,10 +20,7 @@ export function useTokenAllowance(
   // If there is no allowance yet, re-check next observed block.
   // This guarantees that the tokenAllowance is marked isSyncing upon approval and updated upon being synced.
   const [blocksPerFetch, setBlocksPerFetch] = useState<1>()
-  const { result, syncing: isSyncing } = useSingleCallResult(contract, 'allowance', inputs, { blocksPerFetch }) as {
-    result: Awaited<ReturnType<Erc20['allowance']>> | undefined
-    syncing: boolean
-  }
+  const { result, syncing: isSyncing } = useSingleCallResult(contract, 'allowance', inputs, { blocksPerFetch })
 
   const rawAmount = result?.toString() // convert to a string before using in a hook, to avoid spurious rerenders
   const allowance = useMemo(


### PR DESCRIPTION
Adds typings for multicall hooks to improve multicall ergonomics and reduce the chance of misuse (eg ReferenceErrors).
Although functional, this is a POC - it is better to move this into redux-multicall itself so it can be useful for interface and other consumers as well.