### PR TITLE
fix: lose focus on input when clicking max

### DIFF
--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -137,8 +137,7 @@ export function FieldWrapper({
   const onClickMax = useCallback(() => {
     if (!maxAmount) return
     updateAmount(maxAmount, /* origin= */ 'max')
-    input?.focus()
-  }, [input, maxAmount, updateAmount])
+  }, [maxAmount, updateAmount])
 
   return (
     <InputColumn


### PR DESCRIPTION
based on design feedback, we want to lose focus on the input when clicking max. this is also how the swap component works in interface currently.