### PR TITLE
fix: settings icon alignment and bugs

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -95,7 +95,7 @@ export function BottomSheetModal({ children, onClose, open, title }: BottomSheet
       <RootElement ref={setRootElement} open={open} />
       <DialogProvider value={rootElement}>
         {open && (
-          <Dialog color="dialog" onClose={onClose}>
+          <Dialog color="dialog" onClose={onClose} forceContain>
             <>
               {title && <Header title={<Trans>{title}</Trans>} closeButton={<StyledXButton />} />}
               {children}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -331,7 +331,7 @@ export default function Dialog({ color, children, onClose, forceContain }: Dialo
       <ThemeProvider>
         <PopoverBoundaryProvider value={popoverRef.current} updateTrigger={updatePopover}>
           <div ref={popoverRef}>
-            <FullScreenWrapper enabled={pageCentered} onClick={onClose}>
+            <FullScreenWrapper enabled={pageCentered} onClick={() => (pageCentered ? onClose?.() : null)}>
               <HiddenWrapper
                 constrain={pageCentered}
                 hidden={context.options?.animationType === DialogAnimationType.SLIDE}

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -31,8 +31,10 @@ const PopoverContainer = styled.div<{ show: boolean }>`
 `
 
 const Reference = styled.div`
-  display: inline-block;
-  height: 1em;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-height: 1em;
 `
 
 const Arrow = styled.div`

--- a/src/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -57,7 +57,7 @@ const Option = forwardRef<HTMLButtonElement, OptionProps>(function Option(
 ) {
   return (
     <Wrapper selected={selected} onClick={onSelect} ref={ref} tabIndex={tabIndex} data-testid={testid}>
-      <Row gap={0.5} flex grow flow="nowrap" justify={justify}>
+      <Row gap={0.5} flex grow flow="nowrap" justify={justify} align="center">
         {children}
         {icon ? icon : <LargeIcon icon={Check} size={1.25} color={selected ? 'active' : 'hint'} />}
       </Row>
@@ -104,7 +104,12 @@ export default function MaxSlippageSelect() {
     },
     [onSlippageChange, setSlippageBase]
   )
-  const setAutoSlippage = useCallback(() => setSlippage({ ...slippage, auto: true }), [setSlippage, slippage])
+  const setAutoSlippage = useCallback(() => {
+    setSlippage({
+      auto: true,
+      max: undefined,
+    })
+  }, [setSlippage])
   const [maxSlippageInput, setMaxSlippageInput] = useState(slippage.max?.toString() || '')
 
   const option = useRef<HTMLButtonElement>(null)

--- a/src/components/Swap/Settings/RouterPreferenceToggle.tsx
+++ b/src/components/Swap/Settings/RouterPreferenceToggle.tsx
@@ -33,7 +33,7 @@ export default function RouterPreferenceToggle() {
 
   return (
     <ThemedText.Subhead2 color="secondary">
-      <Row>
+      <Row flex align="center">
         <Label
           name={<Trans>Auto Router API</Trans>}
           // TODO (tina): clicking on this tooltip on mobile shouldn't open/close expando

--- a/src/components/Swap/Settings/components.tsx
+++ b/src/components/Swap/Settings/components.tsx
@@ -40,7 +40,7 @@ interface LabelProps {
 
 export function Label({ name, tooltip }: LabelProps) {
   return (
-    <Row gap={0.5} justify="flex-start">
+    <Row gap={0.5} justify="flex-start" flex align="center">
       <ThemedText.Subhead2>{name}</ThemedText.Subhead2>
       {tooltip && (
         <Tooltip placement="top" contained icon={Info}>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -58,10 +58,10 @@ const SettingsButton = styled(IconButton)`
 export default function Settings() {
   const [open, setOpen] = useState(false)
   const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
-  useOutsideClickHandler(wrapper, () => setOpen(false))
+  const isMobile = useIsMobileWidth()
+  useOutsideClickHandler(isMobile ? null : wrapper, () => setOpen(false))
   useOnEscapeHandler(() => setOpen(false))
 
-  const isMobile = useIsMobileWidth()
   return (
     <div ref={setWrapper}>
       {isMobile ? (

--- a/src/components/Swap/Toolbar/__snapshots__/ToolbarOrderRouting.test.tsx.snap
+++ b/src/components/Swap/Toolbar/__snapshots__/ToolbarOrderRouting.test.tsx.snap
@@ -18,7 +18,7 @@ Object {
             Order routing
           </div>
           <div
-            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+            class="Popover__Reference-sc-1liex6z-1 dFwFDV"
           >
             <div
               class="Row-sc-1nzvhrh-0 ckykgM"
@@ -54,7 +54,7 @@ Object {
           Order routing
         </div>
         <div
-          class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+          class="Popover__Reference-sc-1liex6z-1 dFwFDV"
         >
           <div
             class="Row-sc-1nzvhrh-0 ckykgM"
@@ -147,7 +147,7 @@ Object {
             Order routing
           </div>
           <div
-            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+            class="Popover__Reference-sc-1liex6z-1 dFwFDV"
           >
             <div
               class="Row-sc-1nzvhrh-0 ckykgM"
@@ -183,7 +183,7 @@ Object {
           Order routing
         </div>
         <div
-          class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+          class="Popover__Reference-sc-1liex6z-1 dFwFDV"
         >
           <div
             class="Row-sc-1nzvhrh-0 ckykgM"
@@ -276,7 +276,7 @@ Object {
             Order routing
           </div>
           <div
-            class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+            class="Popover__Reference-sc-1liex6z-1 dFwFDV"
           >
             <div
               class="Row-sc-1nzvhrh-0 ckykgM"
@@ -312,7 +312,7 @@ Object {
           Order routing
         </div>
         <div
-          class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+          class="Popover__Reference-sc-1liex6z-1 dFwFDV"
         >
           <div
             class="Row-sc-1nzvhrh-0 ckykgM"

--- a/src/components/__snapshots__/Header.test.tsx.snap
+++ b/src/components/__snapshots__/Header.test.tsx.snap
@@ -29,7 +29,7 @@ Object {
           >
             <div>
               <div
-                class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+                class="Popover__Reference-sc-1liex6z-1 dFwFDV"
               >
                 <button
                   class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Settings__SettingsButton-sc-1hvqnx5-1 evHSmT"
@@ -87,7 +87,7 @@ Object {
                                 class="Row-sc-1nzvhrh-0 houru"
                               >
                                 <div
-                                  class="Row-sc-1nzvhrh-0 iKBbTz"
+                                  class="Row-sc-1nzvhrh-0 bAZdWs"
                                 >
                                   <div
                                     class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
@@ -95,7 +95,7 @@ Object {
                                     Max slippage
                                   </div>
                                   <div
-                                    class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+                                    class="Popover__Reference-sc-1liex6z-1 dFwFDV"
                                   >
                                     <button
                                       class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
@@ -242,7 +242,7 @@ Object {
                               class="Expando__TitleHeader-sc-yzkwmi-2 gSKTNM"
                             >
                               <div
-                                class="Row-sc-1nzvhrh-0 iKBbTz"
+                                class="Row-sc-1nzvhrh-0 bAZdWs"
                               >
                                 <div
                                   class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
@@ -250,7 +250,7 @@ Object {
                                   Transaction deadline
                                 </div>
                                 <div
-                                  class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+                                  class="Popover__Reference-sc-1liex6z-1 dFwFDV"
                                 >
                                   <button
                                     class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
@@ -409,7 +409,7 @@ Object {
         >
           <div>
             <div
-              class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+              class="Popover__Reference-sc-1liex6z-1 dFwFDV"
             >
               <button
                 class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Settings__SettingsButton-sc-1hvqnx5-1 evHSmT"
@@ -467,7 +467,7 @@ Object {
                               class="Row-sc-1nzvhrh-0 houru"
                             >
                               <div
-                                class="Row-sc-1nzvhrh-0 iKBbTz"
+                                class="Row-sc-1nzvhrh-0 bAZdWs"
                               >
                                 <div
                                   class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
@@ -475,7 +475,7 @@ Object {
                                   Max slippage
                                 </div>
                                 <div
-                                  class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+                                  class="Popover__Reference-sc-1liex6z-1 dFwFDV"
                                 >
                                   <button
                                     class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"
@@ -622,7 +622,7 @@ Object {
                             class="Expando__TitleHeader-sc-yzkwmi-2 gSKTNM"
                           >
                             <div
-                              class="Row-sc-1nzvhrh-0 iKBbTz"
+                              class="Row-sc-1nzvhrh-0 bAZdWs"
                             >
                               <div
                                 class="type__TextWrapper-sc-16386l-0 kDfZL subhead subhead-2 css-e17nie"
@@ -630,7 +630,7 @@ Object {
                                 Transaction deadline
                               </div>
                               <div
-                                class="Popover__Reference-sc-1liex6z-1 dxsTSY"
+                                class="Popover__Reference-sc-1liex6z-1 dFwFDV"
                               >
                                 <button
                                   class="Button__BaseButton-sc-1soikk5-0 Button__transparentButton-sc-1soikk5-2 Button__StyledIconButton-sc-1soikk5-3 gleKKe bbtvxg jwaziW Tooltip__IconTooltip-sc-tsxpgp-1 fPAwBP"


### PR DESCRIPTION
fixes the "auto-dismiss" bug (see `Dialog` change)  [link](https://www.notion.so/uniswaplabs/On-mobile-web-trying-to-edit-slippage-dismisses-the-bottom-sheet-modal-instead-33cd786e636d46f8a8d14a33ebe80421?pvs=4)

fixes icon aligments (see `Popover` change and changes in settings components) [link](https://www.notion.so/uniswaplabs/All-icons-in-settings-appear-a-little-misaligned-1b588c96be3245bea141f4974ef7554b?pvs=4)

fixes Auto slippage issue [link](https://www.notion.so/uniswaplabs/Setting-a-custom-slippage-number-then-switching-back-to-Auto-doesn-t-reset-the-slippage-number-in-3af1668dd3494ebf9eadbf8879817798?pvs=4)