### PR TITLE
fix: Handle no routes state in toolbar

### DIFF
--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -87,7 +87,7 @@ function CaptionRow() {
         }
       }
 
-      if (state === TradeState.INVALID) {
+      if (state === TradeState.INVALID || state === TradeState.NO_ROUTE_FOUND) {
         return { caption: <Caption.Error /> }
       }
     }


### PR DESCRIPTION
We are currently catching the no routes state as "missing input" instead of displaying a trade error