### PR TITLE
feat: use bottom sheet for routing diagram

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -116,7 +116,7 @@ export const Modal = styled.div<{ color: Color }>`
   padding: 0.5em;
   position: absolute;
   top: 0;
-  width: 100%;
+  width: calc(100% - 1em);
   z-index: ${Layer.DIALOG};
 `
 

--- a/src/components/Swap/RoutingDiagram/index.tsx
+++ b/src/components/Swap/RoutingDiagram/index.tsx
@@ -131,16 +131,22 @@ function Route({ route }: { route: RoutingDiagramEntry }) {
 export default function RoutingDiagram({
   trade,
   gasUseEstimateUSD,
+  hideHeader,
 }: {
   trade: InterfaceTrade
   gasUseEstimateUSD?: CurrencyAmount<Token> | null
+  hideHeader?: boolean
 }) {
   const routes: RoutingDiagramEntry[] = useMemo(() => getTokenPath(trade), [trade])
 
   return (
     <Column gap={0.75}>
-      <AutoRouterHeader />
-      <Rule />
+      {!hideHeader && (
+        <>
+          <AutoRouterHeader />
+          <Rule />
+        </>
+      )}
       {routes.map((route, index) => (
         <Route key={index} route={route} />
       ))}

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -2,13 +2,17 @@ import { Trans } from '@lingui/macro'
 import { Placement } from '@popperjs/core'
 import { formatCurrencyAmount, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { BottomSheetModal } from 'components/BottomSheetModal'
+import { IconButton } from 'components/Button'
+import Column from 'components/Column'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
 import { loadingCss } from 'css/loading'
+import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import { PriceImpact as PriceImpactType } from 'hooks/usePriceImpact'
 import { useIsWideWidget } from 'hooks/useWidgetWidth'
 import { AlertTriangle, ChevronDown, Gas, Icon, Info, LargeIcon, Spinner } from 'icons'
-import { ReactNode, useCallback } from 'react'
+import { ReactNode, useCallback, useState } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { Color, ThemedText } from 'theme'
@@ -71,6 +75,8 @@ function Caption({ icon: Icon, caption, color = 'secondary', tooltip }: CaptionP
 
 function GasEstimate({ gasUseEstimateUSD, trade }: TradeTooltip) {
   const isWideWidget = useIsWideWidget()
+  const isMobile = useIsMobileWidth()
+  const [open, setOpen] = useState(false)
   if (gasUseEstimateUSD === null) {
     return null
   }
@@ -79,9 +85,20 @@ function GasEstimate({ gasUseEstimateUSD, trade }: TradeTooltip) {
     <CaptionRow gap={0.25}>
       <>
         {trade ? (
-          <Tooltip icon={Gas} placement="left" iconProps={{ color: 'secondary' }}>
-            <RoutingDiagram trade={trade} />
-          </Tooltip>
+          isMobile ? (
+            <>
+              <IconButton onClick={() => setOpen(!open)} icon={Gas} iconProps={{ color: 'secondary' }} />
+              <BottomSheetModal title="Route details" onClose={() => setOpen(false)} open={open}>
+                <Column padded>
+                  <RoutingDiagram trade={trade} hideHeader />
+                </Column>
+              </BottomSheetModal>
+            </>
+          ) : (
+            <Tooltip icon={Gas} placement="left" iconProps={{ color: 'secondary' }}>
+              <RoutingDiagram trade={trade} />
+            </Tooltip>
+          )
         ) : (
           <Gas color="secondary" />
         )}

--- a/src/components/Swap/Toolbar/ToolbarOrderRouting.tsx
+++ b/src/components/Swap/Toolbar/ToolbarOrderRouting.tsx
@@ -1,8 +1,13 @@
 import { Trans } from '@lingui/macro'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { BottomSheetModal } from 'components/BottomSheetModal'
+import { IconButton } from 'components/Button'
+import Column from 'components/Column'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
+import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import { Info } from 'icons'
+import { useState } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -26,17 +31,29 @@ interface ToolbarOrderRoutingProps {
 }
 
 export default function ToolbarOrderRouting({ trade, gasUseEstimateUSD }: ToolbarOrderRoutingProps) {
+  const isMobile = useIsMobileWidth()
+  const [open, setOpen] = useState(false)
   return (
     <OrderRoutingRow flex>
       <Row gap={0.25}>
         <ThemedText.Body2 color="secondary">
           <Trans>Order routing</Trans>
         </ThemedText.Body2>
-        {trade && (
-          <Tooltip icon={Info} contained>
-            <RoutingDiagram trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} />
-          </Tooltip>
-        )}
+        {trade &&
+          (isMobile ? (
+            <>
+              <IconButton onClick={() => setOpen(!open)} icon={Info} />
+              <BottomSheetModal title="Route details" onClose={() => setOpen(false)} open={open}>
+                <Column padded>
+                  <RoutingDiagram trade={trade} hideHeader />
+                </Column>
+              </BottomSheetModal>
+            </>
+          ) : (
+            <Tooltip icon={Info} contained>
+              <RoutingDiagram trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} />
+            </Tooltip>
+          ))}
       </Row>
       <AutoRouterHeader />
     </OrderRoutingRow>


### PR DESCRIPTION
based on the [design spec](https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=1708%3A26043&t=5QXnxfgYI7whcjzT-0)

the routing diagram tooltip should also become a bottom sheet on smaller screens. this PR updates the two callsites for of RoutingDiagram to optionally wrap it in the BottomSheetModal.

also, fixes a width issue with the bottom sheet dialog