### PR TITLE
fix: don't propogate tooltip clicks to their parents

### DIFF
--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -112,7 +112,7 @@ export default function Popover({
   const reference = useRef<HTMLDivElement>(null)
 
   // Use callback refs to be notified when instantiated
-  const [popover, setPopover] = useState<HTMLDivElement | null>(null)
+  const popover = useRef<HTMLDivElement | null>(null)
   const [arrow, setArrow] = useState<HTMLDivElement | null>(null)
 
   const options = useMemo((): Options => {
@@ -149,7 +149,7 @@ export default function Popover({
     }
   }, [offset, arrow, contained, placement, boundary])
 
-  const { styles, attributes, update } = usePopper(reference.current, popover, options)
+  const { styles, attributes, update } = usePopper(reference.current, popover?.current, options)
 
   // Manually triggers an update, if prop is provided
   useEffect(() => {
@@ -161,7 +161,13 @@ export default function Popover({
       <Reference ref={reference}>{children}</Reference>
       {boundary &&
         createPortal(
-          <PopoverContainer show={show} ref={setPopover} style={styles.popper} {...attributes.popper}>
+          <PopoverContainer
+            show={show}
+            ref={popover}
+            style={styles.popper}
+            {...attributes.popper}
+            onClick={(e) => e.stopPropagation()}
+          >
             {content}
             {showArrow && (
               <Arrow

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -1,6 +1,15 @@
 import { Options, Placement } from '@popperjs/core'
 import maxSize from 'popper-max-size-modifier'
-import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { usePopper } from 'react-popper'
 import styled from 'styled-components/macro'
@@ -156,6 +165,10 @@ export default function Popover({
     update?.()
   }, [update, updateTrigger])
 
+  const containerOnClick = useCallback((e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.stopPropagation()
+  }, [])
+
   return (
     <>
       <Reference ref={reference}>{children}</Reference>
@@ -166,7 +179,7 @@ export default function Popover({
             ref={popover}
             style={styles.popper}
             {...attributes.popper}
-            onClick={(e) => e.stopPropagation()}
+            onClick={containerOnClick}
           >
             {content}
             {showArrow && (

--- a/src/components/Swap/Settings/MaxSlippageSelect.tsx
+++ b/src/components/Swap/Settings/MaxSlippageSelect.tsx
@@ -153,7 +153,6 @@ export default function MaxSlippageSelect() {
           <Row grow>
             <Label
               name={<Trans>Max slippage</Trans>}
-              // TODO (tina): clicking on this tooltip on mobile shouldn't open/close expando
               tooltip={
                 <Trans>
                   Your transaction will revert if the price changes unfavorably by more than this percentage.

--- a/src/components/Swap/Settings/RouterPreferenceToggle.tsx
+++ b/src/components/Swap/Settings/RouterPreferenceToggle.tsx
@@ -36,7 +36,6 @@ export default function RouterPreferenceToggle() {
       <Row flex align="center">
         <Label
           name={<Trans>Auto Router API</Trans>}
-          // TODO (tina): clicking on this tooltip on mobile shouldn't open/close expando
           tooltip={<Trans>Use the Uniswap Labs API to get faster quotes.</Trans>}
         />
         <Toggle onToggle={onToggle} checked={routerPreference === RouterPreference.API} />

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -53,7 +53,6 @@ export default function TransactionTtlInput() {
         title={
           <Label
             name={<Trans>Transaction deadline</Trans>}
-            // TODO (tina): clicking on this tooltip on mobile shouldn't open/close expando
             tooltip={
               <Trans>Your transaction will revert if it has been pending for longer than this period of time.</Trans>
             }


### PR DESCRIPTION
There are some more issues w/ this tooltip/popper setup that I'd like to fix eventually, but this change makes the tooltip usable with our `Expando` component at least