### PR TITLE
fix: contained tokenlist height

### DIFF
--- a/src/components/TokenSelect/TokenOptions.tsx
+++ b/src/components/TokenSelect/TokenOptions.tsx
@@ -1,10 +1,8 @@
 import { Currency } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { useIsDialogPageCentered } from 'components/Dialog'
 import useCurrencyBalance from 'hooks/useCurrencyBalance'
 import useNativeEvent from 'hooks/useNativeEvent'
 import useScrollbar from 'hooks/useScrollbar'
-import { useWindowWidth } from 'hooks/useWindowWidth'
 import {
   ComponentClass,
   CSSProperties,
@@ -140,8 +138,6 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
   { tokens, onSelect }: TokenOptionsProps,
   ref
 ) {
-  const width = useWindowWidth()
-  const isPageCentered = useIsDialogPageCentered()
   const [focused, setFocused] = useState(false)
 
   const [selected, setSelected] = useState<Currency>(tokens[0])
@@ -225,9 +221,8 @@ const TokenOptions = forwardRef<TokenOptionsHandle, TokenOptionsProps>(function 
       onFocus={onFocus}
       onMouseMove={onMouseMove}
       style={{
+        minHeight: Math.min(tokens.length, MIN_VISIBLE_TOKENS) * ITEM_SIZE,
         overflow: 'hidden',
-        minWidth: isPageCentered ? Math.min(400, width) : 'auto',
-        minHeight: isPageCentered ? Math.min(tokens.length, MIN_VISIBLE_TOKENS) * ITEM_SIZE : '100%',
       }}
     >
       {/* OnHover is a workaround to Safari's incorrect (overflow: overlay) implementation */}

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -8,6 +8,7 @@ import { useCurrencyBalances } from 'hooks/useCurrencyBalance'
 import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import useTokenList, { useIsTokenListLoaded, useQueryTokens } from 'hooks/useTokenList'
+import { useWindowWidth } from 'hooks/useWindowWidth'
 import { Search } from 'icons'
 import { useAtomValue } from 'jotai/utils'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -66,6 +67,9 @@ export function TokenSelectDialogContent({ value, onSelect, onClose }: TokenSele
   const list = useTokenList()
   const tokens = useQueryTokens(query, list)
 
+  const width = useWindowWidth()
+  const isPageCentered = useIsDialogPageCentered()
+
   const isTokenListLoaded = useIsTokenListLoaded()
   const areBalancesLoaded = useAreBalancesLoaded()
   const [isLoaded, setIsLoaded] = useState(isTokenListLoaded && areBalancesLoaded)
@@ -98,7 +102,12 @@ export function TokenSelectDialogContent({ value, onSelect, onClose }: TokenSele
     )
   }
   return (
-    <TokenSelectContainer>
+    <TokenSelectContainer
+      style={{
+        minWidth: isPageCentered ? Math.min(400, width) : 'auto',
+        minHeight: isPageCentered ? 'unset' : '100%',
+      }}
+    >
       <Header title={<Trans>Select a token</Trans>} />
       <Column gap={0.75}>
         <Column gap={0.75} style={{ margin: '0 0.5em' }}>

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -8,7 +8,6 @@ import { useCurrencyBalances } from 'hooks/useCurrencyBalance'
 import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import useTokenList, { useIsTokenListLoaded, useQueryTokens } from 'hooks/useTokenList'
-import { useWindowWidth } from 'hooks/useWindowWidth'
 import { Search } from 'icons'
 import { useAtomValue } from 'jotai/utils'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -30,8 +29,10 @@ const SearchInputContainer = styled(Row)`
   ${inputCss}
 `
 
-const TokenSelectContainer = styled.div`
+const TokenSelectContainer = styled.div<{ $pageCentered: boolean }>`
   border-radius: ${({ theme }) => theme.borderRadius.medium}em;
+  min-height: ${($pageCentered) => ($pageCentered ? 'unset' : '100%')};
+  min-width: ${({ $pageCentered }) => ($pageCentered ? "min(400px, '100vw')" : 'auto')};
   overflow: hidden;
   padding: 0.5em 0 0;
   @supports (overflow: clip) {
@@ -67,7 +68,6 @@ export function TokenSelectDialogContent({ value, onSelect, onClose }: TokenSele
   const list = useTokenList()
   const tokens = useQueryTokens(query, list)
 
-  const width = useWindowWidth()
   const isPageCentered = useIsDialogPageCentered()
 
   const isTokenListLoaded = useIsTokenListLoaded()
@@ -102,12 +102,7 @@ export function TokenSelectDialogContent({ value, onSelect, onClose }: TokenSele
     )
   }
   return (
-    <TokenSelectContainer
-      style={{
-        minWidth: isPageCentered ? Math.min(400, width) : 'auto',
-        minHeight: isPageCentered ? 'unset' : '100%',
-      }}
-    >
+    <TokenSelectContainer $pageCentered={isPageCentered ?? false}>
       <Header title={<Trans>Select a token</Trans>} />
       <Column gap={0.75}>
         <Column gap={0.75} style={{ margin: '0 0.5em' }}>


### PR DESCRIPTION
fixes a bug where the token list was being cut off in the non-page-centered version of the widget.

