### PR TITLE
fix: remove toolbar when on mismatched chain

### DIFF
--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -67,8 +67,6 @@ export default memo(function Toolbar() {
         return <Caption.UnsupportedNetwork />
       case ChainError.MISMATCHED_TOKEN_CHAINS:
         return <Caption.Error />
-      case ChainError.MISMATCHED_CHAINS:
-        return
       default:
     }
 
@@ -166,7 +164,7 @@ export default memo(function Toolbar() {
     return summaryHeight + ORDER_ROUTING_HEIGHT_EM + 1 /* accounts for the border */
   }, [tradeSummaryRows.length])
 
-  if (inputCurrency == null || outputCurrency == null) {
+  if (inputCurrency == null || outputCurrency == null || error === ChainError.MISMATCHED_CHAINS) {
     return null
   }
 


### PR DESCRIPTION
<img width="338" alt="Screenshot 2023-01-18 at 9 52 26 AM" src="https://user-images.githubusercontent.com/66155195/213257360-3d3c968a-3730-4616-acff-bb2ff76e147a.png">

fixes a bug where we show an empty toolbar in the `ChainError.MISMATCHED_CHAINS` case

we can just default to showing the ActionButton here, since it already has the error message and a button to switch.

(draft until design confirms this behavior)