### PR TITLE
feat: small design updates

### DIFF
--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -60,7 +60,7 @@ const actionCss = css`
 export const Overlay = styled(Row)<{ hasAction: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius.small}em;
   flex-flow: row-reverse nowrap;
-  margin-top: 0.75em;
+  margin-top: 0.25em;
   min-height: 3.5em;
   transition: padding ${AnimationSpeed.Medium} ease-out;
   ${({ hasAction }) => hasAction && actionCss}

--- a/src/components/Row.tsx
+++ b/src/components/Row.tsx
@@ -6,6 +6,7 @@ export interface RowProps {
   color?: Color
   align?: string
   justify?: string
+  flow?: string
   pad?: number
   gap?: number
   flex?: true
@@ -18,7 +19,7 @@ const Row = styled.div<RowProps>`
   align-items: ${({ align }) => align ?? 'center'};
   color: ${({ color, theme }) => color && theme[color]};
   display: ${({ flex }) => (flex ? 'flex' : 'grid')};
-  flex-flow: wrap;
+  flex-flow: ${({ flow }) => flow ?? 'wrap'};
   flex-grow: ${({ grow }) => grow && 1};
   gap: ${({ gap }) => gap && `${gap}em`};
   grid-auto-flow: column;

--- a/src/components/Swap/Input.tsx
+++ b/src/components/Swap/Input.tsx
@@ -18,6 +18,7 @@ import { maxAmountSpend } from 'utils/maxAmountSpend'
 
 import Column from '../Column'
 import Row from '../Row'
+import { PriceImpactRow } from './PriceImpactRow'
 import TokenInput, { TokenInputHandle } from './TokenInput'
 
 const USDC = styled(Row)`
@@ -163,11 +164,7 @@ export function FieldWrapper({
           <Row>
             <USDC isLoading={isRouteLoading}>
               {usdc && `${formatCurrencyAmount(usdc, NumberType.FiatTokenQuantity)}`}
-              {impact && (
-                <ThemedText.Body2 userSelect={false} color={impact.warning ?? 'hint'}>
-                  ({impact.toString()})
-                </ThemedText.Body2>
-              )}
+              <PriceImpactRow impact={impact} />
             </USDC>
             {balance && (
               <Row gap={0.5}>

--- a/src/components/Swap/Output.tsx
+++ b/src/components/Swap/Output.tsx
@@ -15,7 +15,6 @@ export const colorAtom = atom<string | undefined>(undefined)
 const OutputWrapper = styled(FieldWrapper)<{ hasColor?: boolean | null; isWide: boolean }>`
   border-bottom: 1px solid ${({ theme }) => theme.container};
   padding: ${({ isWide }) => (isWide ? '1em 0' : '1.5em 0 1em')};
-  margin-bottom: 0.75em;
 
   // Set transitions to reduce color flashes when switching color/token.
   // When color loads, transition the background so that it transitions from the empty or last state, but not _to_ the empty state.

--- a/src/components/Swap/PriceImpactRow.test.tsx
+++ b/src/components/Swap/PriceImpactRow.test.tsx
@@ -1,0 +1,56 @@
+import { Percent } from '@uniswap/sdk-core'
+import { renderComponent } from 'test'
+
+import { PriceImpactRow } from './PriceImpactRow'
+
+describe('PriceImpactRow', () => {
+  it('should display the percentage and icon for an error', () => {
+    const el = renderComponent(
+      <PriceImpactRow
+        impact={{
+          percent: new Percent(10, 100),
+          warning: 'error',
+          toString: () => '10%',
+        }}
+      />
+    )
+    // verify that the percentage string is visible
+    expect(el.getByText('(10%)')).toBeTruthy()
+    // verify the tooltip is visible
+    const iconElement = el.container.querySelector('svg')
+    expect(iconElement).toBeTruthy()
+  })
+
+  it('should display the percentage and icon for a warning', () => {
+    const el = renderComponent(
+      <PriceImpactRow
+        impact={{
+          percent: new Percent(1, 100),
+          warning: 'warning',
+          toString: () => '1%',
+        }}
+      />
+    )
+    // verify that the percentage string is visible
+    expect(el.getByText('(1%)')).toBeTruthy()
+    // verify the tooltip is visible
+    const iconElement = el.container.querySelector('svg')
+    expect(iconElement).toBeTruthy()
+  })
+
+  it('should display the percentage but no icon for small percentage', () => {
+    const el = renderComponent(
+      <PriceImpactRow
+        impact={{
+          percent: new Percent(1, 10000),
+          toString: () => '0.01%',
+        }}
+      />
+    )
+    // verify that the percentage string is visible
+    expect(el.getByText('(0.01%)')).toBeTruthy()
+    // verify the tooltip is visible
+    const iconElement = el.container.querySelector('svg')
+    expect(iconElement).not.toBeTruthy()
+  })
+})

--- a/src/components/Swap/PriceImpactRow.tsx
+++ b/src/components/Swap/PriceImpactRow.tsx
@@ -1,0 +1,33 @@
+import { Trans } from '@lingui/macro'
+import Row from 'components/Row'
+import Tooltip, { SmallToolTipBody } from 'components/Tooltip'
+import { PriceImpact } from 'hooks/usePriceImpact'
+import { AlertTriangle } from 'icons'
+import { ThemedText } from 'theme'
+
+interface PriceImpactProps {
+  impact: PriceImpact | undefined | null
+  reverse?: boolean
+}
+
+export function PriceImpactRow({ impact, reverse }: PriceImpactProps) {
+  if (!impact) {
+    return null
+  }
+  return (
+    <Row gap={0.25} flex align="center" flow={reverse ? 'row-reverse' : 'row wrap'}>
+      <ThemedText.Body2 userSelect={false} color={impact.warning ?? 'hint'}>
+        ({impact.toString()})
+      </ThemedText.Body2>
+      {impact?.warning && (
+        <Tooltip icon={AlertTriangle} iconProps={{ color: impact.warning }} data-testid="alert-tooltip">
+          <SmallToolTipBody>
+            <Trans>
+              There will be a large difference between your input and output values due to current liquidity.
+            </Trans>
+          </SmallToolTipBody>
+        </Tooltip>
+      )}
+    </Row>
+  )
+}

--- a/src/components/Swap/Summary/Details.tsx
+++ b/src/components/Swap/Summary/Details.tsx
@@ -4,12 +4,13 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import Column from 'components/Column'
 import Row from 'components/Row'
 import Rule from 'components/Rule'
-import Tooltip from 'components/Tooltip'
+import TokenImg from 'components/TokenImg'
+import Tooltip, { SmallToolTipBody } from 'components/Tooltip'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { Slippage } from 'hooks/useSlippage'
 import { useWidgetWidth } from 'hooks/useWidgetWidth'
 import { useAtomValue } from 'jotai/utils'
-import { useMemo } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import { feeOptionsAtom } from 'state/swap'
 import styled from 'styled-components/macro'
@@ -18,6 +19,7 @@ import { WIDGET_BREAKPOINTS } from 'theme/breakpoints'
 import { currencyId } from 'utils/currencyId'
 
 import { useTradeExchangeRate } from '../Price'
+import { PriceImpactRow } from '../PriceImpactRow'
 import { getEstimateMessage } from './Estimate'
 
 const Label = styled.span`
@@ -43,7 +45,7 @@ const MAX_AMOUNT_STR_LENGTH = 9
 
 interface DetailProps {
   label: string
-  value: string
+  value: string | ReactNode
   color?: Color
 }
 
@@ -57,10 +59,6 @@ function Detail({ label, value, color }: DetailProps) {
     </ThemedText.Body2>
   )
 }
-
-const ToolTipBody = styled(ThemedText.Caption)`
-  max-width: 220px;
-`
 
 interface AmountProps {
   tooltipText?: string
@@ -94,15 +92,18 @@ function Amount({ tooltipText, label, amount, usdcAmount }: AmountProps) {
         </ThemedText.Body2>
         {tooltipText && (
           <Tooltip placement="right" offset={8}>
-            <ToolTipBody>{tooltipText}</ToolTipBody>
+            <SmallToolTipBody>{tooltipText}</SmallToolTipBody>
           </Tooltip>
         )}
       </Row>
 
       <Column flex align="flex-end" grow>
-        <ThemedText.H1 color="primary" fontSize={amountFontSize} lineHeight={amountLineHeight}>
-          {formattedAmount} {amount.currency.symbol}
-        </ThemedText.H1>
+        <Row gap={0.5}>
+          {width > WIDGET_BREAKPOINTS.EXTRA_SMALL && <TokenImg token={amount.currency} size={1.75} />}
+          <ThemedText.H1 color="primary" fontSize={amountFontSize} lineHeight={amountLineHeight}>
+            {formattedAmount} {amount.currency.symbol}
+          </ThemedText.H1>
+        </Row>
         {usdcAmount && (
           <ThemedText.Body2>
             <Value color="secondary">{formatCurrencyAmount(usdcAmount, NumberType.FiatTokenPrice)}</Value>
@@ -130,7 +131,7 @@ export default function Details({ trade, slippage, gasUseEstimateUSD, inputUSDC,
   const [exchangeRate] = useTradeExchangeRate(trade)
 
   const { details, estimateMessage } = useMemo(() => {
-    const details: Array<[string, string] | [string, string, Color | undefined]> = []
+    const details: Array<[string, string] | [string, string | ReactNode, Color | undefined]> = []
 
     details.push([t`Exchange rate`, exchangeRate])
 
@@ -147,7 +148,7 @@ export default function Details({ trade, slippage, gasUseEstimateUSD, inputUSDC,
     }
 
     if (impact) {
-      details.push([t`Price impact`, impact.toString(), impact.warning])
+      details.push([t`Price impact`, <PriceImpactRow key="impact" impact={impact} reverse />, impact.warning])
     }
 
     const { estimateMessage, descriptor, value } = getEstimateMessage(trade, slippage)

--- a/src/components/Swap/TokenInput.tsx
+++ b/src/components/Swap/TokenInput.tsx
@@ -25,7 +25,7 @@ const ValueInput = styled(DecimalInput)`
 `
 
 const TokenInputColumn = styled(Column)`
-  margin: 0.5em 1em 0;
+  margin: 0.25em 1em 0;
 `
 
 export interface TokenInputHandle {

--- a/src/components/Swap/Toolbar/__snapshots__/ToolbarOrderRouting.test.tsx.snap
+++ b/src/components/Swap/Toolbar/__snapshots__/ToolbarOrderRouting.test.tsx.snap
@@ -10,7 +10,7 @@ Object {
         style="isolation: isolate;"
       >
         <div
-          class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 cKFIuN fdhJDq"
+          class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 iYjZBm fdhJDq"
         >
           <div
             class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
@@ -21,7 +21,7 @@ Object {
             class="Popover__Reference-sc-1liex6z-1 dxsTSY"
           >
             <div
-              class="Row-sc-1nzvhrh-0 feiOJv"
+              class="Row-sc-1nzvhrh-0 ckykgM"
               style="outline: none;"
               tabindex="-1"
             >
@@ -46,7 +46,7 @@ Object {
       style="isolation: isolate;"
     >
       <div
-        class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 cKFIuN fdhJDq"
+        class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 iYjZBm fdhJDq"
       >
         <div
           class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
@@ -57,7 +57,7 @@ Object {
           class="Popover__Reference-sc-1liex6z-1 dxsTSY"
         >
           <div
-            class="Row-sc-1nzvhrh-0 feiOJv"
+            class="Row-sc-1nzvhrh-0 ckykgM"
             style="outline: none;"
             tabindex="-1"
           >
@@ -139,7 +139,7 @@ Object {
         style="isolation: isolate;"
       >
         <div
-          class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 cKFIuN fdhJDq"
+          class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 iYjZBm fdhJDq"
         >
           <div
             class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
@@ -150,7 +150,7 @@ Object {
             class="Popover__Reference-sc-1liex6z-1 dxsTSY"
           >
             <div
-              class="Row-sc-1nzvhrh-0 feiOJv"
+              class="Row-sc-1nzvhrh-0 ckykgM"
               style="outline: none;"
               tabindex="-1"
             >
@@ -175,7 +175,7 @@ Object {
       style="isolation: isolate;"
     >
       <div
-        class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 cKFIuN fdhJDq"
+        class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 iYjZBm fdhJDq"
       >
         <div
           class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
@@ -186,7 +186,7 @@ Object {
           class="Popover__Reference-sc-1liex6z-1 dxsTSY"
         >
           <div
-            class="Row-sc-1nzvhrh-0 feiOJv"
+            class="Row-sc-1nzvhrh-0 ckykgM"
             style="outline: none;"
             tabindex="-1"
           >
@@ -268,7 +268,7 @@ Object {
         style="isolation: isolate;"
       >
         <div
-          class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 cKFIuN fdhJDq"
+          class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 iYjZBm fdhJDq"
         >
           <div
             class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
@@ -279,7 +279,7 @@ Object {
             class="Popover__Reference-sc-1liex6z-1 dxsTSY"
           >
             <div
-              class="Row-sc-1nzvhrh-0 feiOJv"
+              class="Row-sc-1nzvhrh-0 ckykgM"
               style="outline: none;"
               tabindex="-1"
             >
@@ -304,7 +304,7 @@ Object {
       style="isolation: isolate;"
     >
       <div
-        class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 cKFIuN fdhJDq"
+        class="Row-sc-1nzvhrh-0 ToolbarOrderRouting__OrderRoutingRow-sc-6rzp4w-0 iYjZBm fdhJDq"
       >
         <div
           class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
@@ -315,7 +315,7 @@ Object {
           class="Popover__Reference-sc-1liex6z-1 dxsTSY"
         >
           <div
-            class="Row-sc-1nzvhrh-0 feiOJv"
+            class="Row-sc-1nzvhrh-0 ckykgM"
             style="outline: none;"
             tabindex="-1"
           >

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -27,7 +27,7 @@ const StyledExpando = styled(Expando)`
   overflow: hidden;
 `
 
-const COLLAPSED_TOOLBAR_HEIGHT_EM = 3.5
+const COLLAPSED_TOOLBAR_HEIGHT_EM = 3
 
 const ToolbarRow = styled(Row)<{ isExpandable?: true }>`
   cursor: ${({ isExpandable }) => isExpandable && 'pointer'};
@@ -105,9 +105,7 @@ export default memo(function Toolbar() {
         return { caption: <Caption.InsufficientLiquidity /> }
       }
       if (trade?.inputAmount && trade.outputAmount) {
-        const caption = impact?.warning ? (
-          <Caption.PriceImpact impact={impact} expanded={open} />
-        ) : (
+        const caption = (
           <Caption.Trade
             trade={trade}
             outputUSDC={outputUSDC}
@@ -133,7 +131,6 @@ export default memo(function Toolbar() {
     insufficientBalance,
     isWrap,
     trade,
-    impact,
     open,
     outputUSDC,
   ])

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,6 +4,7 @@ import useHasHover from 'hooks/useHasHover'
 import { HelpCircle, Icon } from 'icons'
 import { ComponentProps, ReactNode, useState } from 'react'
 import styled from 'styled-components/macro'
+import { ThemedText } from 'theme'
 
 import { IconButton } from './Button'
 import Popover from './Popover'
@@ -13,6 +14,10 @@ export function useTooltip(tooltip: Node | null | undefined): boolean {
   const focus = useHasFocus(tooltip)
   return hover || focus
 }
+
+export const SmallToolTipBody = styled(ThemedText.Caption)`
+  max-width: 220px;
+`
 
 const IconTooltip = styled(IconButton)`
   cursor: help;


### PR DESCRIPTION
- reduce vertical spacing between elements in the widget
- reduce the height of the toolbar
- add price impact tooltips everywhere we show the value (only shown if warning is "error" or "warning")
  - use a new component for this. added tests for new component
- add token icons to summary page