### PR TITLE
Web 2711 price impact speedbumps

### DIFF
--- a/src/components/Swap/Speedbump/index.tsx
+++ b/src/components/Swap/Speedbump/index.tsx
@@ -1,0 +1,68 @@
+import { t, Trans } from '@lingui/macro'
+import Column from 'components/Column'
+import { StatusHeader } from 'components/Error/ErrorDialog'
+import { PriceImpact } from 'hooks/usePriceImpact'
+import { AlertTriangle, LargeIcon, X } from 'icons'
+import styled from 'styled-components/macro'
+import { ThemedText } from 'theme'
+
+const Body = styled(Column)`
+  height: calc(100% - 2.5em);
+`
+const SpeedbumpWrapper = styled.div`
+  padding: 1.75em 1.25em;
+`
+
+interface SpeedbumpDialogProps {
+  impact: PriceImpact
+  onContinue: () => void
+  onClose: () => void
+}
+
+export function SpeedbumpDialog({ impact, onContinue, onClose }: SpeedbumpDialogProps) {
+  return (
+    <SpeedbumpWrapper>
+      <div onClick={onClose}>
+        <LargeIcon icon={X} color="primary" />
+      </div>
+
+      <Body flex align="stretch" padded gap={0.75}>
+        <StatusHeader icon={AlertTriangle} iconColor="critical" iconSize={4}>
+          <Column>
+            <ThemedText.H3>
+              <Trans>Warning</Trans>
+            </ThemedText.H3>
+            <ThemedText.Body1>
+              {t`This transaction will result in a ${impact?.toString()} price impact on the market price of this pool. Do you wish to continue? `}
+            </ThemedText.Body1>
+          </Column>
+        </StatusHeader>
+        {/* <Heading gap={0.75} flex justify="center">
+          <Summary
+            input={inputAmount}
+            output={outputAmount}
+            inputUSDC={inputUSDC}
+            outputUSDC={outputUSDC}
+            impact={impact}
+            open={open}
+          />
+          <Price trade={trade} />
+        </Heading>
+        <Expando
+          title={<Subhead impact={impact} slippage={slippage} />}
+          open={open}
+          onExpand={onExpand}
+          height={6}
+          gap={open ? 0 : 0.75}
+        >
+          <Column gap={0.5}>
+            <Details trade={trade} slippage={slippage} gasUseEstimateUSD={gasUseEstimateUSD} impact={impact} />
+            <Estimate trade={trade} slippage={slippage} />
+          </Column>
+        </Expando> */}
+
+        {/* <ConfirmButton trade={trade} highPriceImpact={impact?.warning === 'error'} onConfirm={onConfirm} /> */}
+      </Body>
+    </SpeedbumpWrapper>
+  )
+}

--- a/src/components/Swap/Speedbump/index.tsx
+++ b/src/components/Swap/Speedbump/index.tsx
@@ -1,16 +1,38 @@
 import { t, Trans } from '@lingui/macro'
+import Button, { TextButton } from 'components/Button'
 import Column from 'components/Column'
-import { StatusHeader } from 'components/Error/ErrorDialog'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { AlertTriangle, LargeIcon, X } from 'icons'
-import styled from 'styled-components/macro'
+import styled, { css } from 'styled-components/macro'
 import { ThemedText } from 'theme'
 
 const Body = styled(Column)`
-  height: calc(100% - 2.5em);
+  align-items: center;
+  height: 100%;
+  text-align: center;
+  width: 100%;
 `
 const SpeedbumpWrapper = styled.div`
-  padding: 1.75em 1.25em;
+  padding: 1.5em 1.25em;
+`
+const SpeedbumpButtonStyle = css`
+  border-radius: 1em;
+  padding: 1em;
+`
+
+const StyledXButton = styled(LargeIcon).attrs({ icon: X, color: 'primary', size: 1.5 })`
+  :hover {
+    cursor: pointer;
+  }
+`
+const ContinueButton = styled(Button)`
+  ${SpeedbumpButtonStyle}
+  background-color: ${({ theme }) => theme.criticalSoft};
+  color: ${({ theme }) => theme.critical};
+`
+const CancelButton = styled(TextButton)`
+  ${SpeedbumpButtonStyle}
+  color: ${({ theme }) => theme.secondary};
 `
 
 interface SpeedbumpDialogProps {
@@ -22,46 +44,28 @@ interface SpeedbumpDialogProps {
 export function SpeedbumpDialog({ impact, onContinue, onClose }: SpeedbumpDialogProps) {
   return (
     <SpeedbumpWrapper>
-      <div onClick={onClose}>
-        <LargeIcon icon={X} color="primary" />
-      </div>
-
+      <StyledXButton onClick={onClose} />
       <Body flex align="stretch" padded gap={0.75}>
-        <StatusHeader icon={AlertTriangle} iconColor="critical" iconSize={4}>
-          <Column>
-            <ThemedText.H3>
-              <Trans>Warning</Trans>
-            </ThemedText.H3>
-            <ThemedText.Body1>
-              {t`This transaction will result in a ${impact?.toString()} price impact on the market price of this pool. Do you wish to continue? `}
-            </ThemedText.Body1>
-          </Column>
-        </StatusHeader>
-        {/* <Heading gap={0.75} flex justify="center">
-          <Summary
-            input={inputAmount}
-            output={outputAmount}
-            inputUSDC={inputUSDC}
-            outputUSDC={outputUSDC}
-            impact={impact}
-            open={open}
-          />
-          <Price trade={trade} />
-        </Heading>
-        <Expando
-          title={<Subhead impact={impact} slippage={slippage} />}
-          open={open}
-          onExpand={onExpand}
-          height={6}
-          gap={open ? 0 : 0.75}
-        >
-          <Column gap={0.5}>
-            <Details trade={trade} slippage={slippage} gasUseEstimateUSD={gasUseEstimateUSD} impact={impact} />
-            <Estimate trade={trade} slippage={slippage} />
-          </Column>
-        </Expando> */}
+        <LargeIcon icon={AlertTriangle} color="critical" size={4} />
 
-        {/* <ConfirmButton trade={trade} highPriceImpact={impact?.warning === 'error'} onConfirm={onConfirm} /> */}
+        <Column>
+          <ThemedText.H3>
+            <Trans>Warning</Trans>
+          </ThemedText.H3>
+          <ThemedText.Body1>
+            {t`This transaction will result in a ${impact?.toString()} price impact on the market price of this pool. Do you wish to continue? `}
+          </ThemedText.Body1>
+          <ContinueButton onClick={onContinue}>
+            <ThemedText.ButtonLarge>
+              <Trans>Continue</Trans>
+            </ThemedText.ButtonLarge>
+          </ContinueButton>
+          <CancelButton onClick={onClose}>
+            <ThemedText.ButtonMedium>
+              <Trans>Cancel</Trans>
+            </ThemedText.ButtonMedium>
+          </CancelButton>
+        </Column>
       </Body>
     </SpeedbumpWrapper>
   )

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -123,7 +123,7 @@ export function SummaryDialog(props: SummaryDialogProps) {
         props.impact && (
           <SpeedbumpDialog onAcknowledge={onAcknowledgePriceImpact} impact={props.impact}>
             {t`This transaction will result in a`} <PriceImpactText>{props.impact.toString()}</PriceImpactText>
-            {` price impact on the market price of this pool. Do you wish to continue? `}
+            {t` price impact on the market price of this pool. Do you wish to continue? `}
           </SpeedbumpDialog>
         )
       )}

--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -131,7 +131,7 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
         </Dialog>
       )}
       {view === VIEW.IMPACT_SPEEDBUMP && impact && (
-        <Dialog color="dialog" onClose={() => setView(VIEW.DEFAULT)}>
+        <Dialog color="container" onClose={() => setView(VIEW.DEFAULT)}>
           <SpeedbumpDialog onContinue={() => onContinue()} onClose={() => setView(VIEW.DEFAULT)} impact={impact} />
         </Dialog>
       )}

--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -20,12 +20,6 @@ import Dialog from '../../Dialog'
 import { SummaryDialog } from '../Summary'
 import useOnSubmit from './useOnSubmit'
 
-enum VIEW {
-  DEFAULT,
-  IMPACT_SPEEDBUMP,
-  SWAP_REVIEW,
-}
-
 /**
  * A swapping ActionButton.
  * Should only be rendered if a valid swap exists.
@@ -64,7 +58,7 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
 
   const [open, setOpen] = useState(false)
   // Close the review modal if there is no available trade.
-  useEffect(() => setOpen((view) => (trade ? view : false)), [trade])
+  useEffect(() => setOpen((open) => (trade ? open : false)), [trade])
   // Close the review modal on chain change.
   useEffect(() => setOpen(false), [chainId])
 

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -27,7 +27,7 @@ export const ONE_BIPS = new Percent(JSBI.BigInt(1), BIPS_BASE)
 // used for warning states
 export const ALLOWED_PRICE_IMPACT_LOW: Percent = new Percent(JSBI.BigInt(100), BIPS_BASE) // 1%
 export const ALLOWED_PRICE_IMPACT_MEDIUM: Percent = new Percent(JSBI.BigInt(300), BIPS_BASE) // 3%
-export const ALLOWED_PRICE_IMPACT_HIGH: Percent = new Percent(JSBI.BigInt(500), BIPS_BASE) // 5%
+export const ALLOWED_PRICE_IMPACT_HIGH: Percent = new Percent(JSBI.BigInt(5), BIPS_BASE) // 5%
 // if the price slippage exceeds this number, force the user to type 'confirm' to execute
 export const PRICE_IMPACT_WITHOUT_FEE_CONFIRM_MIN: Percent = new Percent(JSBI.BigInt(1000), BIPS_BASE) // 10%
 // for non expert mode disable swaps above this

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -60,7 +60,7 @@ export const largeIconCss = css<{ iconSize: number }>`
 `
 
 const LargeWrapper = styled.div<{ iconSize: number }>`
-  height: 1em;
+  height: ${({ iconSize }) => iconSize}em;
   width: ${({ iconSize }) => iconSize}em;
   ${largeIconCss}
 `
@@ -71,13 +71,14 @@ interface LargeIconProps {
   icon?: Icon
   color?: Color
   size?: number
+  onClick?: () => void
   className?: string
 }
 
-export function LargeIcon({ icon: Icon, color, size = 1.2, className }: LargeIconProps) {
+export function LargeIcon({ icon: Icon, color, size = 1.2, onClick, className }: LargeIconProps) {
   return (
     <LargeWrapper color={color} iconSize={size} className={className}>
-      {Icon && <Icon color={color} />}
+      {Icon && <Icon color={color} onClick={onClick} />}
     </LargeWrapper>
   )
 }


### PR DESCRIPTION
Replaces "acknowledge price impact" section of the confirm swap button with a price impact speedbump, which will appear if the user clicks "Review Swap" on a high impact trade, or if they are on a Review Swap page whose trade's price impact is updated to a warning level.

Once a price impact is acknowledged, further impact update speedbumps will not appear.

Also updates LargeIcon component to accept strokeWidth prop

https://user-images.githubusercontent.com/39385577/213253793-81ef9025-2c90-4493-818d-295e7edeb606.mov