### PR TITLE
feat: remove pending step

### DIFF
--- a/src/components/Swap/Status/StatusDialog.test.tsx
+++ b/src/components/Swap/Status/StatusDialog.test.tsx
@@ -1,0 +1,80 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { CurrencyAmount, Percent, TradeType } from '@uniswap/sdk-core'
+import { InterfaceTrade } from 'state/routing/types'
+import { Transaction, TransactionType } from 'state/transactions'
+import { renderComponent } from 'test'
+import { buildMultiV3Route, buildSingleV3Route, DAI, USDC } from 'test/utils'
+
+import TransactionStatusDialog from './StatusDialog'
+
+const usdc = CurrencyAmount.fromRawAmount(USDC, 1)
+const dai = CurrencyAmount.fromRawAmount(DAI, 1)
+
+const buildTestTx = (status?: number): Transaction => ({
+  addedTime: 0,
+  receipt: {
+    status,
+    confirmations: 0,
+    from: '0x123',
+    to: '0x123',
+    contractAddress: '0x123',
+    gasUsed: BigNumber.from('0x123'),
+    logsBloom: '0x123',
+    transactionIndex: 0,
+    blockHash: '0x123',
+    transactionHash: '0x123',
+    logs: [],
+    blockNumber: 0,
+    cumulativeGasUsed: BigNumber.from('0x123'),
+    byzantium: true,
+    effectiveGasPrice: BigNumber.from('0x123'),
+    type: 0,
+  },
+  info: {
+    type: TransactionType.SWAP,
+    tradeType: TradeType.EXACT_INPUT,
+    response: {
+      hash: '0x123',
+      confirmations: 0,
+      from: '0x123',
+      to: '0x123',
+      gasLimit: BigNumber.from('0x123'),
+      wait: jest.fn(),
+      nonce: 0,
+      data: '0x123',
+      value: BigNumber.from('0x123'),
+      chainId: 1,
+    },
+    trade: new InterfaceTrade({
+      v2Routes: [],
+      v3Routes: [buildMultiV3Route(usdc, dai), buildSingleV3Route(usdc, dai)],
+      tradeType: TradeType.EXACT_INPUT,
+    }),
+    slippageTolerance: new Percent(1, 100),
+  },
+})
+
+describe('StatusDialog', () => {
+  it('should render an error dialog', () => {
+    const testTx: Transaction = buildTestTx(0)
+    const component = renderComponent(<TransactionStatusDialog tx={testTx} onClose={jest.fn()} />)
+    expect(component.queryByTestId('status-dialog')).toBeNull()
+    expect(component.queryByText('Your swap failed.')).not.toBeNull()
+  })
+
+  it('should render a success dialog', () => {
+    const testTx: Transaction = buildTestTx(1)
+
+    const component = renderComponent(<TransactionStatusDialog tx={testTx} onClose={jest.fn()} />)
+    expect(component.queryByText('Your swap failed.')).toBeNull()
+    expect(component.queryByText('Success')).not.toBeNull()
+  })
+
+  it('should render a pending dialog', () => {
+    const testTx: Transaction = buildTestTx(undefined)
+    const component = renderComponent(<TransactionStatusDialog tx={testTx} onClose={jest.fn()} />)
+    expect(component.queryByText('Your swap failed.')).toBeNull()
+    expect(component.queryByText('Success')).toBeNull()
+    expect(component.queryByText('Transaction submitted')).not.toBeNull()
+  })
+})

--- a/src/components/Swap/Status/StatusDialog.tsx
+++ b/src/components/Swap/Status/StatusDialog.tsx
@@ -42,7 +42,7 @@ function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
   }, [tx.receipt?.status])
 
   return (
-    <Column flex padded gap={0.75} align="stretch" style={{ height: '100%' }}>
+    <Column flex padded gap={0.75} align="stretch" style={{ height: '100%' }} data-testid="status-dialog">
       <StatusHeader icon={Icon} iconColor={tx.receipt?.status ? 'success' : undefined}>
         <ThemedText.H4>{heading}</ThemedText.H4>
         {tx.info.type === TransactionType.SWAP ? (

--- a/src/components/Swap/Status/StatusDialog.tsx
+++ b/src/components/Swap/Status/StatusDialog.tsx
@@ -3,12 +3,11 @@ import ErrorDialog, { StatusHeader } from 'components/Error/ErrorDialog'
 import EtherscanLink from 'components/EtherscanLink'
 import Row from 'components/Row'
 import SwapSummary from 'components/Swap/Summary'
-import { MS_IN_SECOND } from 'constants/misc'
-import { LargeArrow, LargeCheck, LargeSpinner } from 'icons'
-import { useEffect, useMemo, useState } from 'react'
+import { LargeArrow, LargeCheck } from 'icons'
+import { useMemo } from 'react'
 import { Transaction, TransactionType } from 'state/transactions'
 import styled from 'styled-components/macro'
-import { AnimationSpeed, ThemedText, TransitionDuration } from 'theme'
+import { AnimationSpeed, ThemedText } from 'theme'
 import { ExplorerDataType } from 'utils/getExplorerLink'
 
 import ActionButton from '../../ActionButton'
@@ -29,37 +28,11 @@ interface TransactionStatusProps {
 }
 
 function TransactionStatus({ tx, onClose }: TransactionStatusProps) {
-  const [showConfirmation, setShowConfirmation] = useState(true)
-  const Icon = useMemo(() => {
-    if (showConfirmation) {
-      return LargeArrow
-    }
-    return tx.receipt?.status ? LargeCheck : LargeSpinner
-  }, [showConfirmation, tx.receipt?.status])
-
-  useEffect(() => {
-    // We should show the confirmation for 1 second,
-    // which should start after the entrance animation is complete.
-    const handle = setTimeout(() => {
-      setShowConfirmation(false)
-    }, MS_IN_SECOND + TransitionDuration.Medium)
-    return () => {
-      clearTimeout(handle)
-    }
-  }, [])
+  const Icon = useMemo(() => (tx.receipt?.status ? LargeCheck : LargeArrow), [tx.receipt?.status])
 
   const heading = useMemo(() => {
-    if (showConfirmation) {
-      return <Trans>Transaction submitted</Trans>
-    } else if (tx.info.type === TransactionType.SWAP) {
-      return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Swap pending</Trans>
-    } else if (tx.info.type === TransactionType.WRAP) {
-      return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Unwrap pending</Trans>
-    } else if (tx.info.type === TransactionType.UNWRAP) {
-      return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Unwrap pending</Trans>
-    }
-    return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Transaction pending</Trans>
-  }, [showConfirmation, tx.info.type, tx.receipt?.status])
+    return tx.receipt?.status ? <Trans>Success</Trans> : <Trans>Transaction submitted</Trans>
+  }, [tx.receipt?.status])
 
   const subheading = useMemo(() => {
     if (tx.receipt?.status) {


### PR DESCRIPTION
[design request](https://www.notion.so/uniswaplabs/Widget-design-feedback-835bfad85aac4ad3a00550fcea18bf99): remove the "pending" step in this dialog. instead of showing the spinner, we'll transition directly from the "submitted" state to the "success" state (or error state)