### PR TITLE
fix: use correct conedison formatter for trade quote

### DIFF
--- a/src/components/Swap/Price.tsx
+++ b/src/components/Swap/Price.tsx
@@ -32,9 +32,7 @@ export function useTradeExchangeRate(
 
   return useMemo(
     () => [
-      `${1} ${price.baseCurrency.symbol} = ${formatPrice(price, NumberType.SwapTradeAmount)} ${
-        price.quoteCurrency.symbol
-      }`,
+      `${1} ${price.baseCurrency.symbol} = ${formatPrice(price, NumberType.TokenTx)} ${price.quoteCurrency.symbol}`,
       usdcPrice && formatCurrencyAmount(usdcPrice, NumberType.FiatTokenPrice),
     ],
     [price, usdcPrice]


### PR DESCRIPTION
according to our [Number Formatting standards](https://www.notion.so/uniswaplabs/Number-standards-fbb9f533f10e4e22820722c2f66d23c0), it's actually more appropriate to use this formatter here since it's not the input or output field. this fixes the layout issue on smaller widths