### PR TITLE
fix: design issues in settings

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import { X } from 'icons'
 import { forwardRef, PropsWithChildren, useState } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { keyframes } from 'styled-components/macro'
@@ -73,6 +74,13 @@ const Wrapper = styled.div<{ open: boolean }>`
   }
 `
 
+const StyledXButton = styled(X)`
+  :hover {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+`
+
 type BottomSheetModalProps = PropsWithChildren<{
   onClose: () => void
   open: boolean
@@ -89,7 +97,7 @@ export function BottomSheetModal({ children, onClose, open, title }: BottomSheet
         {open && (
           <Dialog color="dialog" onClose={onClose}>
             <>
-              <Header title={<Trans>{title}</Trans>} />
+              <Header title={<Trans>{title}</Trans>} closeButton={<StyledXButton />} />
               {children}
             </>
           </Dialog>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -110,13 +110,14 @@ const Title = styled.div`
 
 interface HeaderProps {
   title?: ReactElement
+  closeButton?: ReactElement
 }
 
-export function Header({ title }: HeaderProps) {
+export function Header({ title, closeButton }: HeaderProps) {
   const onClose = useCloseDialog()
   return (
     <HeaderRow iconSize={1.25} data-testid="dialog-header">
-      <StyledBackButton onClick={onClose} />
+      {closeButton ? <div onClick={onClose}>{closeButton}</div> : <StyledBackButton onClick={onClose} />}
       <Title>
         <ThemedText.Subhead1>{title}</ThemedText.Subhead1>
       </Title>

--- a/src/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -20,14 +20,23 @@ import { Label, optionCss } from './components'
 
 const Button = styled(TextButton)<{ selected: boolean }>`
   ${({ selected }) => optionCss(selected)}
+  display: flex;
+  flex-grow: 1;
+  max-width: 180px;
 `
 
 const Custom = styled(BaseButton)<{ selected: boolean }>`
   ${({ selected }) => optionCss(selected)}
   ${inputCss}
+  display: flex;
+  flex-grow: 1;
+  max-width: 180px;
+  * input {
+    text-align: right;
+  }
 `
 
-const ExpandoContent = styled(Row)`
+const ExpandoContentRow = styled(Row)`
   margin: 1em 0 0;
 `
 
@@ -36,20 +45,21 @@ interface OptionProps {
   selected: boolean
   onSelect: () => void
   'data-testid': string
+  justify?: 'flex-end' | 'flex-start'
   icon?: ReactNode
   tabIndex?: number
   children: ReactNode
 }
 
 const Option = forwardRef<HTMLButtonElement, OptionProps>(function Option(
-  { wrapper: Wrapper, children, selected, onSelect, icon, tabIndex, 'data-testid': testid }: OptionProps,
+  { wrapper: Wrapper, children, selected, onSelect, icon, tabIndex, 'data-testid': testid, justify }: OptionProps,
   ref
 ) {
   return (
     <Wrapper selected={selected} onClick={onSelect} ref={ref} tabIndex={tabIndex} data-testid={testid}>
-      <Row gap={0.5}>
+      <Row gap={0.5} flex grow flow="nowrap" justify={justify}>
         {children}
-        {icon ? icon : <LargeIcon icon={selected ? Check : undefined} size={1.25} />}
+        {icon ? icon : <LargeIcon icon={Check} size={1.25} color={selected ? 'active' : 'hint'} />}
       </Row>
     </Wrapper>
   )
@@ -152,7 +162,7 @@ export default function MaxSlippageSelect() {
         open={open}
         onExpand={() => setOpen(!open)}
       >
-        <ExpandoContent gap={0.5} grow="first">
+        <ExpandoContentRow gap={0.5} grow="first" flex justify="flex-end">
           <Option wrapper={Button} selected={slippage.auto} onSelect={setAutoSlippage} data-testid="auto-slippage">
             <ThemedText.ButtonMedium>
               <Trans>Auto</Trans>
@@ -165,9 +175,10 @@ export default function MaxSlippageSelect() {
             icon={warning && <Warning state={warning} showTooltip={showTooltip} />}
             ref={option}
             tabIndex={-1}
+            justify="flex-end"
             data-testid="custom-slippage"
           >
-            <Row color={warning === 'error' ? 'error' : undefined}>
+            <Row color={warning === 'error' ? 'error' : undefined} flex grow flow="nowrap">
               <DecimalInput
                 size={Math.max(maxSlippageInput.length, 4)}
                 value={maxSlippageInput}
@@ -175,11 +186,12 @@ export default function MaxSlippageSelect() {
                 placeholder={'0.10'}
                 ref={input}
                 data-testid="input-slippage"
+                maxLength={10}
               />
               %
             </Row>
           </Option>
-        </ExpandoContent>
+        </ExpandoContentRow>
       </Expando>
     </Column>
   )

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -14,7 +14,7 @@ const Input = styled(Row)`
   ${inputCss};
 
   background-color: transparent;
-  width: 4em;
+  max-width: 360px;
 
   input {
     text-align: right;
@@ -22,9 +22,7 @@ const Input = styled(Row)`
 `
 
 const InputContainer = styled(Row)`
-  display: flex;
   gap: 0.5em;
-  justify-content: flex-start;
   margin: 1em 0 0;
 `
 
@@ -62,20 +60,19 @@ export default function TransactionTtlInput() {
           />
         }
       >
-        <InputContainer grow>
-          <Input pad={0.5} justify="start" onClick={() => input.current?.focus()}>
-            <ThemedText.Body1>
-              <IntegerInput
-                placeholder={placeholder}
-                value={ttlValue ?? ''}
-                onChange={(value) => setTtl(value ? parseFloat(value) : undefined)}
-                ref={input}
-              />
-            </ThemedText.Body1>
+        <InputContainer flex grow justify="flex-end">
+          <Input gap={0.5} pad={0.5} onClick={() => input.current?.focus()} flex grow flow="nowrap">
+            <IntegerInput
+              placeholder={placeholder}
+              value={ttlValue ?? ''}
+              onChange={(value) => setTtl(value ? parseFloat(value) : undefined)}
+              ref={input}
+              maxLength={10}
+            />
+            <ThemedText.Body2 color="secondary" margin="0 0.5rem 0 0">
+              <Trans>minutes</Trans>
+            </ThemedText.Body2>
           </Input>
-          <Trans>
-            <ThemedText.Body2 color="secondary">minutes</ThemedText.Body2>
-          </Trans>
         </InputContainer>
       </Expando>
     </Column>

--- a/src/components/Swap/Settings/components.tsx
+++ b/src/components/Swap/Settings/components.tsx
@@ -1,3 +1,4 @@
+import { Info } from 'icons'
 import { ReactNode } from 'react'
 import styled, { AnyStyledComponent, css } from 'styled-components/macro'
 import { ThemedText } from 'theme'
@@ -42,7 +43,7 @@ export function Label({ name, tooltip }: LabelProps) {
     <Row gap={0.5} justify="flex-start">
       <ThemedText.Subhead2>{name}</ThemedText.Subhead2>
       {tooltip && (
-        <Tooltip placement="top" contained>
+        <Tooltip placement="top" contained icon={Info}>
           <ThemedText.Caption>{tooltip}</ThemedText.Caption>
         </Tooltip>
       )}

--- a/src/components/__snapshots__/Header.test.tsx.snap
+++ b/src/components/__snapshots__/Header.test.tsx.snap
@@ -120,14 +120,17 @@ Object {
                                           cy="12"
                                           r="10"
                                         />
-                                        <path
-                                          d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+                                        <line
+                                          x1="12"
+                                          x2="12"
+                                          y1="16"
+                                          y2="12"
                                         />
                                         <line
                                           x1="12"
                                           x2="12.01"
-                                          y1="17"
-                                          y2="17"
+                                          y1="8"
+                                          y2="8"
                                         />
                                       </svg>
                                     </button>
@@ -158,14 +161,14 @@ Object {
                           class="Column-sc-1ul9eki-0 Expando__InnerColumn-sc-yzkwmi-4 Expando___StyledInnerColumn-sc-yzkwmi-5 iSonrV fScoqQ fbFiQW"
                         >
                           <div
-                            class="Row-sc-1nzvhrh-0 MaxSlippageSelect__ExpandoContent-sc-9adwbi-2 gMSmq hhEkFu"
+                            class="Row-sc-1nzvhrh-0 MaxSlippageSelect__ExpandoContentRow-sc-9adwbi-2 ftQsXL cheHiA"
                           >
                             <button
-                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe iTVhWO TaTpc"
+                              class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe iTVhWO bnctWB"
                               data-testid="auto-slippage"
                             >
                               <div
-                                class="Row-sc-1nzvhrh-0 fZrFzq"
+                                class="Row-sc-1nzvhrh-0 iFLCZk"
                               >
                                 <div
                                   class="type__TextWrapper-sc-16386l-0 hBKeLq button button-medium css-17g4kvt"
@@ -174,20 +177,21 @@ Object {
                                 </div>
                                 <div
                                   class="icons__LargeWrapper-sc-lekdau-1 gyYXVl"
+                                  color="active"
                                 />
                               </div>
                             </button>
                             <button
-                              class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe kRvBEX"
+                              class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe hXefAh"
                               data-testid="custom-slippage"
                               style="outline: none;"
                               tabindex="-1"
                             >
                               <div
-                                class="Row-sc-1nzvhrh-0 fZrFzq"
+                                class="Row-sc-1nzvhrh-0 fFwGMy"
                               >
                                 <div
-                                  class="Row-sc-1nzvhrh-0 kSeFcF"
+                                  class="Row-sc-1nzvhrh-0 fUVNpP"
                                 >
                                   <input
                                     autocomplete="off"
@@ -195,7 +199,7 @@ Object {
                                     class="Input-sc-1e35ws5-0 qhvlL"
                                     data-testid="input-slippage"
                                     inputmode="decimal"
-                                    maxlength="79"
+                                    maxlength="10"
                                     minlength="1"
                                     pattern="^[0-9]*[.,]?[0-9]*$"
                                     placeholder="0.10"
@@ -208,6 +212,7 @@ Object {
                                 </div>
                                 <div
                                   class="icons__LargeWrapper-sc-lekdau-1 gyYXVl"
+                                  color="hint"
                                 />
                               </div>
                             </button>
@@ -270,14 +275,17 @@ Object {
                                         cy="12"
                                         r="10"
                                       />
-                                      <path
-                                        d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+                                      <line
+                                        x1="12"
+                                        x2="12"
+                                        y1="16"
+                                        y2="12"
                                       />
                                       <line
                                         x1="12"
                                         x2="12.01"
-                                        y1="17"
-                                        y2="17"
+                                        y1="8"
+                                        y2="8"
                                       />
                                     </svg>
                                   </button>
@@ -312,33 +320,29 @@ Object {
                           class="Column-sc-1ul9eki-0 Expando__InnerColumn-sc-yzkwmi-4 Expando___StyledInnerColumn-sc-yzkwmi-5 iSonrV fRDzgd fbFiQW"
                         >
                           <div
-                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gpwEJV bpVbyU"
+                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gQrhhv knpWPV"
                           >
                             <div
-                              class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fBCrSN enSvbW"
+                              class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 eljOnX fAOjbi"
                             >
+                              <input
+                                autocomplete="off"
+                                autocorrect="off"
+                                class="Input-sc-1e35ws5-0 qhvlL"
+                                inputmode="decimal"
+                                maxlength="10"
+                                minlength="1"
+                                pattern="^[0-9]*$"
+                                placeholder="30"
+                                spellcheck="false"
+                                type="text"
+                                value=""
+                              />
                               <div
-                                class="type__TextWrapper-sc-16386l-0 dvdIBe body body-1 css-jmxshz"
+                                class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-ijlljt"
                               >
-                                <input
-                                  autocomplete="off"
-                                  autocorrect="off"
-                                  class="Input-sc-1e35ws5-0 qhvlL"
-                                  inputmode="decimal"
-                                  maxlength="79"
-                                  minlength="1"
-                                  pattern="^[0-9]*$"
-                                  placeholder="30"
-                                  spellcheck="false"
-                                  type="text"
-                                  value=""
-                                />
+                                minutes
                               </div>
-                            </div>
-                            <div
-                              class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
-                            >
-                              minutes
                             </div>
                           </div>
                         </div>
@@ -497,14 +501,17 @@ Object {
                                         cy="12"
                                         r="10"
                                       />
-                                      <path
-                                        d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+                                      <line
+                                        x1="12"
+                                        x2="12"
+                                        y1="16"
+                                        y2="12"
                                       />
                                       <line
                                         x1="12"
                                         x2="12.01"
-                                        y1="17"
-                                        y2="17"
+                                        y1="8"
+                                        y2="8"
                                       />
                                     </svg>
                                   </button>
@@ -535,14 +542,14 @@ Object {
                         class="Column-sc-1ul9eki-0 Expando__InnerColumn-sc-yzkwmi-4 Expando___StyledInnerColumn-sc-yzkwmi-5 iSonrV fScoqQ fbFiQW"
                       >
                         <div
-                          class="Row-sc-1nzvhrh-0 MaxSlippageSelect__ExpandoContent-sc-9adwbi-2 gMSmq hhEkFu"
+                          class="Row-sc-1nzvhrh-0 MaxSlippageSelect__ExpandoContentRow-sc-9adwbi-2 ftQsXL cheHiA"
                         >
                           <button
-                            class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe iTVhWO TaTpc"
+                            class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 MaxSlippageSelect__Button-sc-9adwbi-0 gleKKe iTVhWO bnctWB"
                             data-testid="auto-slippage"
                           >
                             <div
-                              class="Row-sc-1nzvhrh-0 fZrFzq"
+                              class="Row-sc-1nzvhrh-0 iFLCZk"
                             >
                               <div
                                 class="type__TextWrapper-sc-16386l-0 hBKeLq button button-medium css-17g4kvt"
@@ -551,20 +558,21 @@ Object {
                               </div>
                               <div
                                 class="icons__LargeWrapper-sc-lekdau-1 gyYXVl"
+                                color="active"
                               />
                             </div>
                           </button>
                           <button
-                            class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe kRvBEX"
+                            class="Button__BaseButton-sc-1soikk5-0 MaxSlippageSelect__Custom-sc-9adwbi-1 gleKKe hXefAh"
                             data-testid="custom-slippage"
                             style="outline: none;"
                             tabindex="-1"
                           >
                             <div
-                              class="Row-sc-1nzvhrh-0 fZrFzq"
+                              class="Row-sc-1nzvhrh-0 fFwGMy"
                             >
                               <div
-                                class="Row-sc-1nzvhrh-0 kSeFcF"
+                                class="Row-sc-1nzvhrh-0 fUVNpP"
                               >
                                 <input
                                   autocomplete="off"
@@ -572,7 +580,7 @@ Object {
                                   class="Input-sc-1e35ws5-0 qhvlL"
                                   data-testid="input-slippage"
                                   inputmode="decimal"
-                                  maxlength="79"
+                                  maxlength="10"
                                   minlength="1"
                                   pattern="^[0-9]*[.,]?[0-9]*$"
                                   placeholder="0.10"
@@ -585,6 +593,7 @@ Object {
                               </div>
                               <div
                                 class="icons__LargeWrapper-sc-lekdau-1 gyYXVl"
+                                color="hint"
                               />
                             </div>
                           </button>
@@ -647,14 +656,17 @@ Object {
                                       cy="12"
                                       r="10"
                                     />
-                                    <path
-                                      d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+                                    <line
+                                      x1="12"
+                                      x2="12"
+                                      y1="16"
+                                      y2="12"
                                     />
                                     <line
                                       x1="12"
                                       x2="12.01"
-                                      y1="17"
-                                      y2="17"
+                                      y1="8"
+                                      y2="8"
                                     />
                                   </svg>
                                 </button>
@@ -689,33 +701,29 @@ Object {
                         class="Column-sc-1ul9eki-0 Expando__InnerColumn-sc-yzkwmi-4 Expando___StyledInnerColumn-sc-yzkwmi-5 iSonrV fRDzgd fbFiQW"
                       >
                         <div
-                          class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gpwEJV bpVbyU"
+                          class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gQrhhv knpWPV"
                         >
                           <div
-                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fBCrSN enSvbW"
+                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 eljOnX fAOjbi"
                           >
+                            <input
+                              autocomplete="off"
+                              autocorrect="off"
+                              class="Input-sc-1e35ws5-0 qhvlL"
+                              inputmode="decimal"
+                              maxlength="10"
+                              minlength="1"
+                              pattern="^[0-9]*$"
+                              placeholder="30"
+                              spellcheck="false"
+                              type="text"
+                              value=""
+                            />
                             <div
-                              class="type__TextWrapper-sc-16386l-0 dvdIBe body body-1 css-jmxshz"
+                              class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-ijlljt"
                             >
-                              <input
-                                autocomplete="off"
-                                autocorrect="off"
-                                class="Input-sc-1e35ws5-0 qhvlL"
-                                inputmode="decimal"
-                                maxlength="79"
-                                minlength="1"
-                                pattern="^[0-9]*$"
-                                placeholder="30"
-                                spellcheck="false"
-                                type="text"
-                                value=""
-                              />
+                              minutes
                             </div>
-                          </div>
-                          <div
-                            class="type__TextWrapper-sc-16386l-0 bkyFtK body body-2 css-d5fsiy"
-                          >
-                            minutes
                           </div>
                         </div>
                       </div>

--- a/src/hooks/useIsMobileWidth.ts
+++ b/src/hooks/useIsMobileWidth.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-const MOBILE_BREAKPOINT_WIDTH = 900
+const MOBILE_BREAKPOINT_WIDTH = 640
 
 export function useIsMobileWidth() {
   const [width, setWidth] = useState(window.innerWidth)

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -109,9 +109,9 @@ export const XOctagon = icon(XOctagonIcon)
 export const Reverse = icon(ReverseIcon)
 export const Search = icon(SearchIcon)
 
-export const Check = styled(icon(CheckIcon))`
+export const Check = styled(icon(CheckIcon))<{ color?: Color }>`
   circle {
-    fill: ${({ theme }) => theme.active};
+    fill: ${({ theme, color }) => theme[color ?? 'active']};
     stroke: none;
   }
 `


### PR DESCRIPTION
see the design feedbacks [here](https://www.notion.so/uniswaplabs/Settings-responsiveness-issues-and-design-refinement-606be8f282cb403dae1147b79ce16b06?pvs=4)

list of changes:
- change arrow icon to x icon
- introduce max-width to elements in these expando rows
- adjust input visuals slightly
- change icons for tooltips
- change mobile breakpoint

<img width="512" alt="Screenshot 2023-02-13 at 3 26 39 PM" src="https://user-images.githubusercontent.com/66155195/218597427-92c010a2-09e0-484c-9e78-a2798106a093.png">
<img width="512" alt="Screenshot 2023-02-13 at 3 26 31 PM" src="https://user-images.githubusercontent.com/66155195/218597435-5c0160f7-123a-47f2-9444-f5ba10abad05.png">
<img width="512" alt="Screenshot 2023-02-13 at 3 26 22 PM" src="https://user-images.githubusercontent.com/66155195/218597438-6dc2f2fa-a57e-4236-a38a-d579c5b38a64.png">
<img width="512" alt="Screenshot 2023-02-13 at 3 26 12 PM" src="https://user-images.githubusercontent.com/66155195/218597443-8f464a93-0ff3-4094-aaf3-1e0fbd0902fb.png">
<img width="364" alt="Screenshot 2023-02-13 at 3 25 55 PM" src="https://user-images.githubusercontent.com/66155195/218597447-60b3d01b-957a-41aa-88f0-69b1195fb473.png">
