### PR TITLE
chore: upgrade universal-router-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@uniswap/sdk-core": "^3.0.1",
     "@uniswap/smart-order-router": "^2.10.0",
     "@uniswap/token-lists": "^1.0.0-beta.30",
-    "@uniswap/universal-router-sdk": "^1.3.4",
+    "@uniswap/universal-router-sdk": "^1.3.6",
     "@uniswap/v2-sdk": "^3.0.1",
     "@uniswap/v3-sdk": "^3.8.2",
     "@web3-react/core": "8.0.35-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3624,10 +3624,10 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.30.tgz#2103ca23b8007c59ec71718d34cdc97861c409e5"
   integrity sha512-HwY2VvkQ8lNR6ks5NqQfAtg+4IZqz3KV1T8d2DlI8emIn9uMmaoFbIOg0nzjqAVKKnZSbMTRRtUoAh6mmjRvog==
 
-"@uniswap/universal-router-sdk@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.3.4.tgz#7b6b8e30d6faff812f224d32a832385378568160"
-  integrity sha512-RIWZm48N/fiAssMOj0nMLoeN5JATKOMfbFwyVnCaFHIVMJmKEZtZLKe3QOkl2LMVnQ/nP4LVCDwHU+mdP68jCQ==
+"@uniswap/universal-router-sdk@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.3.6.tgz#01347070f69ca6b395723c614fc2a12a9a9a6db1"
+  integrity sha512-wdJLQgpj/Rl1+9LZ14N7ikJbQmVWnUoTPjyupc+lNyiX1a8jEVFwFiVGgSP/ERs5hdgWyApw5F67HljYEIWCDA==
   dependencies:
     "@uniswap/permit2-sdk" "^1.2.0"
     "@uniswap/router-sdk" "^1.4.0"


### PR DESCRIPTION
Resolves an issue with permit signatures not working with smart contract wallets.