### PR TITLE
feat: add confirmation step to the StatusDialog flow

### DIFF
--- a/src/assets/svg/large_arrow.svg
+++ b/src/assets/svg/large_arrow.svg
@@ -1,0 +1,5 @@
+<svg width="90" height="90" viewBox="0 0 90 90" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M45 82.5C65.7107 82.5 82.5 65.7107 82.5 45C82.5 24.2893 65.7107 7.5 45 7.5C24.2893 7.5 7.5 24.2893 7.5 45C7.5 65.7107 24.2893 82.5 45 82.5Z" stroke="#4C82FB" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M60 45L45 30L30 45" stroke="#4C82FB" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M45 60V30" stroke="#4C82FB" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -72,6 +72,7 @@ export interface Action {
   onClick?: () => void
   color?: Color
   children?: ReactNode
+  hideButton?: boolean
 }
 
 type ActionButtonColor = keyof Pick<Colors, 'accent' | 'accentSoft' | 'warningSoft' | 'interactive' | 'critical'>
@@ -114,17 +115,19 @@ export default function ActionButton({
 
   return (
     <Overlay data-testid="action-button" hasAction={Boolean(action)} flex align="stretch" {...wrapperProps}>
-      <StyledButton
-        color={color}
-        disabled={disabled}
-        shouldUseDisabledColor={shouldUseDisabledColor}
-        onClick={action?.onClick || onClick}
-        {...rest}
-      >
-        <ThemedText.TransitionButton buttonSize={action ? 'medium' : 'large'} color={textColor}>
-          {action?.children || children}
-        </ThemedText.TransitionButton>
-      </StyledButton>
+      {!action?.hideButton && (
+        <StyledButton
+          color={color}
+          disabled={disabled}
+          shouldUseDisabledColor={shouldUseDisabledColor}
+          onClick={action?.onClick || onClick}
+          {...rest}
+        >
+          <ThemedText.TransitionButton buttonSize={action ? 'medium' : 'large'} color={textColor}>
+            {action?.children || children}
+          </ThemedText.TransitionButton>
+        </StyledButton>
+      )}
       {action && (
         <ActionRow gap={0.5} color={action.color ?? 'primary'}>
           {action.tooltipContent ? (

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -24,7 +24,7 @@ interface StatusHeaderProps {
   children: ReactNode
 }
 
-export function StatusHeader({ icon: Icon, iconColor, iconSize = 4, children }: StatusHeaderProps) {
+export function StatusHeader({ icon: Icon, iconColor, iconSize = 5, children }: StatusHeaderProps) {
   return (
     <>
       <Column flex style={{ flexGrow: 1 }}>

--- a/src/components/Swap/Status/StatusDialog.tsx
+++ b/src/components/Swap/Status/StatusDialog.tsx
@@ -3,8 +3,9 @@ import ErrorDialog, { StatusHeader } from 'components/Error/ErrorDialog'
 import EtherscanLink from 'components/EtherscanLink'
 import Row from 'components/Row'
 import SwapSummary from 'components/Swap/Summary'
-import { LargeCheck, LargeSpinner } from 'icons'
-import { useMemo } from 'react'
+import { DialogAnimationLengthMs } from 'components/Widget'
+import { LargeArrow, LargeCheck, LargeSpinner } from 'icons'
+import { useEffect, useMemo, useState } from 'react'
 import { Transaction, TransactionType } from 'state/transactions'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -28,11 +29,27 @@ interface TransactionStatusProps {
 }
 
 function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
+  const [showConfirmation, setShowConfirmation] = useState(true)
   const Icon = useMemo(() => {
+    if (showConfirmation) {
+      return LargeArrow
+    }
     return tx.receipt?.status ? LargeCheck : LargeSpinner
-  }, [tx.receipt?.status])
+  }, [showConfirmation, tx.receipt?.status])
+  useEffect(() => {
+    // We should show the confirmation for 1 second,
+    // which should start after the entrance animation is complete.
+    const handle = setTimeout(() => {
+      setShowConfirmation(false)
+    }, 1000 + DialogAnimationLengthMs)
+    return () => {
+      clearTimeout(handle)
+    }
+  }, [])
   const heading = useMemo(() => {
-    if (tx.info.type === TransactionType.SWAP) {
+    if (showConfirmation) {
+      return <Trans>Transaction submitted</Trans>
+    } else if (tx.info.type === TransactionType.SWAP) {
       return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Swap pending</Trans>
     } else if (tx.info.type === TransactionType.WRAP) {
       return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Unwrap pending</Trans>
@@ -40,7 +57,7 @@ function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
       return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Unwrap pending</Trans>
     }
     return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Transaction pending</Trans>
-  }, [tx.info, tx.receipt?.status])
+  }, [showConfirmation, tx.info.type, tx.receipt?.status])
 
   const subheading = useMemo(() => {
     if (tx.receipt?.status) {

--- a/src/components/Swap/Status/StatusDialog.tsx
+++ b/src/components/Swap/Status/StatusDialog.tsx
@@ -4,6 +4,7 @@ import EtherscanLink from 'components/EtherscanLink'
 import Row from 'components/Row'
 import SwapSummary from 'components/Swap/Summary'
 import { DialogAnimationLengthMs } from 'components/Widget'
+import { MS_IN_SECOND } from 'constants/misc'
 import { LargeArrow, LargeCheck, LargeSpinner } from 'icons'
 import { useEffect, useMemo, useState } from 'react'
 import { Transaction, TransactionType } from 'state/transactions'
@@ -36,16 +37,18 @@ function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
     }
     return tx.receipt?.status ? LargeCheck : LargeSpinner
   }, [showConfirmation, tx.receipt?.status])
+
   useEffect(() => {
     // We should show the confirmation for 1 second,
     // which should start after the entrance animation is complete.
     const handle = setTimeout(() => {
       setShowConfirmation(false)
-    }, 1000 + DialogAnimationLengthMs)
+    }, MS_IN_SECOND + DialogAnimationLengthMs)
     return () => {
       clearTimeout(handle)
     }
   }, [])
+
   const heading = useMemo(() => {
     if (showConfirmation) {
       return <Trans>Transaction submitted</Trans>

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -51,7 +51,7 @@ function ConfirmButton({
 
   const action = useMemo((): Action | undefined => {
     if (isPending) {
-      return { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner }
+      return { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner, hideButton: true }
     } else if (doesTradeDiffer) {
       return {
         color: 'accent',

--- a/src/components/Swap/SwapActionButton/WrapButton.tsx
+++ b/src/components/Swap/SwapActionButton/WrapButton.tsx
@@ -47,7 +47,9 @@ export default function WrapButton({ disabled }: { disabled: boolean }) {
 
   const actionProps = useMemo(
     () =>
-      isPending ? { action: { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner } } : { onClick: onWrap },
+      isPending
+        ? { action: { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner, hideButton: true } }
+        : { onClick: onWrap },
     [isPending, onWrap]
   )
 

--- a/src/components/Widget.tsx
+++ b/src/components/Widget.tsx
@@ -35,6 +35,8 @@ const slideOutRight = keyframes`
   }
 `
 
+export const DialogAnimationLengthMs = 250
+
 export const DialogWrapper = styled.div`
   border: ${({ theme }) => `1px solid ${theme.outline}`};
 
@@ -52,13 +54,13 @@ export const DialogWrapper = styled.div`
   }
 
   ${Modal} {
-    animation: ${slideInLeft} 0.25s ease-in;
+    animation: ${slideInLeft} ${DialogAnimationLengthMs}ms ease-in;
 
     &.${Animation.PAGING} {
-      animation: ${slideOutLeft} 0.25s ease-in;
+      animation: ${slideOutLeft} ${DialogAnimationLengthMs}ms ease-in;
     }
     &.${Animation.CLOSING} {
-      animation: ${slideOutRight} 0.25s ease-out;
+      animation: ${slideOutRight} ${DialogAnimationLengthMs}ms ease-out;
     }
   }
 `

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -7,6 +7,8 @@ export const NetworkContextName = 'NETWORK'
 
 export const IS_IN_IFRAME = window.parent !== window
 
+export const MS_IN_SECOND = 1000
+
 // 30 minutes, denominated in seconds
 export const DEFAULT_DEADLINE_FROM_NOW = 60 * 30
 export const L2_DEADLINE_FROM_NOW = 60 * 5

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -2,6 +2,7 @@ import { ReactComponent as RouterIcon } from 'assets/svg/auto_router.svg'
 import { ReactComponent as CheckIcon } from 'assets/svg/check.svg'
 import { ReactComponent as ExpandoIcon } from 'assets/svg/expando.svg'
 import { ReactComponent as GasIcon } from 'assets/svg/gasIcon.svg'
+import { ReactComponent as LargeArrowIcon } from 'assets/svg/large_arrow.svg'
 import { ReactComponent as LargeCheckIcon } from 'assets/svg/large_check.svg'
 import { ReactComponent as LargeSpinnerIcon } from 'assets/svg/large_spinner.svg'
 import { ReactComponent as LogoIcon } from 'assets/svg/logo.svg'
@@ -160,6 +161,10 @@ export const LargeCheck = styled(icon(LargeCheckIcon))<{ color?: Color }>`
 
 export const LargeSpinner = styled(icon(LargeSpinnerIcon))<{ color?: Color }>`
   animation: 2s ${rotate} linear infinite;
+  stroke: ${({ color = 'primary', theme }) => theme[color]};
+`
+
+export const LargeArrow = styled(icon(LargeArrowIcon))<{ color?: Color }>`
   stroke: ${({ color = 'primary', theme }) => theme[color]};
 `
 


### PR DESCRIPTION
we want to show this state for one second before the spinner state


https://user-images.githubusercontent.com/66155195/213035780-e126bde3-f9ba-483c-b47f-095178706dd5.mov

