### PR TITLE
fix: use larger RoutingDiagram in Toolbar

### DIFF
--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -172,7 +172,7 @@ function CaptionRow() {
     >
       <Column>
         <ToolbarTradeSummary rows={tradeSummaryRows} />
-        <ToolbarOrderRouting trade={trade} />
+        <ToolbarOrderRouting trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} />
       </Column>
     </StyledExpando>
   )


### PR DESCRIPTION
[feedback link](https://www.notion.so/uniswaplabs/Auto-router-tooltip-looks-off-small-relative-to-rest-of-the-font-and-UI-dfc67677064d4e2c9fddc9babca07083?pvs=4)

passes the Gas Estimate to the Routing Tooltip in this case too, because apparently they should match