### PR TITLE
fix: stop blocking swap on balance fetching

### DIFF
--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -28,8 +28,8 @@ export default function SwapActionButton() {
       (!permit2Enabled && approval.state !== SwapApprovalState.APPROVED) ||
       error !== undefined ||
       (!isWrap && !trade) ||
-      !(inputCurrencyAmount && inputCurrencyBalance) ||
-      inputCurrencyBalance.lessThan(inputCurrencyAmount),
+      !inputCurrencyAmount ||
+      (Boolean(inputCurrencyBalance) && Boolean(inputCurrencyBalance?.lessThan(inputCurrencyAmount))),
     [permit2Enabled, approval.state, error, isWrap, trade, inputCurrencyAmount, inputCurrencyBalance]
   )
 

--- a/src/components/Swap/SwapActionButton/index.tsx
+++ b/src/components/Swap/SwapActionButton/index.tsx
@@ -29,7 +29,8 @@ export default function SwapActionButton() {
       error !== undefined ||
       (!isWrap && !trade) ||
       !inputCurrencyAmount ||
-      (Boolean(inputCurrencyBalance) && Boolean(inputCurrencyBalance?.lessThan(inputCurrencyAmount))),
+      // If there is no balance loaded, we should default to isDisabled=false
+      Boolean(inputCurrencyBalance?.lessThan(inputCurrencyAmount)),
     [permit2Enabled, approval.state, error, isWrap, trade, inputCurrencyAmount, inputCurrencyBalance]
   )
 

--- a/src/hooks/useCurrencyBalance.ts
+++ b/src/hooks/useCurrencyBalance.ts
@@ -118,7 +118,6 @@ export function useCurrencyBalances(
   const tokenBalances = useTokenBalances(account, tokens)
   const containsETH: boolean = useMemo(() => currencies?.some((currency) => currency?.isNative) ?? false, [currencies])
   const ethBalance = useNativeCurrencyBalances(useMemo(() => (containsETH ? [account] : []), [containsETH, account]))
-
   return useMemo(
     () =>
       currencies?.map((currency) => {


### PR DESCRIPTION
https://uniswaplabs.atlassian.net/browse/WEB-2766?atlOrigin=eyJpIjoiNTA4OGVmZWI5ZTJhNDMyMThhMjkwOGRkZjc0NjBhMmUiLCJwIjoiaiJ9

we want to stop blocking swap if the balances aren't loaded to match the current behavior in interface.

if the balance IS loaded, we should still disable the button if the user doesn't have enough funds