### PR TITLE
fix: deep link by swapping sooner after user interaction

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
     // Jest does not always resolve src/test (probably because of babel's TypeScript transpilation):
     '^test/*': '<rootDir>/src/test',
     '@uniswap/conedison/format': '@uniswap/conedison/dist/format.js',
-    '@uniswap/conedison/provider': '@uniswap/conedison/dist/provider.js',
+    '@uniswap/conedison/provider': '@uniswap/conedison/dist/provider/index.js',
   },
   setupFiles: ['<rootDir>/test/setup.ts'],
   setupFilesAfterEnv: ['<rootDir>/test/setup-jest.ts'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
 
     // Jest does not always resolve src/test (probably because of babel's TypeScript transpilation):
     '^test/*': '<rootDir>/src/test',
+
     '@uniswap/conedison/format': '@uniswap/conedison/dist/format.js',
     '@uniswap/conedison/provider': '@uniswap/conedison/dist/provider/index.js',
   },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@fontsource/inter": "^4.5.1",
     "@popperjs/core": "^2.4.4",
     "@reduxjs/toolkit": "^1.6.1",
-    "@uniswap/conedison": "^1.5.0",
+    "@uniswap/conedison": "^1.5.1",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/redux-multicall": "^1.1.8",
     "@uniswap/router-sdk": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@fontsource/inter": "^4.5.1",
     "@popperjs/core": "^2.4.4",
     "@reduxjs/toolkit": "^1.6.1",
-    "@uniswap/conedison": "^1.3.0",
+    "@uniswap/conedison": "^1.5.0",
     "@uniswap/permit2-sdk": "^1.2.0",
     "@uniswap/redux-multicall": "^1.1.8",
     "@uniswap/router-sdk": "^1.3.0",

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -40,3 +40,6 @@ export const BETTER_TRADE_LESS_HOPS_THRESHOLD = new Percent(JSBI.BigInt(50), BIP
 export const ZERO_PERCENT = new Percent('0')
 export const TWO_PERCENT = new Percent(JSBI.BigInt(200), BIPS_BASE)
 export const ONE_HUNDRED_PERCENT = new Percent('1')
+
+// gas margin to ensure successful transactions
+export const TX_GAS_MARGIN = 0.2

--- a/src/hooks/usePermitAllowance.ts
+++ b/src/hooks/usePermitAllowance.ts
@@ -1,4 +1,4 @@
-import { signTypedData } from '@uniswap/conedison/provider'
+import { signTypedData } from '@uniswap/conedison/provider/signing'
 import { AllowanceTransfer, MaxAllowanceTransferAmount, PERMIT2_ADDRESS, PermitSingle } from '@uniswap/permit2-sdk'
 import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -7,6 +7,7 @@ import { SwapRouter, UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-
 import { FeeOptions, toHex } from '@uniswap/v3-sdk'
 import { useWeb3React } from '@web3-react/core'
 import { ErrorCode } from 'constants/eip1193'
+import { TX_GAS_MARGIN } from 'constants/misc'
 import { SwapError } from 'errors'
 import { useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
@@ -68,7 +69,7 @@ export function useUniversalRouterSwapCallback(trade: InterfaceTrade | undefined
         ...(value && !isZero(value) ? { value: toHex(value) } : {}),
       }
 
-      response = await sendTransaction(provider, tx, 0.2)
+      response = await sendTransaction(provider, tx, TX_GAS_MARGIN)
     } catch (swapError) {
       if (didUserReject(swapError)) {
         return null

--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber'
 import { TransactionRequest, TransactionResponse } from '@ethersproject/providers'
 import { t } from '@lingui/macro'
+import { sendTransaction } from '@uniswap/conedison/provider/index'
 import { Percent } from '@uniswap/sdk-core'
 import { SwapRouter, UNIVERSAL_ROUTER_ADDRESS } from '@uniswap/universal-router-sdk'
 import { FeeOptions, toHex } from '@uniswap/v3-sdk'
@@ -9,7 +10,6 @@ import { ErrorCode } from 'constants/eip1193'
 import { SwapError } from 'errors'
 import { useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
-import { calculateGasMargin } from 'utils/calculateGasMargin'
 import isZero from 'utils/isZero'
 import { getReason, swapErrorToUserReadableMessage } from 'utils/swapErrorToUserReadableMessage'
 
@@ -68,15 +68,7 @@ export function useUniversalRouterSwapCallback(trade: InterfaceTrade | undefined
         ...(value && !isZero(value) ? { value: toHex(value) } : {}),
       }
 
-      let gasEstimate: BigNumber
-      try {
-        gasEstimate = await provider.estimateGas(tx)
-      } catch (gasError) {
-        console.warn(gasError)
-        throw new SwapError({ header: t`Swap Error`, message: t`Your swap is expected to fail` })
-      }
-      const gasLimit = calculateGasMargin(gasEstimate)
-      response = await provider.getSigner().sendTransaction({ ...tx, gasLimit })
+      response = await sendTransaction(provider, tx, 0.2)
     } catch (swapError) {
       if (didUserReject(swapError)) {
         return null

--- a/test/setup-jest.ts
+++ b/test/setup-jest.ts
@@ -18,7 +18,7 @@ jest.mock('@uniswap/conedison/format', () => ({
 const MOCK_TYPED_DATA_SIG =
   '0x1befd08fcc4085dc484346d69fd15659616522454a33e66e7b0f6917379ab888236304ebed307813208bf004da04d998dcd15a8f83241d033e4040adc4b0b5311b'
 
-jest.mock('@uniswap/conedison/provider', () => ({
+jest.mock('@uniswap/conedison/provider/signing', () => ({
   signTypedData: () => Promise.resolve(MOCK_TYPED_DATA_SIG),
 }))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,10 +3518,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@uniswap/conedison@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.3.0.tgz#998aca2bad27f0780a05b40e4512acfcadfece79"
-  integrity sha512-zpZ52svBJ2btwl09mLOw7HlBxFDuYAjAZXLAR7WQZJeRgjD1yD2QuI3v7JliXvHzJh3ePYH6820EMp7xQbdAGQ==
+"@uniswap/conedison@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.5.0.tgz#6d2ae3779256425ad04e955dbb5388fd1c671e98"
+  integrity sha512-zzP3+YZ+a0g1zo2GVbdBDHH17A0qURohrVqJ1nPrhDER/5VSeO8KLTi5KgAvS2Jc7QEpAPhgvMgui9g+u0wHCA==
 
 "@uniswap/default-token-list@^2.0.0":
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,10 +3518,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@uniswap/conedison@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.5.0.tgz#6d2ae3779256425ad04e955dbb5388fd1c671e98"
-  integrity sha512-zzP3+YZ+a0g1zo2GVbdBDHH17A0qURohrVqJ1nPrhDER/5VSeO8KLTi5KgAvS2Jc7QEpAPhgvMgui9g+u0wHCA==
+"@uniswap/conedison@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/conedison/-/conedison-1.5.1.tgz#91527cc9928ce0187f30a5eb4abb705b8f0cd013"
+  integrity sha512-VJqUW4l54QVj5a4vAzAlWWd193iCcT8HMugFPB28S2Uqhs2elAg/RDQmiPOf9TOFB635MdBlD0S6xUuqo7FB4A==
 
 "@uniswap/default-token-list@^2.0.0":
   version "2.2.0"


### PR DESCRIPTION
Uses `@uniswap/conedison/provider` implementation of `sendTransaction`, which includes a gas margin computation.

It also omits the gas margin computation for Uniswap Wallet, and uses sendUncheckedTransaction under the hood. This allows the app to be linked to within 300ms, which allows iOS to deep-link through WalletConnect to the mobile app instead of navigating the to app's webpage.

To test (this may not work on cloudflare/vercel deploys - I'm not sure why, but it may be because they add instrumentation):
- Using your iOS device, connect to the App using Uniswap Wallet via WalletConnect
- Initiate a swap/wrap/etc on the app
- The application should deep-link directly to the wallet

Requires https://github.com/Uniswap/conedison/pull/13 to poll before merging.