### PR TITLE
fix: show gas estimate tooltip over text and icon

### DIFF
--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -1,24 +1,20 @@
 import { Trans } from '@lingui/macro'
 import { Placement } from '@popperjs/core'
-import { formatCurrencyAmount, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
-import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
-import { BottomSheetModal } from 'components/BottomSheetModal'
-import { IconButton } from 'components/Button'
-import Column from 'components/Column'
+import { formatPriceImpact } from '@uniswap/conedison/format'
+import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
 import { loadingCss } from 'css/loading'
-import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import { PriceImpact as PriceImpactType } from 'hooks/usePriceImpact'
 import { useIsWideWidget } from 'hooks/useWidgetWidth'
-import { AlertTriangle, ChevronDown, Gas, Icon, Info, LargeIcon, Spinner } from 'icons'
-import { ReactNode, useCallback, useState } from 'react'
+import { AlertTriangle, ChevronDown, Icon, Info, LargeIcon, Spinner } from 'icons'
+import { ReactNode, useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled from 'styled-components/macro'
 import { AnimationSpeed, Color, ThemedText } from 'theme'
 
 import Price from '../Price'
-import RoutingDiagram from '../RoutingDiagram'
+import { GasEstimateTooltip, TradeTooltip } from './GasEstimateTooltip'
 
 const Loading = styled.span`
   color: ${({ theme }) => theme.secondary};
@@ -55,11 +51,6 @@ interface CaptionProps {
   tooltip?: CaptionTooltip
 }
 
-interface TradeTooltip {
-  trade?: InterfaceTrade
-  gasUseEstimateUSD?: CurrencyAmount<Token> | null
-}
-
 function Caption({ icon: Icon, caption, color = 'secondary', tooltip }: CaptionProps) {
   return (
     <CaptionRow gap={0.5} shrink={0}>
@@ -71,41 +62,6 @@ function Caption({ icon: Icon, caption, color = 'secondary', tooltip }: CaptionP
         Icon && <LargeIcon icon={Icon} color={color} />
       )}
       <ThemedText.Body2 color={color}>{caption}</ThemedText.Body2>
-    </CaptionRow>
-  )
-}
-
-function GasEstimate({ gasUseEstimateUSD, trade }: TradeTooltip) {
-  const isWideWidget = useIsWideWidget()
-  const isMobile = useIsMobileWidth()
-  const [open, setOpen] = useState(false)
-  if (gasUseEstimateUSD === null) {
-    return null
-  }
-  const displayEstimate = formatCurrencyAmount(gasUseEstimateUSD, NumberType.FiatGasPrice)
-  return (
-    <CaptionRow gap={0.25}>
-      <>
-        {trade ? (
-          isMobile ? (
-            <>
-              <IconButton onClick={() => setOpen(!open)} icon={Gas} iconProps={{ color: 'secondary' }} />
-              <BottomSheetModal title="Route details" onClose={() => setOpen(false)} open={open}>
-                <Column padded>
-                  <RoutingDiagram trade={trade} hideHeader />
-                </Column>
-              </BottomSheetModal>
-            </>
-          ) : (
-            <Tooltip icon={Gas} placement="left" iconProps={{ color: 'secondary' }}>
-              <RoutingDiagram trade={trade} />
-            </Tooltip>
-          )
-        ) : (
-          <Gas color="secondary" />
-        )}
-        {isWideWidget && <ThemedText.Body2 color="secondary">{displayEstimate}</ThemedText.Body2>}
-      </>
     </CaptionRow>
   )
 }
@@ -177,7 +133,9 @@ export function LoadingTrade({ gasUseEstimateUSD }: TradeTooltip) {
           </Loading>
         }
       />
-      <GasEstimate gasUseEstimateUSD={gasUseEstimateUSD} />
+      <CaptionRow gap={0.25}>
+        <GasEstimateTooltip gasUseEstimateUSD={gasUseEstimateUSD} />
+      </CaptionRow>
     </>
   )
 }
@@ -231,7 +189,11 @@ export function Trade({
     <>
       <Caption caption={<Price trade={trade} outputUSDC={outputUSDC} />} />
       <CaptionRow gap={0.75}>
-        <GasEstimate gasUseEstimateUSD={gasUseEstimateUSD} trade={trade} />
+        {!expanded && (
+          <CaptionRow gap={0.25}>
+            <GasEstimateTooltip gasUseEstimateUSD={gasUseEstimateUSD} trade={trade} />
+          </CaptionRow>
+        )}
         <Expander expanded={expanded} onToggleExpand={onToggleExpand} />
       </CaptionRow>
     </>

--- a/src/components/Swap/Toolbar/GasEstimateTooltip.tsx
+++ b/src/components/Swap/Toolbar/GasEstimateTooltip.tsx
@@ -1,0 +1,66 @@
+import { formatCurrencyAmount, NumberType } from '@uniswap/conedison/format'
+import { CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { BottomSheetModal } from 'components/BottomSheetModal'
+import Column from 'components/Column'
+import Popover from 'components/Popover'
+import Row from 'components/Row'
+import { useTooltip } from 'components/Tooltip'
+import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
+import { useIsWideWidget } from 'hooks/useWidgetWidth'
+import { Gas } from 'icons'
+import { useState } from 'react'
+import { InterfaceTrade } from 'state/routing/types'
+import { ThemedText } from 'theme'
+
+import RoutingDiagram from '../RoutingDiagram'
+
+export interface TradeTooltip {
+  trade?: InterfaceTrade
+  gasUseEstimateUSD?: CurrencyAmount<Token> | null
+}
+
+/**
+ * Renders a Gas Icon and estimated gas cost in USD.
+ *
+ * On mobile widths, clicking the view opens a bottom sheet with the routing diagram.
+ * On larger widths, hovering or focusing the view shows a popover with the routing diagram.
+ */
+export function GasEstimateTooltip({ gasUseEstimateUSD, trade }: TradeTooltip) {
+  const isWide = useIsWideWidget()
+  const isMobile = useIsMobileWidth()
+  const [tooltip, setTooltip] = useState<HTMLDivElement | null>(null)
+  const showTooltip = useTooltip(tooltip)
+  const [open, setOpen] = useState(false)
+  const displayEstimate = formatCurrencyAmount(gasUseEstimateUSD, NumberType.FiatGasPrice)
+  return isMobile ? (
+    <>
+      <Row
+        gap={0.25}
+        onClick={() => {
+          setOpen((open) => !open)
+        }}
+      >
+        <Gas color="secondary" />
+        {isWide && <ThemedText.Body2 color="secondary">{displayEstimate}</ThemedText.Body2>}
+      </Row>
+      <BottomSheetModal title="Route details" onClose={() => setOpen(false)} open={Boolean(trade) && open}>
+        {trade && (
+          <Column padded>
+            <RoutingDiagram trade={trade} hideHeader gasUseEstimateUSD={gasUseEstimateUSD} />
+          </Column>
+        )}
+      </BottomSheetModal>
+    </>
+  ) : (
+    <Popover
+      content={trade ? <RoutingDiagram trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} /> : null}
+      placement="bottom"
+      show={Boolean(trade) && showTooltip}
+    >
+      <Row ref={setTooltip} gap={0.25}>
+        <Gas color="secondary" />
+        {isWide && <ThemedText.Body2 color="secondary">{displayEstimate}</ThemedText.Body2>}
+      </Row>
+    </Popover>
+  )
+}


### PR DESCRIPTION
- moved the GasEstimate tooltip into it's own file, because it's a bit large
- reworked the rendering logic for GasEstimate to be more clear - and so the tooltip will appear when hovering over the text as well as the icon