### PR TITLE
fix: prefer insufficient balance caption over approval flow

### DIFF
--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -56,6 +56,10 @@ export default memo(function Toolbar() {
   const permit2Enabled = usePermit2Enabled()
   const [open, setOpen] = useState(false)
 
+  const insufficientBalance: boolean | undefined = useMemo(() => {
+    return inputBalance && inputAmount && inputBalance.lessThan(inputAmount)
+  }, [inputAmount, inputBalance])
+
   const caption = useMemo(() => {
     const onExpand = () => {
       setOpen((open) => !open)
@@ -75,7 +79,7 @@ export default memo(function Toolbar() {
     }
 
     if (inputCurrency && outputCurrency && isAmountPopulated) {
-      if (inputBalance && inputAmount?.greaterThan(inputBalance)) {
+      if (insufficientBalance) {
         return <Caption.InsufficientBalance currency={inputCurrency} />
       }
       if (isWrap) {
@@ -110,8 +114,7 @@ export default memo(function Toolbar() {
     outputCurrency,
     isAmountPopulated,
     gasUseEstimateUSD,
-    inputBalance,
-    inputAmount,
+    insufficientBalance,
     isWrap,
     trade,
     impact,
@@ -168,13 +171,15 @@ export default memo(function Toolbar() {
     return null
   }
 
-  if (permit2Enabled) {
-    if (allowance.state === AllowanceState.REQUIRED) {
-      return <AllowanceButton {...allowance} />
-    }
-  } else {
-    if (approval.state !== SwapApprovalState.APPROVED) {
-      return <ApproveButton trade={trade} {...approval} />
+  if (!insufficientBalance) {
+    if (permit2Enabled) {
+      if (allowance.state === AllowanceState.REQUIRED) {
+        return <AllowanceButton {...allowance} />
+      }
+    } else {
+      if (approval.state !== SwapApprovalState.APPROVED) {
+        return <ApproveButton trade={trade} {...approval} />
+      }
     }
   }
 


### PR DESCRIPTION
prefer the "insufficient balance" caption instead of approval button.

this helps the user avoid an extra approval transaction before trying to complete a trade that they don't have the balance for.