### PR TITLE
fix: use correct width for non-page-centered dialogs

### DIFF
--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro'
 import { Currency, CurrencyAmount, Token } from '@uniswap/sdk-core'
 import ActionButton, { Action, ActionButtonColor } from 'components/ActionButton'
 import Column from 'components/Column'
-import { Header, useCloseDialog } from 'components/Dialog'
+import { Header, useCloseDialog, useIsDialogPageCentered } from 'components/Dialog'
 import { PopoverBoundaryProvider } from 'components/Popover'
 import { SmallToolTipBody, TooltipText } from 'components/Tooltip'
 import { UserRejectedRequestError } from 'errors'
@@ -265,6 +265,7 @@ export function SummaryDialog(props: SummaryDialogProps) {
   const [showSpeedbump, setShowSpeedbump] = useState(props.impact?.warning === 'error')
   const [boundary, setBoundary] = useState<HTMLDivElement | null>(null)
   const width = useWindowWidth()
+  const isPageCentered = useIsDialogPageCentered()
 
   const onAcknowledgeSpeedbump = useCallback(() => {
     setAckPriceImpact(true)
@@ -293,7 +294,7 @@ export function SummaryDialog(props: SummaryDialogProps) {
           {t`price impact on the market price of this pool. Do you wish to continue? `}
         </SpeedBumpDialog>
       ) : (
-        <div style={{ minWidth: Math.min(400, width) }} ref={setBoundary}>
+        <Column style={{ minWidth: isPageCentered ? Math.min(400, width) : 'auto', height: '100%' }} ref={setBoundary}>
           <PopoverBoundaryProvider value={boundary}>
             <Header title={<Trans>Review swap</Trans>} />
             <Body flex align="stretch">
@@ -301,7 +302,7 @@ export function SummaryDialog(props: SummaryDialogProps) {
             </Body>
             <ConfirmButton {...props} triggerImpactSpeedbump={triggerImpactSpeedbump} />
           </PopoverBoundaryProvider>
-        </div>
+        </Column>
       )}
     </>
   )

--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -1,5 +1,6 @@
 import { Currency } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
+import { useIsDialogPageCentered } from 'components/Dialog'
 import useCurrencyBalance from 'hooks/useCurrencyBalance'
 import useNativeEvent from 'hooks/useNativeEvent'
 import useScrollbar from 'hooks/useScrollbar'
@@ -140,6 +141,7 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
   ref
 ) {
   const width = useWindowWidth()
+  const isPageCentered = useIsDialogPageCentered()
   const [focused, setFocused] = useState(false)
 
   const [selected, setSelected] = useState<Currency>(tokens[0])
@@ -224,8 +226,8 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
       onMouseMove={onMouseMove}
       style={{
         overflow: 'hidden',
-        minWidth: Math.min(400, width),
-        minHeight: Math.min(tokens.length, MIN_VISIBLE_TOKENS) * ITEM_SIZE,
+        minWidth: isPageCentered ? Math.min(400, width) : 'auto',
+        minHeight: isPageCentered ? Math.min(tokens.length, MIN_VISIBLE_TOKENS) * ITEM_SIZE : '100%',
       }}
     >
       {/* OnHover is a workaround to Safari's incorrect (overflow: overlay) implementation */}


### PR DESCRIPTION
we need to avoid setting a min-width for dialog content if it's to be contained within the widget. instead, it should just automatically fill the widget container