### PR TITLE
fix: review dialog responsiveness

### DIFF
--- a/src/components/Swap/Summary/Details.tsx
+++ b/src/components/Swap/Summary/Details.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro'
 import { formatCurrencyAmount, NumberType } from '@uniswap/conedison/format'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import Column from 'components/Column'
+import { useIsDialogPageCentered } from 'components/Dialog'
 import Row from 'components/Row'
 import Rule from 'components/Rule'
 import TokenImg from 'components/TokenImg'
@@ -9,6 +10,7 @@ import Tooltip, { SmallToolTipBody } from 'components/Tooltip'
 import { PriceImpact } from 'hooks/usePriceImpact'
 import { Slippage } from 'hooks/useSlippage'
 import { useWidgetWidth } from 'hooks/useWidgetWidth'
+import { useWindowWidth } from 'hooks/useWindowWidth'
 import { useAtomValue } from 'jotai/utils'
 import { ReactNode, useMemo } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
@@ -67,7 +69,11 @@ interface AmountProps {
 }
 
 function Amount({ tooltipText, label, amount, usdcAmount }: AmountProps) {
-  const width = useWidgetWidth()
+  const widgetWidth = useWidgetWidth()
+  const screenWidth = useWindowWidth()
+  const isDialogPageCenterd = useIsDialogPageCentered()
+  const width = isDialogPageCenterd ? screenWidth : widgetWidth
+
   const [amountFontSize, amountLineHeight] =
     width < WIDGET_BREAKPOINTS.MEDIUM
       ? width < WIDGET_BREAKPOINTS.EXTRA_SMALL
@@ -84,7 +90,7 @@ function Amount({ tooltipText, label, amount, usdcAmount }: AmountProps) {
   }
 
   return (
-    <Row flex align="flex-start">
+    <Row flex align="flex-start" gap={0.5}>
       <Row>
         <ThemedText.Body2 userSelect>
           <Label>{label}</Label>

--- a/src/hooks/useWindowWidth.ts
+++ b/src/hooks/useWindowWidth.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function useWindowWidth() {
+  const [width, setWidth] = useState(window.innerWidth)
+
+  useEffect(() => {
+    const resizeListener = () => setWidth(window.innerWidth)
+    window.addEventListener('resize', resizeListener)
+
+    return () => window.removeEventListener('resize', resizeListener)
+  }, [])
+
+  return width
+}


### PR DESCRIPTION
<img width="663" alt="Screenshot 2023-02-22 at 5 20 27 PM" src="https://user-images.githubusercontent.com/66155195/220801042-31c38ac6-e17c-4e36-b7e7-3af3aef09671.png">


we should use the window width, not the widget width, to determine the responsiveness of this component if it's in a page-centered dialog