### PR TITLE
feat: add close button to error dialog

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,4 +1,5 @@
 import { Trans } from '@lingui/macro'
+import { iconHoverCss } from 'css/hover'
 import { X } from 'icons'
 import { forwardRef, PropsWithChildren, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -75,10 +76,7 @@ const Wrapper = styled.div<{ open: boolean }>`
 `
 
 const StyledXButton = styled(X)`
-  :hover {
-    cursor: pointer;
-    opacity: 0.6;
-  }
+  ${iconHoverCss}
 `
 
 type BottomSheetModalProps = PropsWithChildren<{

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -1,6 +1,5 @@
 import { Trans } from '@lingui/macro'
-import { iconHoverCss } from 'css/hover'
-import { X } from 'icons'
+import { StyledXButton } from 'icons'
 import { forwardRef, PropsWithChildren, useState } from 'react'
 import { createPortal } from 'react-dom'
 import styled, { keyframes } from 'styled-components/macro'
@@ -73,10 +72,6 @@ const Wrapper = styled.div<{ open: boolean }>`
       box-sizing: border-box;
     }
   }
-`
-
-const StyledXButton = styled(X)`
-  ${iconHoverCss}
 `
 
 type BottomSheetModalProps = PropsWithChildren<{

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -2,7 +2,7 @@ import 'wicg-inert'
 
 import { globalFontStyles } from 'css/font'
 import { useOnEscapeHandler } from 'hooks/useOnEscapeHandler'
-import { largeIconCss, X } from 'icons'
+import { largeIconCss, StyledXButton } from 'icons'
 import { ArrowLeft } from 'icons'
 import ms from 'ms.macro'
 import { createContext, ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react'
@@ -108,13 +108,6 @@ const HeaderRow = styled(Row)`
 `
 
 const StyledBackButton = styled(ArrowLeft)`
-  :hover {
-    cursor: pointer;
-    opacity: 0.6;
-  }
-`
-
-const StyledXButton = styled(X)`
   :hover {
     cursor: pointer;
     opacity: 0.6;

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -2,7 +2,9 @@ import { Trans } from '@lingui/macro'
 import ActionButton from 'components/ActionButton'
 import Column from 'components/Column'
 import Expando from 'components/Expando'
-import { AlertTriangle, Icon, LargeIcon } from 'icons'
+import Row from 'components/Row'
+import { iconHoverCss } from 'css/hover'
+import { AlertTriangle, Icon, LargeIcon, X } from 'icons'
 import { Info as InfoIcon } from 'icons'
 import { ReactNode, useCallback, useState } from 'react'
 import styled from 'styled-components/macro'
@@ -51,6 +53,10 @@ const ExpandoContent = styled(ThemedText.Code)`
   margin: 0.5em 0;
 `
 
+const StyledXButton = styled(X)`
+  ${iconHoverCss}
+`
+
 interface ErrorDialogProps {
   header?: ReactNode
   message: ReactNode
@@ -65,6 +71,9 @@ export default function ErrorDialog({ header, message, error, action, onClick }:
 
   return (
     <Column flex padded gap={0.75} align="stretch" style={{ height: '100%' }}>
+      <Row flex flow="row-reverse">
+        <LargeIcon icon={StyledXButton} onClick={onClick} />
+      </Row>
       <StatusHeader icon={AlertTriangle} iconColor="critical" iconSize={open ? 3 : 4}>
         <ErrorHeader gap={open ? 0 : 0.75} open={open}>
           <ThemedText.Subhead1>{header || <Trans>Something went wrong.</Trans>}</ThemedText.Subhead1>

--- a/src/components/Error/ErrorDialog.tsx
+++ b/src/components/Error/ErrorDialog.tsx
@@ -3,8 +3,7 @@ import ActionButton from 'components/ActionButton'
 import Column from 'components/Column'
 import Expando from 'components/Expando'
 import Row from 'components/Row'
-import { iconHoverCss } from 'css/hover'
-import { AlertTriangle, Icon, LargeIcon, X } from 'icons'
+import { AlertTriangle, Icon, LargeIcon, StyledXButton } from 'icons'
 import { Info as InfoIcon } from 'icons'
 import { ReactNode, useCallback, useState } from 'react'
 import styled from 'styled-components/macro'
@@ -51,10 +50,6 @@ const ErrorHeader = styled(Column)<{ open: boolean }>`
 
 const ExpandoContent = styled(ThemedText.Code)`
   margin: 0.5em 0;
-`
-
-const StyledXButton = styled(X)`
-  ${iconHoverCss}
 `
 
 interface ErrorDialogProps {

--- a/src/css/hover.ts
+++ b/src/css/hover.ts
@@ -1,0 +1,8 @@
+import { css } from 'styled-components/macro'
+
+export const iconHoverCss = css`
+  :hover {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+`

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as ReverseIcon } from 'assets/svg/reverse.svg'
 import { ReactComponent as SpinnerIcon } from 'assets/svg/spinner.svg'
 import { ReactComponent as WalletIcon } from 'assets/svg/wallet.svg'
 import { ReactComponent as WalletDisconnectIcon } from 'assets/svg/wallet_disconnect.svg'
+import { iconHoverCss } from 'css/hover'
 import { FunctionComponent, SVGProps } from 'react'
 // This file wraps react-feather, so its import is intentional.
 /* eslint-disable no-restricted-imports */
@@ -168,4 +169,8 @@ export const LargeArrow = styled(icon(LargeArrowIcon))<{ color?: Color }>`
 export const Gas = styled(icon(GasIcon))<{ color?: Color }>`
   fill: ${({ color = 'active', theme }) => theme[color]};
   stroke: ${({ color = 'active', theme }) => theme[color]};
+`
+
+export const StyledXButton = styled(X)`
+  ${iconHoverCss}
 `


### PR DESCRIPTION
see design here: https://www.figma.com/file/kNSDBMpOzxSTOP6MerohLm/Web-Design-Spec?node-id=12156%3A118039&t=b0V5aEN9cKtpFUZH-0


adds an "x" icon to close the error dialog