### PR TITLE
fix: make price impact more consistent

### DIFF
--- a/src/components/Swap/Summary/Details.tsx
+++ b/src/components/Swap/Summary/Details.tsx
@@ -19,7 +19,6 @@ import { WIDGET_BREAKPOINTS } from 'theme/breakpoints'
 import { currencyId } from 'utils/currencyId'
 
 import { useTradeExchangeRate } from '../Price'
-import { PriceImpactRow } from '../PriceImpactRow'
 import { getEstimateMessage } from './Estimate'
 
 const Label = styled.span`
@@ -148,7 +147,7 @@ export default function Details({ trade, slippage, gasUseEstimateUSD, inputUSDC,
     }
 
     if (impact) {
-      details.push([t`Price impact`, <PriceImpactRow key="impact" impact={impact} reverse />, impact.warning])
+      details.push([t`Price impact`, impact?.percent ? impact?.toString() : '-', impact.warning])
     }
 
     const { estimateMessage, descriptor, value } = getEstimateMessage(trade, slippage)

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@lingui/macro'
-import { formatCurrencyAmount, formatPriceImpact, NumberType } from '@uniswap/conedison/format'
+import { formatCurrencyAmount, NumberType } from '@uniswap/conedison/format'
 import ActionButton from 'components/ActionButton'
 import Column from 'components/Column'
 import Expando from 'components/Expando'
@@ -117,7 +117,7 @@ function CaptionRow() {
       {
         color: impact?.warning,
         name: t`Price impact`,
-        value: impact?.percent ? formatPriceImpact(impact?.percent) : '-',
+        value: impact?.percent ? impact?.toString() : '-',
         valueTooltip: impact?.warning
           ? {
               icon: AlertTriangle,
@@ -141,7 +141,7 @@ function CaptionRow() {
       },
     ]
     return rows
-  }, [gasUseEstimateUSD, impact?.percent, impact?.warning, slippage, trade])
+  }, [gasUseEstimateUSD, impact, slippage, trade])
 
   if (inputCurrency == null || outputCurrency == null || error === ChainError.MISMATCHED_CHAINS) {
     return null


### PR DESCRIPTION
addresses some [design feedback](https://www.notion.so/uniswaplabs/Widget-design-feedback-835bfad85aac4ad3a00550fcea18bf99) about the formatting and styling of the price impact.

- remove parens from the % in the review screen
- use `toString` everywhere to ensure consistent values