### PR TITLE
feat: dialog no animation

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -203,10 +203,12 @@ const fadeAnimationCss = css`
   }
 `
 
+const EMPTY_CSS = css``
+
 const getAnimation = (animationType?: DialogAnimationType) => {
   switch (animationType) {
     case DialogAnimationType.NONE:
-      return css``
+      return EMPTY_CSS
     case DialogAnimationType.FADE:
       return fadeAnimationCss
     case DialogAnimationType.SLIDE:

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -33,6 +33,7 @@ export interface DialogWidgetProps {
 export enum DialogAnimationType {
   SLIDE = 'slide', // default
   FADE = 'fade',
+  NONE = 'none',
 }
 
 export enum SlideAnimationType {
@@ -202,9 +203,21 @@ const fadeAnimationCss = css`
   }
 `
 
-const AnimationWrapper = styled.div<{ animationType: DialogAnimationType }>`
+const getAnimation = (animationType?: DialogAnimationType) => {
+  switch (animationType) {
+    case DialogAnimationType.NONE:
+      return css``
+    case DialogAnimationType.FADE:
+      return fadeAnimationCss
+    case DialogAnimationType.SLIDE:
+    default:
+      return slideAnimationCss
+  }
+}
+
+const AnimationWrapper = styled.div<{ animationType?: DialogAnimationType }>`
   ${Modal} {
-    ${({ animationType }) => (animationType === DialogAnimationType.FADE ? fadeAnimationCss : slideAnimationCss)}
+    ${({ animationType }) => getAnimation(animationType)}
   }
 `
 
@@ -254,7 +267,7 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
         <PopoverBoundaryProvider value={popoverRef.current} updateTrigger={updatePopover}>
           <div ref={popoverRef}>
             <HiddenWrapper>
-              <AnimationWrapper animationType={context.options?.animationType ?? DialogAnimationType.SLIDE}>
+              <AnimationWrapper animationType={context.options?.animationType}>
                 <OnCloseContext.Provider value={onClose}>
                   <Modal color={color} ref={modal}>
                     {children}

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -90,7 +90,7 @@ function Fixture() {
 
   const dialogAnimation = useOption('dialogAnimation', {
     defaultValue: DialogAnimationType.SLIDE,
-    options: [DialogAnimationType.SLIDE, DialogAnimationType.FADE],
+    options: [DialogAnimationType.SLIDE, DialogAnimationType.FADE, DialogAnimationType.NONE],
   })
 
   const eventHandlers = useMemo(


### PR DESCRIPTION
adds a new option to `DialogAnimationType` to allow for *no* animation.

this would allow integrators to animation the dialog however they want, at the container level