### PR TITLE
fix: swallow transaction rejected error

### DIFF
--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -69,7 +69,7 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
   const throwAsync = useAsyncError()
   const onSwap = useCallback(async () => {
     try {
-      await onSubmit(async () => {
+      const submitted = await onSubmit(async () => {
         const response = await swapCallback?.()
         if (!response) return
 
@@ -90,7 +90,9 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
       })
 
       // Only close the review modal if the swap submitted (ie no-throw).
-      setOpen(false)
+      if (submitted) {
+        setOpen(false)
+      }
     } catch (e) {
       throwAsync(e)
     }

--- a/src/components/Swap/SwapActionButton/useOnSubmit.ts
+++ b/src/components/Swap/SwapActionButton/useOnSubmit.ts
@@ -6,16 +6,20 @@ import { displayTxHashAtom, Field } from 'state/swap'
 import { TransactionInfo, TransactionType } from 'state/transactions'
 import { isAnimating } from 'utils/animations'
 
-/** Submits a transaction. */
+/**
+ * Returns a callback to submit a transaction.
+ *
+ * Returns a boolean indicating whether the transaction was submitted.
+ * */
 export default function useOnSubmit() {
   const addTransactionInfo = useAddTransactionInfo()
   const setDisplayTxHash = useUpdateAtom(displayTxHashAtom)
   const [, setInputAmount] = useSwapAmount(Field.INPUT)
 
   return useCallback(
-    async (submit: () => Promise<TransactionInfo | void>): Promise<void> => {
+    async (submit: () => Promise<TransactionInfo | void>): Promise<boolean> => {
       const info = await submit()
-      if (!info) return
+      if (!info) return false
 
       addTransactionInfo(info)
 
@@ -40,6 +44,7 @@ export default function useOnSubmit() {
             setInputAmount('')
           }
       }
+      return true
     },
     [addTransactionInfo, setDisplayTxHash, setInputAmount]
   )

--- a/src/components/Swap/SwapActionButton/useOnSubmit.ts
+++ b/src/components/Swap/SwapActionButton/useOnSubmit.ts
@@ -10,6 +10,9 @@ import { isAnimating } from 'utils/animations'
  * Returns a callback to submit a transaction.
  *
  * Returns a boolean indicating whether the transaction was submitted.
+ * For example, will return false if the user rejected the transaction.
+ *
+ * For other types of errors, `submit` should throw.
  * */
 export default function useOnSubmit() {
   const addTransactionInfo = useAddTransactionInfo()

--- a/src/components/__snapshots__/Header.test.tsx.snap
+++ b/src/components/__snapshots__/Header.test.tsx.snap
@@ -32,7 +32,7 @@ Object {
                 class="Popover__Reference-sc-1liex6z-1 dxsTSY"
               >
                 <button
-                  class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW Settings__SettingsButton-sc-1hvqnx5-0 cnMPAK"
+                  class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Settings__SettingsButton-sc-1hvqnx5-0 cnMPAK"
                   data-testid="settings-button"
                 >
                   <svg
@@ -99,7 +99,7 @@ Object {
                                     class="Popover__Reference-sc-1liex6z-1 dxsTSY"
                                   >
                                     <button
-                                      class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
+                                      class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
                                       style="outline: none;"
                                       tabindex="-1"
                                     >
@@ -144,7 +144,7 @@ Object {
                                 Auto
                               </div>
                               <button
-                                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW"
+                                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW"
                                 color="secondary"
                               />
                             </div>
@@ -161,7 +161,7 @@ Object {
                             class="Row-sc-1nzvhrh-0 MaxSlippageSelect__ExpandoContent-sc-9adwbi-2 gMSmq hhEkFu"
                           >
                             <button
-                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe eyTUY gUnHND"
+                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe iTVhWO TaTpc"
                               data-testid="auto-slippage"
                             >
                               <div
@@ -178,7 +178,7 @@ Object {
                               </div>
                             </button>
                             <button
-                              class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe iiNNRv"
+                              class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe kRvBEX"
                               data-testid="custom-slippage"
                               style="outline: none;"
                               tabindex="-1"
@@ -249,7 +249,7 @@ Object {
                                   class="Popover__Reference-sc-1liex6z-1 dxsTSY"
                                 >
                                   <button
-                                    class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
+                                    class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
                                     style="outline: none;"
                                     tabindex="-1"
                                   >
@@ -298,7 +298,7 @@ Object {
                                 </div>
                               </div>
                               <button
-                                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW"
+                                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW"
                                 color="secondary"
                               />
                             </div>
@@ -315,7 +315,7 @@ Object {
                             class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gpwEJV bpVbyU"
                           >
                             <div
-                              class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fBCrSN crRNBf"
+                              class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fBCrSN enSvbW"
                             >
                               <div
                                 class="type__TextWrapper-sc-16386l-0 dvdIBe body body-1 css-jmxshz"
@@ -409,7 +409,7 @@ Object {
               class="Popover__Reference-sc-1liex6z-1 dxsTSY"
             >
               <button
-                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW Settings__SettingsButton-sc-1hvqnx5-0 cnMPAK"
+                class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Settings__SettingsButton-sc-1hvqnx5-0 cnMPAK"
                 data-testid="settings-button"
               >
                 <svg
@@ -476,7 +476,7 @@ Object {
                                   class="Popover__Reference-sc-1liex6z-1 dxsTSY"
                                 >
                                   <button
-                                    class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
+                                    class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
                                     style="outline: none;"
                                     tabindex="-1"
                                   >
@@ -521,7 +521,7 @@ Object {
                               Auto
                             </div>
                             <button
-                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW"
+                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW"
                               color="secondary"
                             />
                           </div>
@@ -538,7 +538,7 @@ Object {
                           class="Row-sc-1nzvhrh-0 MaxSlippageSelect__ExpandoContent-sc-9adwbi-2 gMSmq hhEkFu"
                         >
                           <button
-                            class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe eyTUY gUnHND"
+                            class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe iTVhWO TaTpc"
                             data-testid="auto-slippage"
                           >
                             <div
@@ -555,7 +555,7 @@ Object {
                             </div>
                           </button>
                           <button
-                            class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe iiNNRv"
+                            class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe kRvBEX"
                             data-testid="custom-slippage"
                             style="outline: none;"
                             tabindex="-1"
@@ -626,7 +626,7 @@ Object {
                                 class="Popover__Reference-sc-1liex6z-1 dxsTSY"
                               >
                                 <button
-                                  class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
+                                  class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
                                   style="outline: none;"
                                   tabindex="-1"
                                 >
@@ -675,7 +675,7 @@ Object {
                               </div>
                             </div>
                             <button
-                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe hoTLoq jwaziW"
+                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW"
                               color="secondary"
                             />
                           </div>
@@ -692,7 +692,7 @@ Object {
                           class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gpwEJV bpVbyU"
                         >
                           <div
-                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fBCrSN crRNBf"
+                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fBCrSN enSvbW"
                           >
                             <div
                               class="type__TextWrapper-sc-16386l-0 dvdIBe body body-1 css-jmxshz"

--- a/src/utils/swapErrorToUserReadableMessage.tsx
+++ b/src/utils/swapErrorToUserReadableMessage.tsx
@@ -1,5 +1,15 @@
 import { t } from '@lingui/macro'
 import { ErrorCode } from 'constants/eip1193'
+
+export function getReason(error: any): string | undefined {
+  let reason: string | undefined
+  while (Boolean(error)) {
+    reason = error.reason ?? error.message ?? reason
+    error = error.error ?? error.data?.originalError
+  }
+  return reason
+}
+
 /**
  * This is hacking out the revert reason from the ethers provider thrown error however it can.
  * This object seems to be undocumented by ethers.
@@ -12,11 +22,7 @@ export function swapErrorToUserReadableMessage(error: any): string {
     }
   }
 
-  let reason: string | undefined
-  while (Boolean(error)) {
-    reason = error.reason ?? error.message ?? reason
-    error = error.error ?? error.data?.originalError
-  }
+  let reason = getReason(error)
 
   if (reason?.indexOf('execution reverted: ') === 0) reason = reason.substr('execution reverted: '.length)
 


### PR DESCRIPTION
stop throwing `SwapError`s when the user rejects the Transaction. instead, if we detect that the user rejected, just notify the product code via the return value. for now, we swallow the error and just revert the UI so they can try again. but we may want to show a message inline in this situation

https://uniswaplabs.atlassian.net/browse/WEB-2888?atlOrigin=eyJpIjoiYTg1YWFiZDYwMGM2NDc3NWJmOGRiZGE3NGNmNGQyZTQiLCJwIjoiaiJ9