### PR TITLE
feat: update ui for tx status dialog

### DIFF
--- a/src/components/EtherscanLink.tsx
+++ b/src/components/EtherscanLink.tsx
@@ -19,9 +19,16 @@ interface EtherscanLinkProps {
   data?: string
   color?: Color
   children: ReactNode
+  showIcon?: boolean
 }
 
-export default function EtherscanLink({ data, type, color = 'currentColor', children }: EtherscanLinkProps) {
+export default function EtherscanLink({
+  data,
+  type,
+  color = 'currentColor',
+  children,
+  showIcon = true,
+}: EtherscanLinkProps) {
   const { chainId } = useWeb3React()
   const url = useMemo(
     () => data && getExplorerLink(chainId || SupportedChainId.MAINNET, data, type),
@@ -32,7 +39,7 @@ export default function EtherscanLink({ data, type, color = 'currentColor', chil
     <StyledExternalLink href={url} color={color} target="_blank">
       <Row gap={0.25}>
         {children}
-        {url && <Link />}
+        {url && showIcon && <Link />}
       </Row>
     </StyledExternalLink>
   )

--- a/src/theme/type.tsx
+++ b/src/theme/type.tsx
@@ -40,6 +40,12 @@ export function H3(props: TextProps) {
   )
 }
 
+export function H4(props: TextProps) {
+  return (
+    <TextWrapper className="headline headline-4" fontSize={20} fontWeight={500} lineHeight="28px" noWrap {...props} />
+  )
+}
+
 export function Subhead1(props: TextProps) {
   return (
     <TextWrapper className="subhead subhead-1" fontSize={16} fontWeight={500} lineHeight="24px" noWrap {...props} />


### PR DESCRIPTION
design for this screen: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=10369%3A106419&t=ijfa7EEMSPInWNSl-4

<img width="407" alt="Screenshot 2023-01-17 at 9 52 19 AM" src="https://user-images.githubusercontent.com/66155195/212974794-d207d653-6b72-4ab0-b1b7-dacc150db1a5.png">
<img width="407" alt="Screenshot 2023-01-17 at 9 52 34 AM" src="https://user-images.githubusercontent.com/66155195/212974798-d4aef654-2425-497d-954c-bc1116ae8a70.png">

updates the fonts and placement of the UI elements on the "waiting for confirmation" and "success" screens