### PR TITLE
feat: x button for dialogs

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -2,7 +2,7 @@ import 'wicg-inert'
 
 import { globalFontStyles } from 'css/font'
 import { useOnEscapeHandler } from 'hooks/useOnEscapeHandler'
-import { largeIconCss } from 'icons'
+import { largeIconCss, X } from 'icons'
 import { ArrowLeft } from 'icons'
 import ms from 'ms.macro'
 import { createContext, ReactElement, ReactNode, useContext, useEffect, useRef, useState } from 'react'
@@ -85,6 +85,11 @@ export function useCloseDialog() {
   return useContext(OnCloseContext)
 }
 
+export function useDialogAnimationType() {
+  const { options } = useContext(Context)
+  return options?.animationType
+}
+
 const HeaderRow = styled(Row)`
   display: flex;
   height: 1.75em;
@@ -96,6 +101,13 @@ const HeaderRow = styled(Row)`
 `
 
 const StyledBackButton = styled(ArrowLeft)`
+  :hover {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+`
+
+const StyledXButton = styled(X)`
   :hover {
     cursor: pointer;
     opacity: 0.6;
@@ -114,9 +126,14 @@ interface HeaderProps {
 
 export function Header({ title }: HeaderProps) {
   const onClose = useCloseDialog()
+  const animationType = useDialogAnimationType()
   return (
     <HeaderRow iconSize={1.25} data-testid="dialog-header">
-      <StyledBackButton onClick={onClose} />
+      {animationType === DialogAnimationType.SLIDE ? (
+        <StyledBackButton onClick={onClose} />
+      ) : (
+        <StyledXButton onClick={onClose} />
+      )}
       <Title>
         <ThemedText.Subhead1>{title}</ThemedText.Subhead1>
       </Title>


### PR DESCRIPTION
changes the dialog "close" button to an `X` icon , if it's _not_ sliding in from the right

<img width="385" alt="Screenshot 2023-02-14 at 5 18 02 PM" src="https://user-images.githubusercontent.com/66155195/218900326-a6298ff4-65f0-43f1-a0b0-4cacd35392f8.png">
