### PR TITLE
fix: Remove spin state on un-hovering settings icon

### DIFF
--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -24,13 +24,9 @@ export function SettingsPopover() {
 }
 
 const SettingsButton = styled(IconButton)`
+  // don't rotate back when un-hovering because it works weirdly with modal backdrop opening on top
   ${SettingsIcon}:hover {
     transform: rotate(45deg);
-    transition: transform 0.25s;
-  }
-
-  ${SettingsIcon} {
-    transform: rotate(0);
     transition: transform 0.25s;
   }
 `

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -24,7 +24,7 @@ export function SettingsPopover() {
 }
 
 const SettingsButton = styled(IconButton)`
-  // don't rotate back when un-hovering because it works weirdly with modal backdrop opening on top
+  // Don't rotate back when un-hovering so that clicking (and losing hover due to the modal backdrop) doesn't cause unintentional back-rotation.
   ${SettingsIcon}:hover {
     transform: rotate(45deg);
     transition: transform 0.25s;


### PR DESCRIPTION
[slack](https://uniswapteam.slack.com/archives/C04JP2P3F7T/p1673506938838779?thread_ts=1673506038.511189&cid=C04JP2P3F7T) convo for context