### PR TITLE
chore: Transform quote results into Trades within rtk-query

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -97,3 +97,7 @@ export const L2_CHAIN_IDS = [
 ] as const
 
 export type SupportedL2ChainId = typeof L2_CHAIN_IDS[number]
+
+export function isPolygonChain(chainId: number): chainId is SupportedChainId.POLYGON | SupportedChainId.POLYGON_MUMBAI {
+  return chainId === SupportedChainId.POLYGON || chainId === SupportedChainId.POLYGON_MUMBAI
+}

--- a/src/hooks/routing/clientSideSmartOrderRouter.ts
+++ b/src/hooks/routing/clientSideSmartOrderRouter.ts
@@ -12,7 +12,7 @@ import {
   UniswapMulticallProvider,
 } from '@uniswap/smart-order-router'
 import JSBI from 'jsbi'
-import { GetQuoteArgs, GetQuoteResult, INITIALIZED, NO_ROUTE } from 'state/routing/types'
+import { GetQuoteArgs, GetQuoteError, INITIALIZED, NO_ROUTE, QuoteResult } from 'state/routing/types'
 import { isExactInput } from 'utils/tradeType'
 
 import { transformSwapRouteToGetQuoteResult } from './transformSwapRouteToGetQuoteResult'
@@ -94,7 +94,7 @@ async function getQuote(
   },
   router: AlphaRouter,
   routerConfig: Partial<AlphaRouterConfig>
-): Promise<GetQuoteResult> {
+): Promise<QuoteResult | GetQuoteError> {
   const currencyIn = new Token(tokenIn.chainId, tokenIn.address, tokenIn.decimals, tokenIn.symbol)
   const currencyOut = new Token(tokenOut.chainId, tokenOut.address, tokenOut.decimals, tokenOut.symbol)
 

--- a/src/hooks/routing/transformSwapRouteToGetQuoteResult.ts
+++ b/src/hooks/routing/transformSwapRouteToGetQuoteResult.ts
@@ -1,6 +1,6 @@
 import { Protocol } from '@uniswap/router-sdk'
 import type { SwapRoute } from '@uniswap/smart-order-router'
-import { GetQuoteResult, V2PoolInRoute, V3PoolInRoute } from 'state/routing/types'
+import { QuoteResult, V2PoolInRoute, V3PoolInRoute } from 'state/routing/types'
 import { isExactInput } from 'utils/tradeType'
 
 // from routing-api (https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/quote.ts#L243-L311)
@@ -16,7 +16,7 @@ export function transformSwapRouteToGetQuoteResult({
   methodParameters,
   blockNumber,
   trade: { tradeType, inputAmount, outputAmount },
-}: SwapRoute & { routeString: string }): GetQuoteResult {
+}: SwapRoute & { routeString: string }): QuoteResult {
   const routeResponse: Array<V3PoolInRoute[] | V2PoolInRoute[]> = []
 
   for (const subRoute of route) {

--- a/src/hooks/routing/types.ts
+++ b/src/hooks/routing/types.ts
@@ -9,3 +9,10 @@ export enum PoolType {
   V2Pool = 'v2-pool',
   V3Pool = 'v3-pool',
 }
+
+// swap router API special cases these strings to represent native currencies
+// all chains have "ETH" as native currency symbol except for polygon
+export enum SwapRouterNativeAssets {
+  MATIC = 'MATIC',
+  ETH = 'ETH',
+}

--- a/src/hooks/routing/types.ts
+++ b/src/hooks/routing/types.ts
@@ -4,3 +4,8 @@ export enum RouterPreference {
   API,
   CLIENT,
 }
+
+export enum PoolType {
+  V2Pool = 'v2-pool',
+  V3Pool = 'v3-pool',
+}

--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -7,7 +7,7 @@ import useTimeout from 'hooks/useTimeout'
 import ms from 'ms.macro'
 import { useCallback, useMemo } from 'react'
 import { useGetQuoteArgs } from 'state/routing/args'
-import { useGetQuoteQueryState, useLazyGetQuoteQuery } from 'state/routing/slice'
+import { TradeResult, useGetQuoteQueryState, useLazyGetQuoteQuery } from 'state/routing/slice'
 import { InterfaceTrade, NO_ROUTE, TradeState } from 'state/routing/types'
 
 import { RouterPreference } from './types'
@@ -71,21 +71,21 @@ export function useRouterTrade(
   }, [fulfilledTimeStamp, pollingInterval, queryArgs, trigger])
   useTimeout(request, 200)
 
-  const quoteResult = typeof data === 'object' ? data : undefined
-  const isValidBlock = useIsValidBlock(Number(quoteResult?.blockNumber))
+  const tradeResult: TradeResult | undefined = typeof data === 'object' ? data : undefined
+  const isValidBlock = useIsValidBlock(Number(tradeResult?.blockNumber))
   const isValid = currentData === data && isValidBlock
-  const gasUseEstimateUSD = useStablecoinAmountFromFiatValue(quoteResult?.gasUseEstimateUSD)
+  const gasUseEstimateUSD = useStablecoinAmountFromFiatValue(tradeResult?.gasUseEstimateUSD)
 
   return useMemo(() => {
     if (!amountSpecified || isError || queryArgs === skipToken) {
       return TRADE_INVALID
     } else if (data === NO_ROUTE) {
       return TRADE_NOT_FOUND
-    } else if (!quoteResult?.trade) {
+    } else if (!tradeResult?.trade) {
       return TRADE_LOADING
     } else {
       const state = isValid ? TradeState.VALID : TradeState.LOADING
-      return { state, trade: quoteResult?.trade, gasUseEstimateUSD }
+      return { state, trade: tradeResult?.trade, gasUseEstimateUSD }
     }
-  }, [amountSpecified, isError, queryArgs, data, quoteResult?.trade, isValid, gasUseEstimateUSD])
+  }, [amountSpecified, isError, queryArgs, data, tradeResult?.trade, isValid, gasUseEstimateUSD])
 }

--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -7,8 +7,8 @@ import useTimeout from 'hooks/useTimeout'
 import ms from 'ms.macro'
 import { useCallback, useMemo } from 'react'
 import { useGetQuoteArgs } from 'state/routing/args'
-import { TradeResult, useGetQuoteQueryState, useLazyGetQuoteQuery } from 'state/routing/slice'
-import { InterfaceTrade, NO_ROUTE, TradeState } from 'state/routing/types'
+import { useGetQuoteQueryState, useLazyGetQuoteQuery } from 'state/routing/slice'
+import { InterfaceTrade, NO_ROUTE, TradeResult, TradeState } from 'state/routing/types'
 
 import { RouterPreference } from './types'
 

--- a/src/hooks/routing/useRouterTrade.ts
+++ b/src/hooks/routing/useRouterTrade.ts
@@ -7,7 +7,7 @@ import useTimeout from 'hooks/useTimeout'
 import ms from 'ms.macro'
 import { useCallback, useMemo } from 'react'
 import { useGetQuoteArgs } from 'state/routing/args'
-import { useGetQuoteQueryState, useLazyGetQuoteQuery } from 'state/routing/slice'
+import { useGetTradeQuoteQueryState, useLazyGetTradeQuoteQuery } from 'state/routing/slice'
 import { InterfaceTrade, NO_ROUTE, TradeResult, TradeState } from 'state/routing/types'
 
 import { RouterPreference } from './types'
@@ -58,11 +58,11 @@ export function useRouterTrade(
 
   // Get the cached state *immediately* to update the UI without sending a request - using useGetQuoteQueryState -
   // but debounce the actual request - using useLazyGetQuoteQuery - to avoid flooding the router / JSON-RPC endpoints.
-  const { isError, data, currentData, fulfilledTimeStamp } = useGetQuoteQueryState(queryArgs)
+  const { isError, data, currentData, fulfilledTimeStamp } = useGetTradeQuoteQueryState(queryArgs)
 
   // An already-fetched value should be refetched if it is older than the pollingInterval.
   // Without explicit refetch, it would not be refetched until another pollingInterval has elapsed.
-  const [trigger] = useLazyGetQuoteQuery({ pollingInterval })
+  const [trigger] = useLazyGetTradeQuoteQuery({ pollingInterval })
   const request = useCallback(() => {
     const { refetch } = trigger(queryArgs, /*preferCacheValue=*/ true)
     if (fulfilledTimeStamp && Date.now() - fulfilledTimeStamp > pollingInterval) {

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -17,6 +17,9 @@ export const store = configureStore({
     getDefaultMiddleware({
       thunk: true,
       serializableCheck: {
+        // meta.arg and meta.baseQueryMeta are defaults. trade is a nonserializable return value, but that's ok
+        // because we are not persisting it to a redux store
+        ignoredActionPaths: ['meta.arg', 'meta.baseQueryMeta', 'payload.trade'],
         ignoredPaths: [routing.reducerPath],
       },
     }).concat(routing.middleware),

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -17,8 +17,8 @@ export const store = configureStore({
     getDefaultMiddleware({
       thunk: true,
       serializableCheck: {
-        // meta.arg and meta.baseQueryMeta are defaults. trade is a nonserializable return value, but that's ok
-        // because we are not persisting it to a redux store
+        // meta.arg and meta.baseQueryMeta are defaults. payload.trade is a nonserializable return value, but that's ok
+        // because we are not adding it into any persisted store that requires serialization (e.g. localStorage)
         ignoredActionPaths: ['meta.arg', 'meta.baseQueryMeta', 'payload.trade'],
         ignoredPaths: [routing.reducerPath],
       },

--- a/src/state/routing/args.ts
+++ b/src/state/routing/args.ts
@@ -7,6 +7,7 @@ import useIsWindowVisible from 'hooks/useIsWindowVisible'
 import { useMemo } from 'react'
 
 import { GetQuoteArgs } from './types'
+import { currencyAddressForSwapQuote } from './utils'
 
 const NON_SERIALIZABLE_KEYS = ['provider']
 
@@ -61,14 +62,14 @@ export function useGetQuoteArgs(
 
     return {
       amount: amountSpecified?.quotient.toString() ?? null,
-      tokenInAddress: currencyIn.wrapped.address,
-      tokenInChainId: currencyIn.wrapped.chainId,
-      tokenInDecimals: currencyIn.wrapped.decimals,
-      tokenInSymbol: currencyIn.wrapped.symbol,
-      tokenOutAddress: currencyOut.wrapped.address,
-      tokenOutChainId: currencyOut.wrapped.chainId,
-      tokenOutDecimals: currencyOut.wrapped.decimals,
-      tokenOutSymbol: currencyOut.wrapped.symbol,
+      tokenInAddress: currencyAddressForSwapQuote(currencyIn),
+      tokenInChainId: currencyIn.chainId,
+      tokenInDecimals: currencyIn.decimals,
+      tokenInSymbol: currencyIn.symbol,
+      tokenOutAddress: currencyAddressForSwapQuote(currencyOut),
+      tokenOutChainId: currencyOut.chainId,
+      tokenOutDecimals: currencyOut.decimals,
+      tokenOutSymbol: currencyOut.symbol,
       routerPreference,
       routerUrl,
       tradeType,

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -6,7 +6,7 @@ import qs from 'qs'
 import { isExactInput } from 'utils/tradeType'
 
 import { serializeGetQuoteArgs } from './args'
-import { GetQuoteArgs, GetQuoteError, GetQuoteResult, NO_ROUTE, QuoteResult, TradeResult } from './types'
+import { GetQuoteArgs, GetQuoteError, NO_ROUTE, QuoteResult, TradeResult } from './types'
 import { transformQuoteToTradeResult } from './utils'
 
 const protocols: Protocol[] = [Protocol.V2, Protocol.V3]
@@ -16,7 +16,7 @@ const DEFAULT_QUERY_PARAMS = {
   protocols: protocols.map((p) => p.toLowerCase()).join(','),
 }
 
-const baseQuery: BaseQueryFn<GetQuoteArgs, GetQuoteResult> = () => {
+const baseQuery: BaseQueryFn<GetQuoteArgs, TradeQuoteResult> = () => {
   return { error: { reason: 'Unimplemented baseQuery' } }
 }
 
@@ -27,7 +27,7 @@ export const routing = createApi({
   baseQuery,
   serializeQueryArgs: serializeGetQuoteArgs,
   endpoints: (build) => ({
-    getQuote: build.query({
+    getTradeQuote: build.query({
       async queryFn(args: GetQuoteArgs | SkipToken) {
         if (args === skipToken) return { error: { status: 'CUSTOM_ERROR', error: 'Skipped' } }
 
@@ -78,7 +78,7 @@ export const routing = createApi({
         // Lazy-load the client-side router to improve initial pageload times.
         const clientSideSmartOrderRouter = await import('../../hooks/routing/clientSideSmartOrderRouter')
         try {
-          const quote: GetQuoteResult = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
+          const quote: QuoteResult = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
           if (typeof quote === 'string') return { data: quote as TradeQuoteResult }
 
           const tradeResult = transformQuoteToTradeResult(args, quote)
@@ -93,5 +93,5 @@ export const routing = createApi({
   }),
 })
 
-export const { useLazyGetQuoteQuery } = routing
-export const useGetQuoteQueryState = routing.endpoints.getQuote.useQueryState
+export const { useLazyGetTradeQuoteQuery } = routing
+export const useGetTradeQuoteQueryState = routing.endpoints.getTradeQuote.useQueryState

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -6,7 +6,7 @@ import qs from 'qs'
 import { isExactInput } from 'utils/tradeType'
 
 import { serializeGetQuoteArgs } from './args'
-import { GetQuoteArgs, GetQuoteError, GetQuoteResult, InterfaceTrade, NO_ROUTE, QuoteResult } from './types'
+import { GetQuoteArgs, GetQuoteError, GetQuoteResult, NO_ROUTE, QuoteResult, TradeResult } from './types'
 import { transformQuoteToTradeResult } from './utils'
 
 const protocols: Protocol[] = [Protocol.V2, Protocol.V3]
@@ -18,12 +18,6 @@ const DEFAULT_QUERY_PARAMS = {
 
 const baseQuery: BaseQueryFn<GetQuoteArgs, GetQuoteResult> = () => {
   return { error: { reason: 'Unimplemented baseQuery' } }
-}
-
-export type TradeResult = {
-  trade?: InterfaceTrade
-  gasUseEstimateUSD?: string
-  blockNumber: string
 }
 
 type TradeQuoteResult = TradeResult | GetQuoteError

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -6,7 +6,8 @@ import qs from 'qs'
 import { isExactInput } from 'utils/tradeType'
 
 import { serializeGetQuoteArgs } from './args'
-import { GetQuoteArgs, GetQuoteResult, NO_ROUTE } from './types'
+import { GetQuoteArgs, GetQuoteError, GetQuoteResult, InterfaceTrade, NO_ROUTE, QuoteResult } from './types'
+import { transformQuoteToTrade } from './utils'
 
 const protocols: Protocol[] = [Protocol.V2, Protocol.V3]
 
@@ -18,6 +19,13 @@ const DEFAULT_QUERY_PARAMS = {
 const baseQuery: BaseQueryFn<GetQuoteArgs, GetQuoteResult> = () => {
   return { error: { reason: 'Unimplemented baseQuery' } }
 }
+type TradeQuoteResult =
+  | {
+      trade?: InterfaceTrade
+      gasUseEstimateUSD?: string
+      blockNumber: string
+    }
+  | GetQuoteError
 
 export const routing = createApi({
   reducerPath: 'routing',
@@ -56,14 +64,15 @@ export const routing = createApi({
 
               // NO_ROUTE should be treated as a valid response to prevent retries.
               if (typeof data === 'object' && data.errorCode === 'NO_ROUTE') {
-                return { data: NO_ROUTE as GetQuoteResult }
+                return { data: NO_ROUTE as TradeQuoteResult }
               }
 
               throw data
             }
 
-            const quote: GetQuoteResult = await response.json()
-            return { data: quote }
+            const quote: QuoteResult = await response.json()
+            const trade = transformQuoteToTrade(args, quote)
+            return { data: { trade, gasUseEstimateUSD: quote.gasUseEstimateUSD, blockNumber: quote.blockNumber } }
           } catch (error: any) {
             console.warn(
               `GetQuote failed on routing API, falling back to client: ${error?.message ?? error?.detail ?? error}`
@@ -74,8 +83,13 @@ export const routing = createApi({
         // Lazy-load the client-side router to improve initial pageload times.
         const clientSideSmartOrderRouter = await import('../../hooks/routing/clientSideSmartOrderRouter')
         try {
-          const quote = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
-          return { data: quote }
+          const quote: GetQuoteResult = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
+
+          // TODO: handle errors using rtk-query errors instead of returning strings
+          if (typeof quote === 'string') return { data: quote as TradeQuoteResult }
+
+          const trade = transformQuoteToTrade(args, quote)
+          return { data: { trade, gasUseEstimateUSD: quote.gasUseEstimateUSD, blockNumber: quote.blockNumber } }
         } catch (error: any) {
           console.warn(`GetQuote failed on client: ${error}`)
           return { error: { status: 'CUSTOM_ERROR', error: error?.message ?? error?.detail ?? error } }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -84,8 +84,6 @@ export const routing = createApi({
         const clientSideSmartOrderRouter = await import('../../hooks/routing/clientSideSmartOrderRouter')
         try {
           const quote: GetQuoteResult = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
-
-          // TODO: handle errors using rtk-query errors instead of returning strings
           if (typeof quote === 'string') return { data: quote as TradeQuoteResult }
 
           const trade = transformQuoteToTrade(args, quote)

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -78,7 +78,9 @@ export const routing = createApi({
         // Lazy-load the client-side router to improve initial pageload times.
         const clientSideSmartOrderRouter = await import('../../hooks/routing/clientSideSmartOrderRouter')
         try {
-          const quote: QuoteResult = await clientSideSmartOrderRouter.getClientSideQuote(args, { protocols })
+          const quote: QuoteResult | GetQuoteError = await clientSideSmartOrderRouter.getClientSideQuote(args, {
+            protocols,
+          })
           if (typeof quote === 'string') return { data: quote as TradeQuoteResult }
 
           const tradeResult = transformQuoteToTradeResult(args, quote)

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -90,4 +90,10 @@ export const NO_ROUTE = 'No Route'
 export type GetQuoteError = typeof INITIALIZED | typeof NO_ROUTE
 export type GetQuoteResult = QuoteResult | GetQuoteError
 
+export type TradeResult = {
+  trade?: InterfaceTrade
+  gasUseEstimateUSD?: string
+  blockNumber: string
+}
+
 export class InterfaceTrade extends Trade<Currency, Currency, TradeType> {}

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -88,12 +88,13 @@ export const INITIALIZED = 'Initialized'
 export const NO_ROUTE = 'No Route'
 
 export type GetQuoteError = typeof INITIALIZED | typeof NO_ROUTE
-export type GetQuoteResult = QuoteResult | GetQuoteError
 
 export type TradeResult = {
   trade?: InterfaceTrade
   gasUseEstimateUSD?: string
   blockNumber: string
 }
+
+export type TradeQuoteResult = TradeResult | GetQuoteError
 
 export class InterfaceTrade extends Trade<Currency, Currency, TradeType> {}

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -87,6 +87,7 @@ export interface QuoteResult {
 export const INITIALIZED = 'Initialized'
 export const NO_ROUTE = 'No Route'
 
-export type GetQuoteResult = QuoteResult | typeof INITIALIZED | typeof NO_ROUTE
+export type GetQuoteError = typeof INITIALIZED | typeof NO_ROUTE
+export type GetQuoteResult = QuoteResult | GetQuoteError
 
 export class InterfaceTrade extends Trade<Currency, Currency, TradeType> {}

--- a/src/state/routing/utils.test.ts
+++ b/src/state/routing/utils.test.ts
@@ -1,4 +1,4 @@
-import { Token, TradeType } from '@uniswap/sdk-core'
+import { Token } from '@uniswap/sdk-core'
 import { nativeOnChain } from 'constants/tokens'
 import { amount, DAI, MKR, USDC } from 'test/utils'
 
@@ -8,21 +8,18 @@ const ETH = nativeOnChain(1)
 
 describe('#useRoute', () => {
   it('handles an undefined payload', () => {
-    const result = computeRoutes(undefined, undefined, TradeType.EXACT_INPUT, undefined)
+    const result = computeRoutes(false, false, undefined)
 
     expect(result).toBeUndefined()
   })
 
   it('handles empty edges and nodes', () => {
-    const result = computeRoutes(USDC, DAI, TradeType.EXACT_INPUT, {
-      route: [],
-    })
-
+    const result = computeRoutes(false, false, { route: [] })
     expect(result).toEqual([])
   })
 
   it('handles a single route trade from DAI to USDC from v3', () => {
-    const result = computeRoutes(DAI, USDC, TradeType.EXACT_INPUT, {
+    const result = computeRoutes(false, false, {
       route: [
         [
           {
@@ -54,7 +51,7 @@ describe('#useRoute', () => {
   })
 
   it('handles a single route trade from DAI to USDC from v2', () => {
-    const result = computeRoutes(DAI, USDC, TradeType.EXACT_INPUT, {
+    const result = computeRoutes(false, false, {
       route: [
         [
           {
@@ -90,7 +87,7 @@ describe('#useRoute', () => {
   })
 
   it('handles a multi-route trade from DAI to USDC', () => {
-    const result = computeRoutes(DAI, USDC, TradeType.EXACT_OUTPUT, {
+    const result = computeRoutes(false, false, {
       route: [
         [
           {
@@ -159,7 +156,7 @@ describe('#useRoute', () => {
   })
 
   it('handles a single route trade with same token pair, different fee tiers', () => {
-    const result = computeRoutes(DAI, USDC, TradeType.EXACT_INPUT, {
+    const result = computeRoutes(false, false, {
       route: [
         [
           {
@@ -204,7 +201,7 @@ describe('#useRoute', () => {
     it('outputs native ETH as input currency', () => {
       const WETH = ETH.wrapped
 
-      const result = computeRoutes(ETH, USDC, TradeType.EXACT_OUTPUT, {
+      const result = computeRoutes(true, false, {
         route: [
           [
             {
@@ -233,7 +230,7 @@ describe('#useRoute', () => {
 
     it('outputs native ETH as output currency', () => {
       const WETH = new Token(1, ETH.wrapped.address, 18, 'WETH')
-      const result = computeRoutes(USDC, ETH, TradeType.EXACT_OUTPUT, {
+      const result = computeRoutes(false, true, {
         route: [
           [
             {
@@ -262,7 +259,7 @@ describe('#useRoute', () => {
     it('outputs native ETH as input currency for v2 routes', () => {
       const WETH = ETH.wrapped
 
-      const result = computeRoutes(ETH, USDC, TradeType.EXACT_OUTPUT, {
+      const result = computeRoutes(true, false, {
         route: [
           [
             {
@@ -295,7 +292,7 @@ describe('#useRoute', () => {
 
     it('outputs native ETH as output currency for v2 routes', () => {
       const WETH = new Token(1, ETH.wrapped.address, 18, 'WETH')
-      const result = computeRoutes(USDC, ETH, TradeType.EXACT_OUTPUT, {
+      const result = computeRoutes(false, true, {
         route: [
           [
             {

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -123,6 +123,7 @@ function isVersionedRoute<T extends V2PoolInRoute | V3PoolInRoute>(
   return route.every((pool) => pool.type === type)
 }
 
+// TODO: deprecate this once we can use `NATIVE` as a string for native currencies and it can be imported from an SDK
 export function currencyAddressForSwapQuote(currency: Currency): string {
   if (currency.isNative) {
     return isPolygonChain(currency.chainId) ? SwapRouterNativeAssets.MATIC : SwapRouterNativeAssets.ETH

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -53,7 +53,6 @@ export function computeRoutes(
       return {
         routev3: isOnlyV3 ? new V3Route(route.map(parsePool), parsedCurrencyIn, parsedCurrencyOut) : null,
         routev2: isOnlyV2 ? new V2Route(route.map(parsePair), parsedCurrencyIn, parsedCurrencyOut) : null,
-        // TODO: add mixed routes
         inputAmount: CurrencyAmount.fromRawAmount(parsedCurrencyIn, rawAmountIn),
         outputAmount: CurrencyAmount.fromRawAmount(parsedCurrencyOut, rawAmountOut),
       }

--- a/src/state/routing/utils.ts
+++ b/src/state/routing/utils.ts
@@ -5,7 +5,7 @@ import { isPolygonChain } from 'constants/chains'
 import { nativeOnChain } from 'constants/tokens'
 import { PoolType, SwapRouterNativeAssets } from 'hooks/routing/types'
 
-import { TradeResult } from './slice'
+import { TradeResult } from './types'
 import { GetQuoteArgs, InterfaceTrade, QuoteResult, V2PoolInRoute, V3PoolInRoute } from './types'
 
 /**

--- a/src/utils/currencyId.ts
+++ b/src/utils/currencyId.ts
@@ -1,12 +1,5 @@
 import { Currency } from '@uniswap/sdk-core'
 
-// swap router API special cases these strings to represent native currencies
-// all chains have "ETH" as native currency symbol except for polygon
-export enum SwapRouterNativeAssets {
-  MATIC = 'MATIC',
-  ETH = 'ETH',
-}
-
 export function currencyId(currency: Currency): string {
   if (currency.isNative) return 'ETH'
   if (currency.isToken) return currency.address

--- a/src/utils/currencyId.ts
+++ b/src/utils/currencyId.ts
@@ -1,5 +1,12 @@
 import { Currency } from '@uniswap/sdk-core'
 
+// swap router API special cases these strings to represent native currencies
+// all chains have "ETH" as native currency symbol except for polygon
+export enum SwapRouterNativeAssets {
+  MATIC = 'MATIC',
+  ETH = 'ETH',
+}
+
 export function currencyId(currency: Currency): string {
   if (currency.isNative) return 'ETH'
   if (currency.isToken) return currency.address


### PR DESCRIPTION
Our logic previously was set up such that the transform from quote result -> Trade was happening outside of rtk-query. This resulted in a tricky edge case during refetching where input/outputs were unsynced. Steps to repro:

- Get a quote for 0.1 ETH -> DAI. rtk-query returns the quote response, and `data` and `currentData` get filled in.
- Revise quote to 0.1 USDC -> DAI. rtk-query refetches. `data` is the cached result from the previous response, with the route for `ETH -> DAI`. `currentData` is undefined during the refetch.
- We're now creating a `Trade` object using the USDC -> DAI inputs but using `data` that has an ETH -> DAI route. This would error, but we had a [line](https://github.com/Uniswap/widgets/blob/main/src/state/routing/utils.ts#L24) that caught this case:

```
if (parsedTokenIn.address !== currencyIn.wrapped.address) return undefined
if (parsedTokenOut.address !== currencyOut.wrapped.address) return undefined
```
where parsedTokenIn = token from response, and currencyIn = token from input 

This is fine, except for future trade types, this logic wouldn't apply similarly.

The fix is to simply apply the transform -> `Trade` from within rtk-query so that the data that is being transformed is always coupled with the correct corresponding inputs.

