### PR TITLE
fix: clip dialogs at corners

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -141,7 +141,7 @@ const slideOutRight = keyframes`
 `
 
 const HiddenWrapper = styled.div`
-  border-radius: ${({ theme }) => theme.borderRadius}em;
+  border-radius: ${({ theme }) => theme.borderRadius.medium}em;
   height: 100%;
   left: 0;
   overflow: hidden;


### PR DESCRIPTION
fixes a bug where dialogs incorrectly overflowed the widget boundary