### PR TITLE
feat: Move settings menu into expandable components

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -62,6 +62,10 @@ const Wrapper = styled.div<{ open: boolean }>`
     height: unset;
     position: fixed;
     top: unset;
+
+    * {
+      box-sizing: border-box;
+    }
   }
 `
 

--- a/src/components/Expando.tsx
+++ b/src/components/Expando.tsx
@@ -48,27 +48,45 @@ const InnerColumn = styled(Column)<{ height: number }>`
   padding: 0.5em 0;
 `
 
+const IconPrefix = styled.div`
+  color: ${({ theme }) => theme.primary};
+`
+
 interface ExpandoProps extends ColumnProps {
   title: ReactNode
+  iconPrefix?: ReactNode
   open: boolean
   onExpand: () => void
   // The absolute height of the expanded container, in em.
   height: number
+  hideRulers?: boolean
 }
 
 /** A scrollable Expando with an absolute height. */
-export default function Expando({ title, open, onExpand, height, children, ...rest }: PropsWithChildren<ExpandoProps>) {
+export default function Expando({
+  title,
+  iconPrefix,
+  open,
+  onExpand,
+  height,
+  children,
+  hideRulers,
+  ...rest
+}: PropsWithChildren<ExpandoProps>) {
   const [scrollingEl, setScrollingEl] = useState<HTMLDivElement | null>(null)
-  const scrollbar = useScrollbar(scrollingEl)
+  const scrollbar = useScrollbar(scrollingEl, { hideScrollbar: true })
   return (
     <Column {...rest}>
       <HeaderColumn gap={open ? 0.5 : 0.75} onClick={onExpand}>
-        <Rule />
-        <TitleRow>
+        {!hideRulers && <Rule />}
+        <TitleRow gap={1}>
           <TitleHeader>{title}</TitleHeader>
-          <IconButton color="secondary" icon={ExpandoIcon} iconProps={{ open }} />
+          <Row gap={0.2}>
+            {iconPrefix && <IconPrefix>{iconPrefix}</IconPrefix>}
+            <IconButton color="secondary" icon={ExpandoIcon} iconProps={{ open }} />
+          </Row>
         </TitleRow>
-        {open && <Rule />}
+        {!hideRulers && open && <Rule />}
       </HeaderColumn>
       <ExpandoColumn open={open} height={height}>
         <InnerColumn flex align="stretch" height={height} ref={setScrollingEl} css={scrollbar}>

--- a/src/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -134,6 +134,7 @@ export default function MaxSlippageSelect() {
           <Row grow>
             <Label
               name={<Trans>Max slippage</Trans>}
+              // TODO (tina): clicking on this tooltip on mobile shouldn't open/close expando
               tooltip={
                 <Trans>
                   Your transaction will revert if the price changes unfavorably by more than this percentage.

--- a/src/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import Expando from 'components/Expando'
 import Popover from 'components/Popover'
 import { useTooltip } from 'components/Tooltip'
 import { getSlippageWarning, toPercent } from 'hooks/useSlippage'
@@ -123,42 +124,57 @@ export default function MaxSlippageSelect() {
     [setSlippage]
   )
 
+  const [open, setOpen] = useState(false)
   return (
     <Column gap={0.75}>
-      <Label
-        name={<Trans>Max slippage</Trans>}
-        tooltip={
-          <Trans>Your transaction will revert if the price changes unfavorably by more than this percentage.</Trans>
-        }
-      />
-      <Row gap={0.5} grow="last">
-        <Option wrapper={Button} selected={slippage.auto} onSelect={setAutoSlippage} data-testid="auto-slippage">
-          <ThemedText.ButtonMedium>
-            <Trans>Auto</Trans>
-          </ThemedText.ButtonMedium>
-        </Option>
-        <Option
-          wrapper={Custom}
-          selected={!slippage.auto}
-          onSelect={onInputSelect}
-          icon={warning && <Warning state={warning} showTooltip={showTooltip} />}
-          ref={option}
-          tabIndex={-1}
-          data-testid="custom-slippage"
-        >
-          <Row color={warning === 'error' ? 'error' : undefined}>
-            <DecimalInput
-              size={Math.max(maxSlippageInput.length, 4)}
-              value={maxSlippageInput}
-              onChange={(input) => processInput(input)}
-              placeholder={'0.10'}
-              ref={input}
-              data-testid="input-slippage"
+      <Expando
+        hideRulers
+        title={
+          <Row grow>
+            <Label
+              name={<Trans>Max slippage</Trans>}
+              tooltip={
+                <Trans>
+                  Your transaction will revert if the price changes unfavorably by more than this percentage.
+                </Trans>
+              }
             />
-            %
           </Row>
-        </Option>
-      </Row>
+        }
+        iconPrefix={slippage.auto ? <Trans>Auto</Trans> : `${maxSlippageInput}%`}
+        height={4}
+        open={open}
+        onExpand={() => setOpen(!open)}
+      >
+        <Row gap={0.5} grow="first">
+          <Option wrapper={Button} selected={slippage.auto} onSelect={setAutoSlippage} data-testid="auto-slippage">
+            <ThemedText.ButtonMedium>
+              <Trans>Auto</Trans>
+            </ThemedText.ButtonMedium>
+          </Option>
+          <Option
+            wrapper={Custom}
+            selected={!slippage.auto}
+            onSelect={onInputSelect}
+            icon={warning && <Warning state={warning} showTooltip={showTooltip} />}
+            ref={option}
+            tabIndex={-1}
+            data-testid="custom-slippage"
+          >
+            <Row color={warning === 'error' ? 'error' : undefined}>
+              <DecimalInput
+                size={Math.max(maxSlippageInput.length, 4)}
+                value={maxSlippageInput}
+                onChange={(input) => processInput(input)}
+                placeholder={'0.10'}
+                ref={input}
+                data-testid="input-slippage"
+              />
+              %
+            </Row>
+          </Option>
+        </Row>
+      </Expando>
     </Column>
   )
 }

--- a/src/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -129,6 +129,7 @@ export default function MaxSlippageSelect() {
     <Column gap={0.75}>
       <Expando
         hideRulers
+        showBottomGradient={false}
         title={
           <Row grow>
             <Label

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -41,6 +41,7 @@ export default function TransactionTtlInput() {
         title={
           <Label
             name={<Trans>Transaction deadline</Trans>}
+            // TODO (tina): clicking on this tooltip on mobile shouldn't open/close expando
             tooltip={
               <Trans>Your transaction will revert if it has been pending for longer than this period of time.</Trans>
             }

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -1,6 +1,7 @@
 import { Trans } from '@lingui/macro'
+import Expando from 'components/Expando'
 import { useDefaultTransactionTtl, useTransactionTtl } from 'hooks/useTransactionDeadline'
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
@@ -13,31 +14,53 @@ const Input = styled(Row)`
   ${inputCss}
 `
 
+const TtlValue = styled.div`
+  // set min width here to prevent entire popover layout from shrinking when
+  // user deletes text in ttl input
+  min-width: 3rem;
+  text-align: right;
+`
+
 export default function TransactionTtlInput() {
   const [ttl, setTtl] = useTransactionTtl()
   const defaultTtl = useDefaultTransactionTtl()
   const placeholder = defaultTtl.toString()
   const input = useRef<HTMLInputElement>(null)
+
+  const [open, setOpen] = useState(false)
+  const ttlValue = ttl?.toString()
   return (
     <Column gap={0.75}>
-      <Label
-        name={<Trans>Transaction deadline</Trans>}
-        tooltip={
-          <Trans>Your transaction will revert if it has been pending for longer than this period of time.</Trans>
-        }
-      />
-      <ThemedText.Body1>
-        <Input justify="start" onClick={() => input.current?.focus()}>
-          <IntegerInput
-            placeholder={placeholder}
-            value={ttl?.toString() ?? ''}
-            onChange={(value) => setTtl(value ? parseFloat(value) : undefined)}
-            size={Math.max(ttl?.toString().length || 0, placeholder.length)}
-            ref={input}
+      <Expando
+        hideRulers
+        height={4}
+        open={open}
+        onExpand={() => setOpen(!open)}
+        iconPrefix={<TtlValue>{ttlValue ?? placeholder}m</TtlValue>}
+        title={
+          <Label
+            name={<Trans>Transaction deadline</Trans>}
+            tooltip={
+              <Trans>Your transaction will revert if it has been pending for longer than this period of time.</Trans>
+            }
           />
-          <Trans>minutes</Trans>
-        </Input>
-      </ThemedText.Body1>
+        }
+      >
+        <Row grow>
+          <ThemedText.Body1>
+            <Input justify="start" onClick={() => input.current?.focus()}>
+              <IntegerInput
+                placeholder={placeholder}
+                value={ttlValue ?? ''}
+                onChange={(value) => setTtl(value ? parseFloat(value) : undefined)}
+                size={Math.max(ttl?.toString().length || 0, placeholder.length)}
+                ref={input}
+              />
+              <Trans>minutes</Trans>
+            </Input>
+          </ThemedText.Body1>
+        </Row>
+      </Expando>
     </Column>
   )
 }

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -33,6 +33,7 @@ export default function TransactionTtlInput() {
     <Column gap={0.75}>
       <Expando
         hideRulers
+        showBottomGradient={false}
         height={4}
         open={open}
         onExpand={() => setOpen(!open)}

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -53,7 +53,7 @@ export default function TransactionTtlInput() {
                 placeholder={placeholder}
                 value={ttlValue ?? ''}
                 onChange={(value) => setTtl(value ? parseFloat(value) : undefined)}
-                size={Math.max(ttl?.toString().length || 0, placeholder.length)}
+                size={Math.max(ttlValue?.length || 0, placeholder.length)}
                 ref={input}
               />
               <Trans>minutes</Trans>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -1,4 +1,5 @@
 import { BottomSheetModal } from 'components/BottomSheetModal'
+import Rule from 'components/Rule'
 import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import { useOnEscapeHandler } from 'hooks/useOnEscapeHandler'
 import { Settings as SettingsIcon } from 'icons'
@@ -11,14 +12,15 @@ import Popover, { PopoverBoundaryProvider } from '../../Popover'
 import MaxSlippageSelect from './MaxSlippageSelect'
 import TransactionTtlInput from './TransactionTtlInput'
 
-export function SettingsPopover() {
+export function SettingsMenu() {
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
 
   // TODO (WEB-2754): add back reset settings functionality
   return (
-    <Column gap={1} style={{ paddingTop: '1em' }} ref={setBoundary} padded>
+    <Column gap={1} style={{ paddingTop: '1em', paddingBottom: '1em' }} ref={setBoundary} padded>
       <PopoverBoundaryProvider value={boundary}>
         <MaxSlippageSelect />
+        <Rule />
         <TransactionTtlInput />
       </PopoverBoundaryProvider>
     </Column>
@@ -46,12 +48,12 @@ export default function Settings() {
         <>
           <SettingsButton onClick={() => setOpen(!open)} icon={SettingsIcon} />
           <BottomSheetModal title="Settings" onClose={() => setOpen(false)} open={open}>
-            <SettingsPopover />
+            <SettingsMenu />
           </BottomSheetModal>
         </>
       ) : (
         <PopoverBoundaryProvider value={wrapper}>
-          <Popover showArrow={false} offset={10} show={open} placement="top-end" content={<SettingsPopover />}>
+          <Popover showArrow={false} offset={10} show={open} placement="top-end" content={<SettingsMenu />}>
             <SettingsButton onClick={() => setOpen(!open)} icon={SettingsIcon} />
           </Popover>
         </PopoverBoundaryProvider>

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -27,10 +27,11 @@ const CaptionRow = styled(Row)<{ gap: number; shrink?: number }>`
   height: 100%;
 `
 
+// TODO (tina): consolidate this and Expando icon
 const ExpandIcon = styled(ChevronDown)<{ expanded: boolean }>`
   color: ${({ theme }) => theme.secondary};
   cursor: pointer;
-  transform: ${({ expanded }) => (expanded ? 'rotate(-180deg)' : 'rotate(0deg)')};
+  transform: ${({ expanded }) => (expanded ? 'rotate(180deg)' : 'rotate(0deg)')};
   transition: transform 0.25s;
   :hover {
     opacity: 0.6;

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -188,7 +188,7 @@ export default memo(function Toolbar() {
         </ToolbarRow>
       }
       styledTitleWrapper={false}
-      bottomGradient={false}
+      showBottomGradient={false}
       open={open}
       onExpand={() => {
         setOpen((open) => !open)

--- a/src/hooks/useScrollbar.ts
+++ b/src/hooks/useScrollbar.ts
@@ -5,6 +5,10 @@ const overflowCss = css`
   overflow-y: scroll;
 `
 
+const hiddenScrollbarCss = css`
+  overflow-y: auto;
+`
+
 /** Customizes the scrollbar for vertical overflow. */
 const scrollbarCss = (padded: boolean) => css`
   overflow-y: scroll;
@@ -43,14 +47,21 @@ const scrollbarCss = (padded: boolean) => css`
 
 interface ScrollbarOptions {
   padded?: boolean
+  hideScrollbar?: boolean
 }
 
-export default function useScrollbar(element: HTMLElement | null, { padded = false }: ScrollbarOptions = {}) {
+export default function useScrollbar(
+  element: HTMLElement | null,
+  { padded = false, hideScrollbar = false }: ScrollbarOptions = {}
+) {
   return useMemo(
     // NB: The css must be applied on an element's first render. WebKit will not re-apply overflow
     // properties until any transitions have ended, so waiting a frame for state would cause jank.
-    () => (hasOverflow(element) ? scrollbarCss(padded) : overflowCss),
-    [element, padded]
+    () => {
+      if (hideScrollbar) return hiddenScrollbarCss
+      return hasOverflow(element) ? scrollbarCss(padded) : overflowCss
+    },
+    [element, padded, hideScrollbar]
   )
 
   function hasOverflow(element: HTMLElement | null) {

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -114,19 +114,8 @@ export const Check = styled(icon(CheckIcon))`
 `
 
 export const Expando = styled(icon(ExpandoIcon))<{ open: boolean }>`
-  .left,
-  .right {
-    transition: transform 0.25s ease-in-out;
-    will-change: transform;
-  }
-
-  .left {
-    transform: ${({ open }) => (open ? undefined : 'translateX(-25%)')};
-  }
-
-  .right {
-    transform: ${({ open }) => (open ? undefined : 'translateX(25%)')};
-  }
+  transform: ${({ open }) => (open ? 'rotate(0deg)' : 'rotate(-180deg)')};
+  transition: transform 0.25s;
 `
 
 export const Logo = styled(icon(LogoIcon))`


### PR DESCRIPTION
This PR moves the inner content of the settings menu into `Expando` components

https://user-images.githubusercontent.com/59578595/213023578-d96515e8-4be6-45d3-b3e6-224a59794413.mov


https://user-images.githubusercontent.com/59578595/213023731-b2ea3384-faed-4af1-9368-b2b2c0596bef.mov



Followups:
- add the "routing api" settings option
- looks like the "max slippage" option has different sub designs too, will change in a followup PR