### PR TITLE
fix: prefer the github-hosted token img

### DIFF
--- a/src/hooks/useCurrencyLogoURIs.test.tsx
+++ b/src/hooks/useCurrencyLogoURIs.test.tsx
@@ -1,0 +1,28 @@
+import { Currency } from '@uniswap/sdk-core'
+import { renderHook } from 'test'
+import { USDC } from 'test/utils'
+
+import useCurrencyLogoURIs from './useCurrencyLogoURIs'
+
+describe('useCurrencyLogoURIs', () => {
+  it('returns the uniswap-managed GH hosted URL first', () => {
+    const currency: Currency & { logoURI?: string } = {
+      isNative: false,
+      isToken: true,
+      chainId: 1,
+      address: '0x111111111117dC0aa78b770fA6A738034120C302',
+      name: '1inch',
+      symbol: '1INCH',
+      decimals: 18,
+      logoURI: 'https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028',
+      equals: jest.fn(),
+      sortsBefore: jest.fn(),
+      wrapped: USDC,
+    }
+    const { result } = renderHook(() => useCurrencyLogoURIs(currency))
+    expect(result.current).toEqual([
+      'https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x111111111117dC0aa78b770fA6A738034120C302/logo.png',
+      'https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028',
+    ])
+  })
+})

--- a/src/hooks/useCurrencyLogoURIs.ts
+++ b/src/hooks/useCurrencyLogoURIs.ts
@@ -63,7 +63,7 @@ export default function useCurrencyLogoURIs(currency?: (Currency & { logoURI?: s
       } else if (currency.isToken) {
         const logoURI = getTokenLogoURI(currency.address, currency.chainId)
         if (logoURI) {
-          logoURIs.push(logoURI)
+          logoURIs.unshift(logoURI)
         }
       }
     }


### PR DESCRIPTION
default to the github URL for the token image first, if there is one.

this fixes a [feedback](https://www.notion.so/uniswaplabs/Using-different-token-images-in-widget-as-interface-and-are-sometimes-lower-res-36ccabc4384645189772ec7f65facee3) we received about the token images differing from what's shown on interface /swap page