### PR TITLE
feat: update colors in error dialog

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -75,7 +75,7 @@ export interface Action {
   children?: ReactNode
 }
 
-type ActionButtonColor = keyof Pick<Colors, 'accent' | 'accentSoft' | 'warningSoft' | 'interactive'>
+type ActionButtonColor = keyof Pick<Colors, 'accent' | 'accentSoft' | 'warningSoft' | 'interactive' | 'critical'>
 
 interface BaseProps {
   color?: ActionButtonColor
@@ -102,6 +102,7 @@ export default function ActionButton({
     }
     switch (color) {
       case 'accent':
+      case 'critical':
         return 'onAccent'
       case 'accentSoft':
         return 'accent'

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -60,12 +60,12 @@ export default function ErrorDialog({ header, error, action, onClick }: ErrorDia
 
   return (
     <Column flex padded gap={0.75} align="stretch" style={{ height: '100%' }}>
-      <StatusHeader icon={AlertTriangle} iconColor="error" iconSize={open ? 3 : 4}>
+      <StatusHeader icon={AlertTriangle} iconColor="critical" iconSize={open ? 3 : 4}>
         <ErrorHeader gap={open ? 0 : 0.75} open={open}>
           <ThemedText.Subhead1>
             <Trans>Something went wrong.</Trans>
           </ThemedText.Subhead1>
-          <ThemedText.Body2>{header}</ThemedText.Body2>
+          {!open && <ThemedText.Body2>{header}</ThemedText.Body2>}
         </ErrorHeader>
       </StatusHeader>
       <Column gap={open ? 0 : 0.75} style={{ transition: 'gap 0.25s' }}>
@@ -80,12 +80,12 @@ export default function ErrorDialog({ header, error, action, onClick }: ErrorDia
           onExpand={onExpand}
           height={7.5}
         >
-          <ThemedText.Body2 userSelect>
+          <ThemedText.Code userSelect>
             {error.name}
             {error.message ? `: ${error.message}` : ''}
-          </ThemedText.Body2>
+          </ThemedText.Code>
         </Expando>
-        <ActionButton color="interactive" onClick={onClick}>
+        <ActionButton color="critical" onClick={onClick}>
           {action}
         </ActionButton>
       </Column>

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -23,6 +23,8 @@ const stateColors = {
   active: 'hsl(221, 96%, 64%)',
   success: 'hsl(145, 63.4%, 41.8%)',
   warningSoft: 'hsla(44, 86%, 51%, 0.24)',
+  critical: '#FA2B39',
+  criticalSoft: 'rgba(250, 43, 57, 0.12);',
 }
 
 export const lightTheme: Colors = {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -21,6 +21,8 @@ export interface Colors {
   warning: string
   warningSoft: string
   error: string
+  critical: string
+  criticalSoft: string
 
   networkDefaultShadow: string
 


### PR DESCRIPTION
update colors for the error dialog

note: the "code" font is subject to this [issue](https://github.com/Uniswap/interface/issues/3343)

design spec: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=10575%3A122757&t=GMFoRG5hj2E6QPEd-4

<img width="407" alt="image" src="https://user-images.githubusercontent.com/66155195/212428766-5aa971b7-2965-4b57-ae57-3e555f1daeb9.png">

![image](https://user-images.githubusercontent.com/66155195/212428788-c27d65aa-f023-4dcd-bf87-1f0fcbbc07ce.png)
