### PR TITLE
fix: default token images

### DIFF
--- a/src/components/Logo/index.tsx
+++ b/src/components/Logo/index.tsx
@@ -8,7 +8,7 @@ export * from './hooks'
 export * from './util'
 
 const MissingImageLogo = styled.div<{ size?: string }>`
-  --size: ${({ size }) => size};
+  --size: ${({ size }) => size ?? '24px'};
   background-color: ${({ theme }) => theme.interactive};
   border-radius: 100px;
   color: ${({ theme }) => theme.primary};

--- a/src/components/TokenImg.tsx
+++ b/src/components/TokenImg.tsx
@@ -10,8 +10,8 @@ interface BaseProps {
 
 type TokenImgProps = BaseProps & Omit<React.ImgHTMLAttributes<HTMLImageElement>, keyof BaseProps>
 
-function TokenImg({ token, size }: TokenImgProps) {
-  return <Logo currency={token} size={(size ?? 1) + 'em'} />
+function TokenImg({ token, size = 1.5 }: TokenImgProps) {
+  return <Logo currency={token} size={size + 'rem'} symbol={token.symbol} />
 }
 
 export default styled(TokenImg)<{ size?: number }>`

--- a/src/components/TokenSelect/TokenButton.tsx
+++ b/src/components/TokenSelect/TokenButton.tsx
@@ -54,7 +54,7 @@ export default function TokenButton({ value, approved, disabled, onClick }: Toke
       <TokenButtonRow empty={!value} flex gap={0.4}>
         {value ? (
           <>
-            <Logo currency={value} size="1.5em" />
+            <Logo currency={value} symbol={value.symbol} />
             <ThemedText.ButtonLarge color={'currentColor'}>
               <span>{value.symbol}</span>
             </ThemedText.ButtonLarge>


### PR DESCRIPTION
<img width="731" alt="image" src="https://user-images.githubusercontent.com/66155195/221734084-7034a18c-efcb-4129-b757-8cf5fd391c6e.png">

fixes the default token image - we need the token symbol to show the first 3 letters. also, the dot was too small because we were using `em` instead of `rem`