### PR TITLE
feat: add modal zIndex to theme definition

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -35,6 +35,7 @@ const BottomSheetModalBackdrop = styled.div<{ className?: string }>`
   top: 0;
   transition: visibility 0s linear 0s, opacity ${AnimationSpeed.Medium};
   visibility: visible;
+  z-index: ${({ theme }) => theme.zIndex.modal - 1};
 `
 
 const Wrapper = styled.div<{ open: boolean }>`
@@ -43,7 +44,9 @@ const Wrapper = styled.div<{ open: boolean }>`
   left: 0;
   margin: 0;
   overflow: hidden;
+  position: absolute;
   right: 0;
+  z-index: ${({ theme }) => theme.zIndex.modal};
 
   @supports (overflow: clip) {
     overflow: clip;

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -5,6 +5,7 @@ import { mix, rgba, transparentize } from 'polished'
 import { createContext, PropsWithChildren, useContext, useMemo, useState } from 'react'
 import { DefaultTheme, ThemeProvider as StyledProvider } from 'styled-components/macro'
 
+import { Layer } from './layer'
 import type { Colors, Theme, ThemeBorderRadius } from './theme'
 
 export * from './animations'
@@ -98,6 +99,9 @@ const defaultBorderRadius = {
 
 export const defaultTheme = {
   borderRadius: defaultBorderRadius,
+  zIndex: {
+    modal: Layer.DIALOG,
+  },
   fontFamily: {
     font: '"Inter", sans-serif',
     variable: '"InterVariable", sans-serif',

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -40,8 +40,13 @@ export type ThemeBorderRadius = {
   small: number
 }
 
+export type ZIndex = {
+  modal: number
+}
+
 export interface Attributes {
   borderRadius: ThemeBorderRadius
+  zIndex: ZIndex
   fontFamily:
     | string
     | {


### PR DESCRIPTION
gives bottom sheet modals a higher zIndex by default - this is also configurable by the integration theme, so anyone can specify where exactly the modals should appear on the z Index

I tested this by installing a build in `interface` and verifying that I could make the bottom sheet appear over the Mobile Nav Bar