### PR TITLE
fix: tooltip and modal updates

### DIFF
--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,6 +1,7 @@
 import { Options, Placement } from '@popperjs/core'
 import { globalFontStyles } from 'css/font'
 import useInterval from 'hooks/useInterval'
+import ms from 'ms.macro'
 import maxSize from 'popper-max-size-modifier'
 import React, { createContext, PropsWithChildren, useCallback, useContext, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -16,8 +17,7 @@ export function PopoverBoundaryProvider({
   value,
   children,
 }: PropsWithChildren<{ value: HTMLDivElement | null; updateTrigger?: any }>) {
-  const boundaryContextValue = useMemo(() => ({ boundary: value }), [value])
-  return <BoundaryContext.Provider value={boundaryContextValue}>{children}</BoundaryContext.Provider>
+  return <BoundaryContext.Provider value={{ boundary: value }}>{children}</BoundaryContext.Provider>
 }
 
 const PopoverContainer = styled.div<{ show: boolean }>`
@@ -155,7 +155,7 @@ export default function Popover({
     update && update()
   }, [update])
 
-  useInterval(updateCallback, show ? 100 : null)
+  useInterval(updateCallback, show ? ms`0.1s` : null)
 
   return (
     <>

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -9,15 +9,14 @@ import { usePopper } from 'react-popper'
 import styled from 'styled-components/macro'
 import { AnimationSpeed, Layer } from 'theme'
 
-type PopoverBoundary = { boundary?: HTMLDivElement | null }
-const BoundaryContext = createContext<PopoverBoundary>({})
+const BoundaryContext = createContext<HTMLDivElement | null>(null)
 
 /* Defines a boundary component past which a Popover should not overflow. */
 export function PopoverBoundaryProvider({
   value,
   children,
 }: PropsWithChildren<{ value: HTMLDivElement | null; updateTrigger?: any }>) {
-  return <BoundaryContext.Provider value={{ boundary: value }}>{children}</BoundaryContext.Provider>
+  return <BoundaryContext.Provider value={value}>{children}</BoundaryContext.Provider>
 }
 
 const PopoverContainer = styled.div<{ show: boolean }>`
@@ -108,7 +107,7 @@ export default function Popover({
   contained,
   showArrow = true,
 }: PopoverProps) {
-  const { boundary } = useContext(BoundaryContext)
+  const boundary = useContext(BoundaryContext)
   const reference = useRef<HTMLDivElement>(null)
 
   // Use callback refs to be notified when instantiated

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -3,10 +3,12 @@ import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import ActionButton, { Action, ActionButtonColor } from 'components/ActionButton'
 import Column from 'components/Column'
 import { Header } from 'components/Dialog'
+import { PopoverBoundaryProvider } from 'components/Popover'
 import { SmallToolTipBody, TooltipText } from 'components/Tooltip'
 import { Allowance, AllowanceState } from 'hooks/usePermit2Allowance'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { Slippage } from 'hooks/useSlippage'
+import { useWindowWidth } from 'hooks/useWindowWidth'
 import { AlertTriangle, Spinner } from 'icons'
 import { useAtomValue } from 'jotai/utils'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
@@ -255,6 +257,8 @@ interface SummaryDialogProps {
 export function SummaryDialog(props: SummaryDialogProps) {
   const [ackPriceImpact, setAckPriceImpact] = useState(false)
   const [showSpeedbump, setShowSpeedbump] = useState(props.impact?.warning === 'error')
+  const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
+  const width = useWindowWidth()
 
   const onAcknowledgeSpeedbump = useCallback(() => {
     setAckPriceImpact(true)
@@ -283,12 +287,14 @@ export function SummaryDialog(props: SummaryDialogProps) {
           {t`price impact on the market price of this pool. Do you wish to continue? `}
         </SpeedBumpDialog>
       ) : (
-        <div style={{ minWidth: 400 }}>
-          <Header title={<Trans>Review swap</Trans>} />
-          <Body flex align="stretch">
-            <Details {...props} />
-          </Body>
-          <ConfirmButton {...props} triggerImpactSpeedbump={triggerImpactSpeedbump} />
+        <div style={{ minWidth: Math.min(400, width) }} ref={setBoundary}>
+          <PopoverBoundaryProvider value={boundary}>
+            <Header title={<Trans>Review swap</Trans>} />
+            <Body flex align="stretch">
+              <Details {...props} />
+            </Body>
+            <ConfirmButton {...props} triggerImpactSpeedbump={triggerImpactSpeedbump} />
+          </PopoverBoundaryProvider>
         </div>
       )}
     </>

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -3,6 +3,7 @@ import { useWeb3React } from '@web3-react/core'
 import useCurrencyBalance from 'hooks/useCurrencyBalance'
 import useNativeEvent from 'hooks/useNativeEvent'
 import useScrollbar from 'hooks/useScrollbar'
+import { useWindowWidth } from 'hooks/useWindowWidth'
 import {
   ComponentClass,
   CSSProperties,
@@ -138,6 +139,7 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
   { tokens, onSelect }: TokenOptionsProps,
   ref
 ) {
+  const width = useWindowWidth()
   const [focused, setFocused] = useState(false)
 
   const [selected, setSelected] = useState<Currency>(tokens[0])
@@ -220,7 +222,11 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
       onBlur={onBlur}
       onFocus={onFocus}
       onMouseMove={onMouseMove}
-      style={{ overflow: 'hidden', minWidth: 400, minHeight: Math.min(tokens.length, MIN_VISIBLE_TOKENS) * ITEM_SIZE }}
+      style={{
+        overflow: 'hidden',
+        minWidth: Math.min(400, width),
+        minHeight: Math.min(tokens.length, MIN_VISIBLE_TOKENS) * ITEM_SIZE,
+      }}
     >
       {/* OnHover is a workaround to Safari's incorrect (overflow: overlay) implementation */}
       <OnHover hover={hover} ref={onHover} />

--- a/src/components/__snapshots__/Header.test.tsx.snap
+++ b/src/components/__snapshots__/Header.test.tsx.snap
@@ -59,7 +59,7 @@ Object {
                 </button>
               </div>
               <div
-                class="Popover__PopoverContainer-sc-1liex6z-0 DPpIY"
+                class="Popover__PopoverContainer-sc-1liex6z-0 bSKTJc"
                 style="position: absolute; left: 0px; top: 0px;"
               >
                 <div
@@ -349,7 +349,7 @@ Object {
                     </div>
                   </div>
                   <div
-                    class="Popover__PopoverContainer-sc-1liex6z-0 DPpIY"
+                    class="Popover__PopoverContainer-sc-1liex6z-0 bSKTJc"
                     style="position: absolute; left: 0px; top: 0px;"
                   >
                     <div
@@ -363,7 +363,7 @@ Object {
                     />
                   </div>
                   <div
-                    class="Popover__PopoverContainer-sc-1liex6z-0 DPpIY"
+                    class="Popover__PopoverContainer-sc-1liex6z-0 bSKTJc"
                     style="position: absolute; left: 0px; top: 0px;"
                   >
                     <div
@@ -439,7 +439,7 @@ Object {
               </button>
             </div>
             <div
-              class="Popover__PopoverContainer-sc-1liex6z-0 DPpIY"
+              class="Popover__PopoverContainer-sc-1liex6z-0 bSKTJc"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <div
@@ -729,7 +729,7 @@ Object {
                   </div>
                 </div>
                 <div
-                  class="Popover__PopoverContainer-sc-1liex6z-0 DPpIY"
+                  class="Popover__PopoverContainer-sc-1liex6z-0 bSKTJc"
                   style="position: absolute; left: 0px; top: 0px;"
                 >
                   <div
@@ -743,7 +743,7 @@ Object {
                   />
                 </div>
                 <div
-                  class="Popover__PopoverContainer-sc-1liex6z-0 DPpIY"
+                  class="Popover__PopoverContainer-sc-1liex6z-0 bSKTJc"
                   style="position: absolute; left: 0px; top: 0px;"
                 >
                   <div

--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function useWindowWidth() {
+  const [width, setWidth] = useState(window.innerWidth)
+
+  useEffect(() => {
+    const resizeListener = () => setWidth(window.innerWidth)
+    window.addEventListener('resize', resizeListener)
+
+    return () => window.removeEventListener('resize', resizeListener)
+  }, [])
+
+  return width
+}


### PR DESCRIPTION
- remove the manual trigger from `Popover`, instead automatically update like we do in `interface` ([link](https://github.com/Uniswap/interface/blob/main/src/components/Popover/index.tsx#L117))

- change the min width of dialogs to not overflow small width screens