### PR TITLE
fix: spacing bug with em in TokenButton

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -32,7 +32,7 @@ const Balance = styled(ThemedText.Body2)`
 const InputColumn = styled(Column)<{ disableHover?: boolean; isWide: boolean }>`
   background-color: ${({ theme }) => theme.module};
   border-radius: ${({ theme }) => theme.borderRadius - 0.25}em;
-  margin-bottom: 4px;
+  margin-bottom: 0.25em;
   padding: ${({ isWide }) => (isWide ? '1em 0' : '1em 0 1.5em')};
   position: relative;
 

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -49,19 +49,21 @@ export default function TokenButton({ value, approved, disabled, onClick }: Toke
       disabled={disabled}
       data-testid="token-select"
     >
-      <ThemedText.ButtonLarge color={value ? 'currentColor' : 'onAccent'}>
-        <TokenButtonRow empty={!value} flex gap={0.4}>
-          {value ? (
-            <>
-              <TokenImg token={value} size={1.75} />
+      <TokenButtonRow empty={!value} flex gap={0.4}>
+        {value ? (
+          <>
+            <TokenImg token={value} size={1.75} />
+            <ThemedText.ButtonLarge color={'currentColor'}>
               <span>{value.symbol}</span>
-            </>
-          ) : (
+            </ThemedText.ButtonLarge>
+          </>
+        ) : (
+          <ThemedText.ButtonLarge color={'onAccent'}>
             <Trans>Select a token</Trans>
-          )}
-          <ChevronDown strokeWidth={2} />
-        </TokenButtonRow>
-      </ThemedText.ButtonLarge>
+          </ThemedText.ButtonLarge>
+        )}
+        <ChevronDown strokeWidth={2} />
+      </TokenButtonRow>
     </StyledTokenButton>
   )
 }


### PR DESCRIPTION
- move TokenImg out from under the `ThemedText`, because the larger font it inherits was breaking the `em` spacing