### PR TITLE
feat: upgrade conedison to improve signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@fontsource/inter": "^4.5.1",
     "@popperjs/core": "^2.4.4",
     "@reduxjs/toolkit": "^1.6.1",
-    "@uniswap/conedison": "^1.2.1",
+    "@uniswap/conedison": "^1.3.0",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/redux-multicall": "^1.1.8",
     "@uniswap/router-sdk": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,10 +3516,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@uniswap/conedison@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.2.1.tgz#c3dbfe14f4320fc5c60cde23c4bd70ed8a39c782"
-  integrity sha512-ir6j7RQOyREXtW5YlmPjskfl7oDeHWtMFai57snThAkKgrb+8KTX5b0a5nbXeIuaW2RNHAaWTGoSoTneIHCAnQ==
+"@uniswap/conedison@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.3.0.tgz#998aca2bad27f0780a05b40e4512acfcadfece79"
+  integrity sha512-zpZ52svBJ2btwl09mLOw7HlBxFDuYAjAZXLAR7WQZJeRgjD1yD2QuI3v7JliXvHzJh3ePYH6820EMp7xQbdAGQ==
 
 "@uniswap/default-token-list@^2.0.0":
   version "2.2.0"


### PR DESCRIPTION
Upgrades conedison to improve signing.
conedison@1.3 updates signTypedData to default to eth_signTypedData_v4 and only use eth_signTypedData for special-cased wallets.

---

Manually tested on:

- [x] MetaMask (extension)
- [x] MetaMask (mobile)
- [x] Rabby
- [x] SafePal (extension)
- [x] SafePal Mobile
- [x] Zerion
- [x] Rainbow
- [x] Trust
- [x] Argent