### PR TITLE
fix: hint color in dark theme

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -73,7 +73,7 @@ export const darkTheme: Colors = {
   onAccent: white,
   primary: white,
   secondary: 'hsl(227, 21%, 67%)',
-  hint: 'hsl(225, 10%, 47.1%)',
+  hint: 'hsla(225, 18%, 44%)',
   onInteractive: white,
 
   deepShadow: 'hsla(0, 0%, 0%, 0.32), hsla(0, 0%, 0%, 0.24), hsla(0, 0%, 0%, 0.24)',


### PR DESCRIPTION
see the input placeholder color here: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=10298%3A104518&t=MPVEUGMwd2mLGl3t-4