### PR TITLE
fix: polish design issues in widget

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -97,6 +97,9 @@ export default function ActionButton({
   ...rest
 }: ActionButtonProps) {
   const textColor = useMemo(() => {
+    if (disabled) {
+      return 'primary'
+    }
     switch (color) {
       case 'accent':
         return 'onAccent'
@@ -107,7 +110,7 @@ export default function ActionButton({
       default:
         return 'currentColor'
     }
-  }, [color])
+  }, [color, disabled])
 
   return (
     <Overlay data-testid="action-button" hasAction={Boolean(action)} flex align="stretch" {...wrapperProps}>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -141,7 +141,7 @@ export const DecimalInput = forwardRef(function DecimalInput(props: InputProps, 
 
 export const inputCss = css`
   background-color: ${({ theme }) => theme.container};
-  border: 1px solid ${({ theme }) => theme.container};
+  border: 1px solid ${({ theme }) => theme.outline};
   border-radius: ${({ theme }) => theme.borderRadius}em;
   cursor: text;
   padding: calc(0.75em - 1px);

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -219,7 +219,7 @@ export default function Input() {
       maxAmount={maxAmount}
       isSufficientBalance={isSufficientBalance}
       approved={approvalState === SwapApprovalState.APPROVED}
-      subheader={t`You Pay`}
+      subheader={t`You pay`}
     />
   )
 }

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -11,6 +11,7 @@ import { Label } from './components'
 
 const Input = styled(Row)`
   ${inputCss}
+  border: 1px solid ${({ theme }) => theme.outline};
 `
 
 export default function TransactionTtlInput() {

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -11,7 +11,6 @@ import { Label } from './components'
 
 const Input = styled(Row)`
   ${inputCss}
-  border: 1px solid ${({ theme }) => theme.outline};
 `
 
 export default function TransactionTtlInput() {

--- a/src/components/Swap/Settings/components.tsx
+++ b/src/components/Swap/Settings/components.tsx
@@ -6,7 +6,7 @@ import Row from '../../Row'
 import Tooltip from '../../Tooltip'
 
 export const optionCss = (selected: boolean) => css`
-  border: 1px solid ${({ theme }) => (selected ? theme.active : theme.outline)};
+  border: 1px solid ${({ theme }) => (selected ? theme.active : '')};
   border-radius: ${({ theme }) => theme.borderRadius * 0.75}em;
   color: ${({ theme }) => theme.primary} !important;
   display: grid;


### PR DESCRIPTION
- add missing border to settings input
- use 'primary' text color for disable buttons
- fix casing for input sub header

https://www.notion.so/uniswaplabs/widget-design-feedbacks-835bfad85aac4ad3a00550fcea18bf99

design spec: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=10305%3A105762&t=GMFoRG5hj2E6QPEd-0

<img width="397" alt="image" src="https://user-images.githubusercontent.com/66155195/212392751-2b83a16e-c564-4799-ab77-7edfdec8bd42.png">

<img width="397" alt="image" src="https://user-images.githubusercontent.com/66155195/212392816-9e341549-09ec-4c8c-9508-354894634e92.png">
