### PR TITLE
fix: show cancel button on review step

### DIFF
--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -53,7 +53,13 @@ function ConfirmButton({
 
   const action = useMemo((): Action | undefined => {
     if (isPending) {
-      return { message: <Trans>Confirm in your wallet</Trans>, icon: Spinner, hideButton: true }
+      return {
+        message: <Trans>Confirm in your wallet</Trans>,
+        icon: Spinner,
+        onClick: () => {
+          setIsPending(false)
+        },
+      }
     } else if (doesTradeDiffer) {
       return {
         color: 'accent',
@@ -72,8 +78,8 @@ function ConfirmButton({
   }, [ackTrade, doesTradeDiffer, isPending, onAcknowledgeNewTrade, onSwapPriceUpdateAck, trade])
 
   return (
-    <ActionButton onClick={onClick} action={action} disabled={isPending}>
-      {isPending ? <Trans>Confirm</Trans> : <Trans>Confirm swap</Trans>}
+    <ActionButton onClick={onClick} action={action} color={isPending ? 'interactive' : 'accent'}>
+      {isPending ? <Trans>Cancel</Trans> : <Trans>Confirm swap</Trans>}
     </ActionButton>
   )
 }


### PR DESCRIPTION
from design from the testing session: "we should put a cancel button here. just ran into an issue where WC or rainbow bugged out, and I had no way to confirm the txn in wallet. meanwhile this state is persisting"

design spec link: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=11464%3A109782&t=y8WEesOQvG6h2Oop-4

so with this button, we'll always allow the user to cancel and revert the UI to the non-pending state.