### PR TITLE
feat: move RoutingDiagram tooltip

### DIFF
--- a/src/components/Swap/RoutingDiagram/index.tsx
+++ b/src/components/Swap/RoutingDiagram/index.tsx
@@ -8,7 +8,7 @@ import Row from 'components/Row'
 import Rule from 'components/Rule'
 import TokenImg from 'components/TokenImg'
 import { AutoRouter } from 'icons'
-import { useMemo } from 'react'
+import { ComponentProps, forwardRef, useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { Layer, ThemedText } from 'theme'
@@ -23,9 +23,12 @@ const StyledAutoRouterLabel = styled(ThemedText.ButtonSmall)`
   }
 `
 
-export function AutoRouterHeader() {
+export const AutoRouterHeader = forwardRef<HTMLDivElement, ComponentProps<typeof Row>>(function AutoRouterHeader(
+  props,
+  ref
+) {
   return (
-    <Row justify="left" gap={0.25}>
+    <Row justify="left" gap={0.25} ref={ref} {...props}>
       <AutoRouter />
       <StyledAutoRouterLabel color="primary" lineHeight={'16px'}>
         <ThemedText.Subhead2>
@@ -34,7 +37,7 @@ export function AutoRouterHeader() {
       </StyledAutoRouterLabel>
     </Row>
   )
-}
+})
 
 const Dots = styled(DotLine)`
   color: ${({ theme }) => theme.outline};

--- a/src/components/Swap/Toolbar/ToolbarOrderRouting.tsx
+++ b/src/components/Swap/Toolbar/ToolbarOrderRouting.tsx
@@ -1,8 +1,9 @@
 import { Trans } from '@lingui/macro'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import Popover from 'components/Popover'
 import Row from 'components/Row'
-import Tooltip from 'components/Tooltip'
-import { Info } from 'icons'
+import { useTooltip } from 'components/Tooltip'
+import { useState } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -26,19 +27,22 @@ interface ToolbarOrderRoutingProps {
 }
 
 export default function ToolbarOrderRouting({ trade, gasUseEstimateUSD }: ToolbarOrderRoutingProps) {
+  const [tooltip, setTooltip] = useState<HTMLDivElement | null>(null)
+  const showTooltip = useTooltip(tooltip)
   return (
     <OrderRoutingRow flex>
       <Row gap={0.25}>
         <ThemedText.Body2 color="secondary">
           <Trans>Order routing</Trans>
         </ThemedText.Body2>
-        {trade && (
-          <Tooltip icon={Info} contained>
-            <RoutingDiagram trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} />
-          </Tooltip>
-        )}
       </Row>
-      <AutoRouterHeader />
+      <Popover
+        content={trade ? <RoutingDiagram gasUseEstimateUSD={gasUseEstimateUSD} trade={trade} /> : null}
+        show={Boolean(trade) && showTooltip}
+        placement={'top'}
+      >
+        <AutoRouterHeader ref={setTooltip} />
+      </Popover>
     </OrderRoutingRow>
   )
 }

--- a/src/components/Swap/Toolbar/__snapshots__/ToolbarOrderRouting.test.tsx.snap
+++ b/src/components/Swap/Toolbar/__snapshots__/ToolbarOrderRouting.test.tsx.snap
@@ -20,57 +20,23 @@ Object {
             >
               Order routing
             </div>
-            <div
-              class="Popover__Reference-sc-1liex6z-1 dxsTSY"
-            >
-              <button
-                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 bIUiVy hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-0 edibPG"
-                style="outline: none;"
-                tabindex="-1"
-              >
-                <svg
-                  class="icons-sc-lekdau-0 iSRwlR"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                  />
-                  <line
-                    x1="12"
-                    x2="12"
-                    y1="16"
-                    y2="12"
-                  />
-                  <line
-                    x1="12"
-                    x2="12.01"
-                    y1="8"
-                    y2="8"
-                  />
-                </svg>
-              </button>
-            </div>
           </div>
           <div
-            class="Row-sc-1nzvhrh-0 feiOJv"
+            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
           >
             <div
-              class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
+              class="Row-sc-1nzvhrh-0 feiOJv"
+              style="outline: none;"
+              tabindex="-1"
             >
               <div
-                class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+                class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
               >
-                Auto Router
+                <div
+                  class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+                >
+                  Auto Router
+                </div>
               </div>
             </div>
           </div>
@@ -94,57 +60,23 @@ Object {
           >
             Order routing
           </div>
-          <div
-            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
-          >
-            <button
-              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 bIUiVy hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-0 edibPG"
-              style="outline: none;"
-              tabindex="-1"
-            >
-              <svg
-                class="icons-sc-lekdau-0 iSRwlR"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                />
-                <line
-                  x1="12"
-                  x2="12"
-                  y1="16"
-                  y2="12"
-                />
-                <line
-                  x1="12"
-                  x2="12.01"
-                  y1="8"
-                  y2="8"
-                />
-              </svg>
-            </button>
-          </div>
         </div>
         <div
-          class="Row-sc-1nzvhrh-0 feiOJv"
+          class="Popover__Reference-sc-1liex6z-1 dxsTSY"
         >
           <div
-            class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
+            class="Row-sc-1nzvhrh-0 feiOJv"
+            style="outline: none;"
+            tabindex="-1"
           >
             <div
-              class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+              class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
             >
-              Auto Router
+              <div
+                class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+              >
+                Auto Router
+              </div>
             </div>
           </div>
         </div>
@@ -225,57 +157,23 @@ Object {
             >
               Order routing
             </div>
-            <div
-              class="Popover__Reference-sc-1liex6z-1 dxsTSY"
-            >
-              <button
-                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 bIUiVy hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-0 edibPG"
-                style="outline: none;"
-                tabindex="-1"
-              >
-                <svg
-                  class="icons-sc-lekdau-0 iSRwlR"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                  />
-                  <line
-                    x1="12"
-                    x2="12"
-                    y1="16"
-                    y2="12"
-                  />
-                  <line
-                    x1="12"
-                    x2="12.01"
-                    y1="8"
-                    y2="8"
-                  />
-                </svg>
-              </button>
-            </div>
           </div>
           <div
-            class="Row-sc-1nzvhrh-0 feiOJv"
+            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
           >
             <div
-              class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
+              class="Row-sc-1nzvhrh-0 feiOJv"
+              style="outline: none;"
+              tabindex="-1"
             >
               <div
-                class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+                class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
               >
-                Auto Router
+                <div
+                  class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+                >
+                  Auto Router
+                </div>
               </div>
             </div>
           </div>
@@ -299,57 +197,23 @@ Object {
           >
             Order routing
           </div>
-          <div
-            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
-          >
-            <button
-              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 bIUiVy hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-0 edibPG"
-              style="outline: none;"
-              tabindex="-1"
-            >
-              <svg
-                class="icons-sc-lekdau-0 iSRwlR"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                />
-                <line
-                  x1="12"
-                  x2="12"
-                  y1="16"
-                  y2="12"
-                />
-                <line
-                  x1="12"
-                  x2="12.01"
-                  y1="8"
-                  y2="8"
-                />
-              </svg>
-            </button>
-          </div>
         </div>
         <div
-          class="Row-sc-1nzvhrh-0 feiOJv"
+          class="Popover__Reference-sc-1liex6z-1 dxsTSY"
         >
           <div
-            class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
+            class="Row-sc-1nzvhrh-0 feiOJv"
+            style="outline: none;"
+            tabindex="-1"
           >
             <div
-              class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+              class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
             >
-              Auto Router
+              <div
+                class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+              >
+                Auto Router
+              </div>
             </div>
           </div>
         </div>
@@ -430,57 +294,23 @@ Object {
             >
               Order routing
             </div>
-            <div
-              class="Popover__Reference-sc-1liex6z-1 dxsTSY"
-            >
-              <button
-                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 bIUiVy hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-0 edibPG"
-                style="outline: none;"
-                tabindex="-1"
-              >
-                <svg
-                  class="icons-sc-lekdau-0 iSRwlR"
-                  fill="none"
-                  height="24"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <circle
-                    cx="12"
-                    cy="12"
-                    r="10"
-                  />
-                  <line
-                    x1="12"
-                    x2="12"
-                    y1="16"
-                    y2="12"
-                  />
-                  <line
-                    x1="12"
-                    x2="12.01"
-                    y1="8"
-                    y2="8"
-                  />
-                </svg>
-              </button>
-            </div>
           </div>
           <div
-            class="Row-sc-1nzvhrh-0 feiOJv"
+            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
           >
             <div
-              class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
+              class="Row-sc-1nzvhrh-0 feiOJv"
+              style="outline: none;"
+              tabindex="-1"
             >
               <div
-                class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+                class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
               >
-                Auto Router
+                <div
+                  class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+                >
+                  Auto Router
+                </div>
               </div>
             </div>
           </div>
@@ -504,57 +334,23 @@ Object {
           >
             Order routing
           </div>
-          <div
-            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
-          >
-            <button
-              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 bIUiVy hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-0 edibPG"
-              style="outline: none;"
-              tabindex="-1"
-            >
-              <svg
-                class="icons-sc-lekdau-0 iSRwlR"
-                fill="none"
-                height="24"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="10"
-                />
-                <line
-                  x1="12"
-                  x2="12"
-                  y1="16"
-                  y2="12"
-                />
-                <line
-                  x1="12"
-                  x2="12.01"
-                  y1="8"
-                  y2="8"
-                />
-              </svg>
-            </button>
-          </div>
         </div>
         <div
-          class="Row-sc-1nzvhrh-0 feiOJv"
+          class="Popover__Reference-sc-1liex6z-1 dxsTSY"
         >
           <div
-            class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
+            class="Row-sc-1nzvhrh-0 feiOJv"
+            style="outline: none;"
+            tabindex="-1"
           >
             <div
-              class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+              class="type__TextWrapper-sc-16386l-0 bevZkg RoutingDiagram__StyledAutoRouterLabel-sc-3p4p27-0 hyAjPo css-aeawsu"
             >
-              Auto Router
+              <div
+                class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
+              >
+                Auto Router
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
[see updated design](https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=11388%3A110999&t=DBqcwSK7XYGI0Y55-4)

we want the RoutingDiagram to appear in a tooltip over the "Auto Router" label on the right, not as an Icon on the left.