### PR TITLE
fix: use auto placement on toolbar tooltips

### DIFF
--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -151,7 +151,7 @@ export function InsufficientLiquidity() {
         content: (
           <ThemedText.Caption>Not enough liquidity in pool to swap between these two tokens.</ThemedText.Caption>
         ),
-        placement: 'right',
+        placement: 'auto',
       }}
     />
   )
@@ -256,7 +256,7 @@ export function PriceImpact({ impact, expanded, onToggleExpand }: PriceImpactPro
         caption="High price impact"
         color={impact.warning}
         tooltip={{
-          placement: 'right',
+          placement: 'auto',
           content: <PriceImpactWarningTooltipContent />,
         }}
       />

--- a/src/components/Swap/Toolbar/ToolbarOrderRouting.tsx
+++ b/src/components/Swap/Toolbar/ToolbarOrderRouting.tsx
@@ -52,7 +52,7 @@ export default function ToolbarOrderRouting({ trade, gasUseEstimateUSD }: Toolba
           <Popover
             content={trade ? <RoutingDiagram gasUseEstimateUSD={gasUseEstimateUSD} trade={trade} /> : null}
             show={Boolean(trade) && showTooltip}
-            placement={'top'}
+            placement="auto"
           >
             <AutoRouterHeader ref={setTooltip} />
           </Popover>

--- a/src/components/Swap/Toolbar/ToolbarTradeSummary.tsx
+++ b/src/components/Swap/Toolbar/ToolbarTradeSummary.tsx
@@ -45,7 +45,7 @@ function SummaryRow({ name, value, color, nameTooltip, valueTooltip }: SummaryRo
       {nameTooltip ? (
         <Row gap={0.25}>
           <TradeAttributeName color={color}>{name}</TradeAttributeName>
-          <Tooltip icon={nameTooltip.icon} iconProps={{ color }} contained>
+          <Tooltip icon={nameTooltip.icon} iconProps={{ color }} placement="auto">
             {nameTooltip.content}
           </Tooltip>
         </Row>
@@ -54,7 +54,7 @@ function SummaryRow({ name, value, color, nameTooltip, valueTooltip }: SummaryRo
       )}
       {valueTooltip ? (
         <Row gap={0.25}>
-          <Tooltip icon={valueTooltip.icon} iconProps={{ color }} contained>
+          <Tooltip icon={valueTooltip.icon} iconProps={{ color }} placement="auto">
             {valueTooltip.content}
           </Tooltip>
           <TradeAttributeValue color={color}>{value}</TradeAttributeValue>


### PR DESCRIPTION
fixes a bug where the tooltips appear in totally wrong locations after the toolbar is expanded. using "auto" placement fixes the issue for all toolbar tooltips

