### PR TITLE
feat: loading state for toolbar Trade

### DIFF
--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -155,7 +155,7 @@ export function Trade({
     <>
       <Caption
         caption={
-          <ThemedText.Body2 color="secondary" opacity={loading ? 0.4 : 1}>
+          <ThemedText.Body2 opacity={loading ? 0.4 : 1}>
             <Price trade={trade} outputUSDC={outputUSDC} />
           </ThemedText.Body2>
         }

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -48,10 +48,11 @@ interface CaptionProps {
   icon?: Icon | null
   caption: ReactNode
   color?: Color
+  loading?: boolean
   tooltip?: CaptionTooltip
 }
 
-function Caption({ icon: Icon, caption, color = 'secondary', tooltip }: CaptionProps) {
+function Caption({ icon: Icon, caption, color = 'secondary', tooltip, loading }: CaptionProps) {
   return (
     <CaptionRow gap={0.5} shrink={0}>
       {tooltip ? (
@@ -61,7 +62,9 @@ function Caption({ icon: Icon, caption, color = 'secondary', tooltip }: CaptionP
       ) : (
         Icon && <LargeIcon icon={Icon} color={color} />
       )}
-      <ThemedText.Body2 color={color}>{caption}</ThemedText.Body2>
+      <ThemedText.Body2 color={color} opacity={loading ? 0.4 : 1}>
+        {caption}
+      </ThemedText.Body2>
     </CaptionRow>
   )
 }
@@ -132,6 +135,7 @@ export function Wrap({ inputCurrency, outputCurrency }: WrapProps) {
 
 export interface TradeProps {
   trade: InterfaceTrade
+  loading: boolean
   outputUSDC?: CurrencyAmount<Currency>
 }
 
@@ -143,10 +147,20 @@ const Expander = ({ expanded }: ExpandProps) => {
   return <ExpandIcon $expanded={expanded} />
 }
 
-export function Trade({ trade, outputUSDC, gasUseEstimateUSD, expanded }: TradeProps & TradeTooltip & ExpandProps) {
+export function Trade({
+  trade,
+  outputUSDC,
+  gasUseEstimateUSD,
+  expanded,
+  loading,
+}: TradeProps & TradeTooltip & ExpandProps) {
   return (
     <>
-      <Caption caption={<Price trade={trade} outputUSDC={outputUSDC} />} />
+      <Caption
+        caption={<Price trade={trade} outputUSDC={outputUSDC} />}
+        icon={loading ? Spinner : null}
+        loading={loading}
+      />
       <CaptionRow gap={0.75}>
         {!expanded && (
           <CaptionRow gap={0.25}>

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -48,11 +48,10 @@ interface CaptionProps {
   icon?: Icon | null
   caption: ReactNode
   color?: Color
-  loading?: boolean
   tooltip?: CaptionTooltip
 }
 
-function Caption({ icon: Icon, caption, color = 'secondary', tooltip, loading }: CaptionProps) {
+function Caption({ icon: Icon, caption, color = 'secondary', tooltip }: CaptionProps) {
   return (
     <CaptionRow gap={0.5} shrink={0}>
       {tooltip ? (
@@ -62,9 +61,7 @@ function Caption({ icon: Icon, caption, color = 'secondary', tooltip, loading }:
       ) : (
         Icon && <LargeIcon icon={Icon} color={color} />
       )}
-      <ThemedText.Body2 color={color} opacity={loading ? 0.4 : 1}>
-        {caption}
-      </ThemedText.Body2>
+      <ThemedText.Body2 color={color}>{caption}</ThemedText.Body2>
     </CaptionRow>
   )
 }
@@ -157,9 +154,12 @@ export function Trade({
   return (
     <>
       <Caption
-        caption={<Price trade={trade} outputUSDC={outputUSDC} />}
+        caption={
+          <ThemedText.Body2 color="secondary" opacity={loading ? 0.4 : 1}>
+            <Price trade={trade} outputUSDC={outputUSDC} />
+          </ThemedText.Body2>
+        }
         icon={loading ? Spinner : null}
-        loading={loading}
       />
       <CaptionRow gap={0.75}>
         {!expanded && (

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -61,7 +61,7 @@ function CaptionRow() {
       default:
     }
 
-    if (state === TradeState.LOADING && trade === undefined) {
+    if (state === TradeState.LOADING && !trade) {
       return { caption: <Caption.LoadingTrade gasUseEstimateUSD={gasUseEstimateUSD} /> }
     }
 

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -61,7 +61,7 @@ function CaptionRow() {
       default:
     }
 
-    if (state === TradeState.LOADING && trade == null) {
+    if (state === TradeState.LOADING && trade === undefined) {
       return { caption: <Caption.LoadingTrade gasUseEstimateUSD={gasUseEstimateUSD} /> }
     }
 

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -65,14 +65,17 @@ function CaptionRow() {
       return { caption: <Caption.LoadingTrade gasUseEstimateUSD={gasUseEstimateUSD} /> }
     }
 
-    if (inputCurrency && outputCurrency && isAmountPopulated) {
-      if (isWrap) {
-        return {
-          caption: <Caption.Wrap inputCurrency={inputCurrency} outputCurrency={outputCurrency} />,
-        }
+    const allInputsFilled = inputCurrency && outputCurrency && isAmountPopulated
+
+    if (isWrap && allInputsFilled) {
+      return {
+        caption: <Caption.Wrap inputCurrency={inputCurrency} outputCurrency={outputCurrency} />,
       }
-      if (trade?.inputAmount && trade.outputAmount) {
-        const caption = (
+    }
+
+    if (trade && allInputsFilled) {
+      return {
+        caption: (
           <Caption.Trade
             trade={trade}
             outputUSDC={outputUSDC}
@@ -80,12 +83,13 @@ function CaptionRow() {
             expanded={open}
             loading={state === TradeState.LOADING}
           />
-        )
-        return { caption, isExpandable: true }
+        ),
+        isExpandable: true,
       }
-      if (state === TradeState.INVALID) {
-        return { caption: <Caption.Error /> }
-      }
+    }
+
+    if (state === TradeState.INVALID) {
+      return { caption: <Caption.Error /> }
     }
 
     return { caption: <Caption.MissingInputs /> }

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -61,7 +61,7 @@ function CaptionRow() {
       default:
     }
 
-    if (state === TradeState.LOADING) {
+    if (state === TradeState.LOADING && trade == null) {
       return { caption: <Caption.LoadingTrade gasUseEstimateUSD={gasUseEstimateUSD} /> }
     }
 
@@ -78,6 +78,7 @@ function CaptionRow() {
             outputUSDC={outputUSDC}
             gasUseEstimateUSD={open ? null : gasUseEstimateUSD}
             expanded={open}
+            loading={state === TradeState.LOADING}
           />
         )
         return { caption, isExpandable: true }

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -65,31 +65,31 @@ function CaptionRow() {
       return { caption: <Caption.LoadingTrade gasUseEstimateUSD={gasUseEstimateUSD} /> }
     }
 
-    const allInputsFilled = inputCurrency && outputCurrency && isAmountPopulated
-
-    if (isWrap && allInputsFilled) {
-      return {
-        caption: <Caption.Wrap inputCurrency={inputCurrency} outputCurrency={outputCurrency} />,
+    if (inputCurrency && outputCurrency && isAmountPopulated) {
+      if (isWrap) {
+        return {
+          caption: <Caption.Wrap inputCurrency={inputCurrency} outputCurrency={outputCurrency} />,
+        }
       }
-    }
 
-    if (trade && allInputsFilled) {
-      return {
-        caption: (
-          <Caption.Trade
-            trade={trade}
-            outputUSDC={outputUSDC}
-            gasUseEstimateUSD={open ? null : gasUseEstimateUSD}
-            expanded={open}
-            loading={state === TradeState.LOADING}
-          />
-        ),
-        isExpandable: true,
+      if (trade) {
+        return {
+          caption: (
+            <Caption.Trade
+              trade={trade}
+              outputUSDC={outputUSDC}
+              gasUseEstimateUSD={open ? null : gasUseEstimateUSD}
+              expanded={open}
+              loading={state === TradeState.LOADING}
+            />
+          ),
+          isExpandable: true,
+        }
       }
-    }
 
-    if (state === TradeState.INVALID) {
-      return { caption: <Caption.Error /> }
+      if (state === TradeState.INVALID) {
+        return { caption: <Caption.Error /> }
+      }
     }
 
     return { caption: <Caption.MissingInputs /> }


### PR DESCRIPTION
adds a different loading state to the `Trade` caption in the toolbar. instead of replacing all the text with "Fetching Trade", we:
- add a loading spinner next to the exchange rate
- make the exchange rate 0.4 opacity