### PR TITLE
feat: include tx info in OnTxSuccess

### DIFF
--- a/src/hooks/transactions/index.tsx
+++ b/src/hooks/transactions/index.tsx
@@ -66,7 +66,8 @@ export function useIsPendingApproval(token?: Token): boolean {
 }
 
 export type OnTxSubmit = (hash: string, tx: Transaction) => void
-export type OnTxSuccess = (hash: string, receipt: TransactionReceipt) => void
+type WithRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
+export type OnTxSuccess = (hash: string, tx: WithRequired<Transaction, 'receipt'>) => void
 export type OnTxFail = (hash: string, receipt: TransactionReceipt) => void
 
 export interface TransactionEventHandlers {
@@ -102,10 +103,13 @@ export function TransactionsUpdater({ onTxSubmit, onTxSuccess, onTxFail }: Trans
       if (receipt.status === 0) {
         onTxFail?.(hash, receipt)
       } else {
-        onTxSuccess?.(hash, receipt)
+        onTxSuccess?.(hash, {
+          ...currentPendingTxs[hash],
+          receipt,
+        })
       }
     },
-    [updateTxs, onTxFail, onTxSuccess]
+    [updateTxs, onTxFail, onTxSuccess, currentPendingTxs]
   )
 
   const oldPendingTxs = useRef({})

--- a/src/hooks/transactions/index.tsx
+++ b/src/hooks/transactions/index.tsx
@@ -66,7 +66,6 @@ export function useIsPendingApproval(token?: Token): boolean {
 }
 
 export type OnTxSubmit = (hash: string, tx: Transaction) => void
-type WithRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
 export type OnTxSuccess = (hash: string, tx: WithRequired<Transaction, 'receipt'>) => void
 export type OnTxFail = (hash: string, receipt: TransactionReceipt) => void
 

--- a/src/widgets.d.ts
+++ b/src/widgets.d.ts
@@ -41,3 +41,5 @@ declare module '*.svg' {
   const src: string
   export default src
 }
+
+type WithRequired<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>


### PR DESCRIPTION
include the Transaction Info in the `OnTxSuccess` callback - this gives the integrator access to the trade info easily without caching it themselves.

`BREAKING CHANGE` 