### PR TITLE
feat: widget page-centered dialogs

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -258,6 +258,9 @@ const FullScreenWrapper = styled.div<{ enabled?: boolean }>`
       width: 100%;
       z-index: ${Layer.DIALOG};
     `}
+  ${HiddenWrapper} {
+    box-shadow: 0px 40px 120px ${({ theme }) => theme.networkDefaultShadow};
+  }
 `
 
 // Accounts for any animation lag

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -68,7 +68,7 @@ export function Provider({ value, children, options }: ProviderProps) {
   const [active, setActive] = useState(false)
   // If pageCentered dialogs are enabled, we should mount them directly to the document body
   // and adjust the styling in the renderer below so that they are centered and sized correctly.
-  const context = { element: options?.pageCentered ? document.body : value, active, setActive, options }
+  const context = { element: value, active, setActive, options }
   useEffect(() => {
     if (ref.current) {
       ref.current.inert = active
@@ -152,7 +152,7 @@ export const Modal = styled.div<{ color: Color; constrain?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius.large}rem;
   display: flex;
   flex-direction: column;
-  height: ${({ constrain }) => (constrain ? '420px' : '100%')};
+  height: ${({ constrain }) => (constrain ? 'fit-content' : '100%')};
   left: 0;
   outline: ${({ theme }) => `1px solid ${theme.outline}`};
   padding: 0.5em;
@@ -192,13 +192,13 @@ const fadeOut = keyframes`
 
 const HiddenWrapper = styled.div<{ constrain?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius.medium}em;
-  height: ${({ constrain }) => (constrain ? '460px' : '100%')};
+  height: ${({ constrain }) => (constrain ? 'fit-content' : '100%')};
   left: 0;
 
   overflow: hidden;
   position: ${({ constrain }) => (constrain ? 'relative' : 'absolute')};
   top: 0;
-  width: ${({ constrain }) => (constrain ? '460px' : '100%')};
+  width: ${({ constrain }) => (constrain ? 'fit-content' : '100%')};
 
   @supports (overflow: clip) {
     overflow: clip;
@@ -238,8 +238,6 @@ const getAnimation = (animationType?: DialogAnimationType) => {
 }
 
 const AnimationWrapper = styled.div<{ animationType?: DialogAnimationType }>`
-  height: 100%;
-  width: 100%;
   ${Modal} {
     ${({ animationType }) => getAnimation(animationType)}
   }
@@ -269,9 +267,10 @@ interface DialogProps {
   color: Color
   children: ReactNode
   onClose?: () => void
+  forceContain?: boolean
 }
 
-export default function Dialog({ color, children, onClose }: DialogProps) {
+export default function Dialog({ color, children, onClose, forceContain }: DialogProps) {
   const context = useContext(Context)
   useEffect(() => {
     context.setActive(true)
@@ -287,6 +286,9 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
     }, TransitionDuration.Medium + PopoverAnimationUpdateDelay)
   }, [])
 
+  const pageCentered = context.options?.pageCentered && !forceContain
+  const mountPoint = pageCentered ? document.body : context.element
+
   const modal = useRef<HTMLDivElement>(null)
   useUnmountingAnimation(
     popoverRef,
@@ -298,13 +300,13 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
           return SlideAnimationType.CLOSING
         case DialogAnimationType.SLIDE:
         default:
-          if (context.options?.pageCentered) {
+          if (pageCentered) {
             return SlideAnimationType.CLOSING
           }
           // Returns the context element's child count at the time of unmounting.
           // This cannot be done through state because the count is updated outside of React's lifecycle -
           // it *must* be checked at the time of unmounting in order to include the next page of Dialog.
-          return (context.element?.childElementCount ?? 0) > 1 ? SlideAnimationType.PAGING : SlideAnimationType.CLOSING
+          return (mountPoint?.childElementCount ?? 0) > 1 ? SlideAnimationType.PAGING : SlideAnimationType.CLOSING
       }
     },
     modal
@@ -313,21 +315,21 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
   useOnEscapeHandler(onClose)
 
   return (
-    context.element &&
+    mountPoint &&
     createPortal(
       <ThemeProvider>
         <PopoverBoundaryProvider value={popoverRef.current} updateTrigger={updatePopover}>
           <div ref={popoverRef}>
-            <FullScreenWrapper enabled={context.options?.pageCentered} onClick={onClose}>
-              <HiddenWrapper constrain={context.options?.pageCentered}>
+            <FullScreenWrapper enabled={pageCentered} onClick={onClose}>
+              <HiddenWrapper constrain={pageCentered}>
                 <AnimationWrapper animationType={context.options?.animationType}>
                   <OnCloseContext.Provider value={onClose}>
                     <Modal
                       color={color}
                       ref={modal}
-                      constrain={context.options?.pageCentered}
+                      constrain={pageCentered}
                       onClick={(e) => {
-                        context.options?.pageCentered && e.stopPropagation()
+                        pageCentered && e.stopPropagation()
                       }}
                     >
                       {children}
@@ -339,7 +341,7 @@ export default function Dialog({ color, children, onClose }: DialogProps) {
           </div>
         </PopoverBoundaryProvider>
       </ThemeProvider>,
-      context.element
+      mountPoint
     )
   )
 }

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -190,18 +190,18 @@ const fadeOut = keyframes`
   }
 `
 
-const HiddenWrapper = styled.div<{ constrain?: boolean }>`
+const HiddenWrapper = styled.div<{ hidden?: boolean; constrain?: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius.medium}em;
   height: ${({ constrain }) => (constrain ? 'fit-content' : '100%')};
   left: 0;
 
-  overflow: hidden;
+  overflow: ${({ hidden }) => (hidden ? 'hidden' : 'visible')};
   position: ${({ constrain }) => (constrain ? 'relative' : 'absolute')};
   top: 0;
   width: ${({ constrain }) => (constrain ? 'fit-content' : '100%')};
 
   @supports (overflow: clip) {
-    overflow: clip;
+    overflow: ${({ hidden }) => (hidden ? 'clip' : 'visible')};
   }
 `
 
@@ -324,7 +324,10 @@ export default function Dialog({ color, children, onClose, forceContain }: Dialo
         <PopoverBoundaryProvider value={popoverRef.current} updateTrigger={updatePopover}>
           <div ref={popoverRef}>
             <FullScreenWrapper enabled={pageCentered} onClick={onClose}>
-              <HiddenWrapper constrain={pageCentered}>
+              <HiddenWrapper
+                constrain={pageCentered}
+                hidden={context.options?.animationType === DialogAnimationType.SLIDE}
+              >
                 <AnimationWrapper animationType={context.options?.animationType}>
                   <OnCloseContext.Provider value={onClose}>
                     <Modal

--- a/src/components/Error/ErrorBoundary.tsx
+++ b/src/components/Error/ErrorBoundary.tsx
@@ -57,7 +57,7 @@ export default class ErrorBoundary extends Component<PropsWithChildren<ErrorBoun
     const header = error instanceof WidgetError ? error.header : DEFAULT_ERROR_HEADER
     const action = error instanceof WidgetError ? error.action : DEFAULT_ERROR_ACTION
     return (
-      <Dialog color="dialog">
+      <Dialog color="dialog" forceContain>
         <ErrorDialog
           message={header}
           error={error}

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -283,13 +283,13 @@ export function SummaryDialog(props: SummaryDialogProps) {
           {t`price impact on the market price of this pool. Do you wish to continue? `}
         </SpeedBumpDialog>
       ) : (
-        <>
+        <div style={{ minHeight: 400, minWidth: 400 }}>
           <Header title={<Trans>Review swap</Trans>} />
           <Body flex align="stretch">
             <Details {...props} />
           </Body>
           <ConfirmButton {...props} triggerImpactSpeedbump={triggerImpactSpeedbump} />
-        </>
+        </div>
       )}
     </>
   )

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -219,7 +219,7 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
       onBlur={onBlur}
       onFocus={onFocus}
       onMouseMove={onMouseMove}
-      style={{ overflow: 'hidden' }}
+      style={{ overflow: 'hidden', minHeight: 400 }}
     >
       {/* OnHover is a workaround to Safari's incorrect (overflow: overlay) implementation */}
       <OnHover hover={hover} ref={onHover} />

--- a/src/cosmos/Swap.fixture.tsx
+++ b/src/cosmos/Swap.fixture.tsx
@@ -66,6 +66,7 @@ function Fixture() {
 
   const [brandedFooter] = useValue('brandedFooter', { defaultValue: true })
   const [hideConnectionUI] = useValue('hideConnectionUI', { defaultValue: false })
+  const [pageCentered] = useValue('pageCentered', { defaultValue: true })
 
   const [width] = useValue('width', { defaultValue: 360 })
 
@@ -89,7 +90,7 @@ function Fixture() {
   const [routerUrl] = useValue('routerUrl', { defaultValue: 'https://api.uniswap.org/v1/' })
 
   const dialogAnimation = useOption('dialogAnimation', {
-    defaultValue: DialogAnimationType.SLIDE,
+    defaultValue: DialogAnimationType.FADE,
     options: [DialogAnimationType.SLIDE, DialogAnimationType.FADE, DialogAnimationType.NONE],
   })
 
@@ -119,6 +120,7 @@ function Fixture() {
       brandedFooter={brandedFooter}
       dialogOptions={{
         animationType: dialogAnimation,
+        pageCentered,
       }}
       {...eventHandlers}
     />


### PR DESCRIPTION
adds an option to the Widget API which enables page-centered dialogs without any configuration. 

if they are enabled, we mount our dialogs at the page root and make them full screen. if Dialogs are page-centered, then their content needs to define their own size rather than assume the parent's size will be defined. (see my adjustments to the `SummaryDialog` and `TokenOptions` for examples).

note: i'm currently forcing errors to stay centered in the widget because it's a better UX imo.