### PR TITLE
fix: reduce widget min height

### DIFF
--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -17,7 +17,7 @@ const StyledWidgetWrapper = styled.div<{ width: number | string }>`
   flex-direction: column;
 
   max-width: 600px;
-  min-height: 360px;
+  min-height: 300px;
   min-width: 300px;
   padding: ${HORIZONTAL_PADDING}px;
   position: relative;


### PR DESCRIPTION
<img width="377" alt="Screenshot 2023-02-07 at 6 14 34 PM" src="https://user-images.githubusercontent.com/66155195/217411491-e13674b7-a12d-4b7a-aab8-7d6477264c15.png">

reduces the widget min height to fix a layout issue when both `hideConnectionUi` is true and `brandedFooter` is false