### PR TITLE
fix: swap failed modal

### DIFF
--- a/src/components/Error/ErrorBoundary.tsx
+++ b/src/components/Error/ErrorBoundary.tsx
@@ -58,7 +58,7 @@ export default class ErrorBoundary extends Component<PropsWithChildren<ErrorBoun
     const action = error instanceof WidgetError ? error.action : DEFAULT_ERROR_ACTION
     return (
       <Dialog color="dialog">
-        <ErrorDialog error={error} header={header} action={action} onClick={() => window.location.reload()} />
+        <ErrorDialog message={header} error={error} action={action} onClick={() => window.location.reload()} />
       </Dialog>
     )
   }

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -53,12 +53,13 @@ const ExpandoContent = styled(ThemedText.Code)`
 
 interface ErrorDialogProps {
   header?: ReactNode
-  error: Error
+  message: ReactNode
+  error?: Error
   action: ReactNode
   onClick: () => void
 }
 
-export default function ErrorDialog({ header, error, action, onClick }: ErrorDialogProps) {
+export default function ErrorDialog({ header, message, error, action, onClick }: ErrorDialogProps) {
   const [open, setOpen] = useState(false)
   const onExpand = useCallback(() => setOpen((open) => !open), [])
 
@@ -66,33 +67,33 @@ export default function ErrorDialog({ header, error, action, onClick }: ErrorDia
     <Column flex padded gap={0.75} align="stretch" style={{ height: '100%' }}>
       <StatusHeader icon={AlertTriangle} iconColor="critical" iconSize={open ? 3 : 4}>
         <ErrorHeader gap={open ? 0 : 0.75} open={open}>
-          <ThemedText.Subhead1>
-            <Trans>Something went wrong.</Trans>
-          </ThemedText.Subhead1>
-          {!open && <ThemedText.Body2>{header}</ThemedText.Body2>}
+          <ThemedText.Subhead1>{header || <Trans>Something went wrong.</Trans>}</ThemedText.Subhead1>
+          {!open && <ThemedText.Body2>{message}</ThemedText.Body2>}
         </ErrorHeader>
       </StatusHeader>
-      <Column gap={open ? 0 : 0.75} style={{ transition: `gap ${AnimationSpeed.Medium}` }}>
-        <Expando
-          title={
-            <>
-              <InfoIcon style={{ marginRight: '5px' }} color="secondary" />
-              <Trans>Error details</Trans>
-            </>
-          }
-          open={open}
-          onExpand={onExpand}
-          height={7.5}
-        >
-          <ExpandoContent userSelect>
-            {error.name}
-            {error.message ? `: ${error.message}` : ''}
-          </ExpandoContent>
-        </Expando>
-        <ActionButton color="critical" onClick={onClick}>
-          {action}
-        </ActionButton>
-      </Column>
+      {error && (
+        <Column gap={open ? 0 : 0.75} style={{ transition: `gap ${AnimationSpeed.Medium}` }}>
+          <Expando
+            title={
+              <>
+                <InfoIcon style={{ marginRight: '5px' }} color="secondary" />
+                <Trans>Error details</Trans>
+              </>
+            }
+            open={open}
+            onExpand={onExpand}
+            height={7.5}
+          >
+            <ExpandoContent userSelect>
+              {error.name}
+              {error.message ? `: ${error.message}` : ''}
+            </ExpandoContent>
+          </Expando>
+          <ActionButton color="critical" onClick={onClick}>
+            {action}
+          </ActionButton>
+        </Column>
+      )}
     </Column>
   )
 }

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -71,8 +71,8 @@ export default function ErrorDialog({ header, message, error, action, onClick }:
           {!open && <ThemedText.Body2>{message}</ThemedText.Body2>}
         </ErrorHeader>
       </StatusHeader>
-      {error && (
-        <Column gap={open ? 0 : 0.75} style={{ transition: `gap ${AnimationSpeed.Medium}` }}>
+      <Column gap={open ? 0 : 0.75} style={{ transition: `gap ${AnimationSpeed.Medium}` }}>
+        {error ? (
           <Expando
             title={
               <>
@@ -89,11 +89,13 @@ export default function ErrorDialog({ header, message, error, action, onClick }:
               {error.message ? `: ${error.message}` : ''}
             </ExpandoContent>
           </Expando>
-          <ActionButton color="critical" onClick={onClick}>
-            {action}
-          </ActionButton>
-        </Column>
-      )}
+        ) : (
+          <Column style={{ height: '7.5em' }} />
+        )}
+        <ActionButton color="critical" onClick={onClick}>
+          {action}
+        </ActionButton>
+      </Column>
     </Column>
   )
 }

--- a/src/components/Swap/Status/StatusDialog.tsx
+++ b/src/components/Swap/Status/StatusDialog.tsx
@@ -95,7 +95,7 @@ function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
 export default function TransactionStatusDialog({ tx, onClose }: TransactionStatusProps) {
   return tx.receipt?.status === 0 ? (
     <ErrorDialog
-      header={<Trans>Your swap failed</Trans>}
+      header={<Trans>Your swap failed.</Trans>}
       message={
         <Trans>
           Try increasing your slippage tolerance.

--- a/src/components/Swap/Status/StatusDialog.tsx
+++ b/src/components/Swap/Status/StatusDialog.tsx
@@ -95,14 +95,14 @@ function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
 export default function TransactionStatusDialog({ tx, onClose }: TransactionStatusProps) {
   return tx.receipt?.status === 0 ? (
     <ErrorDialog
-      header={
+      header={<Trans>Your swap failed</Trans>}
+      message={
         <Trans>
           Try increasing your slippage tolerance.
           <br />
           NOTE: Fee on transfer and rebase tokens are incompatible with Uniswap V3.
         </Trans>
       }
-      error={new Error('TODO(zzmp)')}
       action={<Trans>Dismiss</Trans>}
       onClick={onClose}
     />


### PR DESCRIPTION
Update swap failed modal to exclude the actual error object, as one is not provided by ethers.
If we want to capture an error object, it will need to be done separately, in SwapButton.tsx.

![image](https://user-images.githubusercontent.com/5403956/213780154-a6eed9c3-05d5-4860-9c01-b6b22c29e9c6.png)


WEB-2793