### PR TITLE
feat: refactor dialogs and bottom sheets

### DIFF
--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -39,7 +39,7 @@ const BottomSheetModalBackdrop = styled.div<{ className?: string }>`
   z-index: ${({ theme }) => theme.zIndex.modal - 1};
 `
 
-const Wrapper = styled.div<{ open: boolean }>`
+const Wrapper = styled.div`
   border-radius: 0;
   bottom: 0;
   left: 0;
@@ -119,7 +119,7 @@ const RootElement = forwardRef<HTMLDivElement, RootElementProps>(function RootWr
           e.stopPropagation()
         }}
       />
-      <Wrapper open={open} ref={ref}>
+      <Wrapper data-testid="BottomSheetModal__Wrapper" ref={ref}>
         {children}
       </Wrapper>
     </>,

--- a/src/components/BottomSheetModal.tsx
+++ b/src/components/BottomSheetModal.tsx
@@ -85,7 +85,7 @@ export function BottomSheetModal({ children, onClose, open, title }: BottomSheet
 
   return (
     <>
-      <RootElement ref={setRootElement} open={open} />
+      <RootElement ref={setRootElement} open={open} onClose={onClose} />
       <DialogProvider value={rootElement}>
         {open && (
           <Dialog color="dialog" onClose={onClose} forceContain>
@@ -102,16 +102,23 @@ export function BottomSheetModal({ children, onClose, open, title }: BottomSheet
 
 type RootElementProps = PropsWithChildren<{
   open: boolean
+  onClose: () => void
 }>
 
 const RootElement = forwardRef<HTMLDivElement, RootElementProps>(function RootWrapper(
-  { children, open }: RootElementProps,
+  { children, open, onClose }: RootElementProps,
   ref
 ) {
   return createPortal(
     <>
       {/* TODO (WEB-2767): Support dismissing modal when clicking on backdrop */}
-      <BottomSheetModalBackdrop className={!open ? 'hidden' : undefined} />
+      <BottomSheetModalBackdrop
+        className={!open ? 'hidden' : undefined}
+        onClick={(e) => {
+          onClose()
+          e.stopPropagation()
+        }}
+      />
       <Wrapper open={open} ref={ref}>
         {children}
       </Wrapper>

--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -173,6 +173,7 @@ export default function Popover({
             style={styles.popper}
             {...attributes.popper}
             onClick={containerOnClick}
+            data-testid="popover-container"
           >
             {content}
             {showArrow && (

--- a/src/components/ResponsiveDialog.test.tsx
+++ b/src/components/ResponsiveDialog.test.tsx
@@ -1,0 +1,98 @@
+import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
+import { render } from 'test'
+import { Provider as ThemeProvider } from 'theme'
+
+import { useIsDialogPageCentered } from './Dialog'
+import { ResponsiveDialog } from './ResponsiveDialog'
+
+jest.mock('hooks/useIsMobileWidth')
+jest.mock('./Dialog')
+
+const mockUseIsMobileWidth = useIsMobileWidth as jest.Mock
+const mockUseIsDialogPageCentered = useIsDialogPageCentered as jest.Mock
+
+describe('ResponsiveDialog', () => {
+  beforeEach(() => {
+    mockUseIsMobileWidth.mockReturnValue(false)
+    mockUseIsDialogPageCentered.mockReturnValue(false)
+  })
+
+  it('renders a dialog by default (nothing rendered when closed)', () => {
+    const view = render(
+      <ThemeProvider>
+        <ResponsiveDialog open={false} setOpen={() => null}>
+          <div>dialog content</div>
+        </ResponsiveDialog>
+      </ThemeProvider>
+    )
+
+    expect(view.queryByText('dialog content')).toBeNull()
+  })
+
+  it('renders a popover when defaultView is set to popover', () => {
+    const view = render(
+      <ThemeProvider>
+        <ResponsiveDialog open={true} setOpen={() => null} defaultView="popover">
+          <div>popover content</div>
+        </ResponsiveDialog>
+      </ThemeProvider>
+    )
+
+    expect(view.getByTestId('popover-container')).toBeTruthy()
+  })
+
+  it('renders a bottom sheet when on mobile and pageCenteredDialogsEnabled is true', () => {
+    mockUseIsMobileWidth.mockReturnValue(true)
+    mockUseIsDialogPageCentered.mockReturnValue(true)
+
+    const view = render(
+      <ThemeProvider>
+        <ResponsiveDialog open={true} setOpen={() => null}>
+          <div>bottom sheet content</div>
+        </ResponsiveDialog>
+      </ThemeProvider>
+    )
+
+    expect(view.getByTestId('BottomSheetModal__Wrapper')).toBeTruthy()
+  })
+
+  it('renders a bottom sheet when on mobile and mobileBottomSheet is true', () => {
+    mockUseIsMobileWidth.mockReturnValue(true)
+
+    const view = render(
+      <ThemeProvider>
+        <ResponsiveDialog open={true} setOpen={() => null} mobileBottomSheet={true}>
+          <div>bottom sheet content</div>
+        </ResponsiveDialog>
+      </ThemeProvider>
+    )
+
+    expect(view.getByTestId('BottomSheetModal__Wrapper')).toBeTruthy()
+  })
+
+  it('renders a popover when on mobile and defaultView is set to popover', () => {
+    mockUseIsMobileWidth.mockReturnValue(true)
+
+    const view = render(
+      <ThemeProvider>
+        <ResponsiveDialog open={true} setOpen={() => null} defaultView="popover">
+          <div>popover content</div>
+        </ResponsiveDialog>
+      </ThemeProvider>
+    )
+
+    expect(view.getByTestId('popover-container')).toBeTruthy()
+  })
+
+  it('renders an anchor when provided', () => {
+    const view = render(
+      <ThemeProvider>
+        <ResponsiveDialog open={true} setOpen={() => null} anchor={<div>anchor</div>}>
+          <div>dialog content</div>
+        </ResponsiveDialog>
+      </ThemeProvider>
+    )
+
+    expect(view.getByText('anchor')).toBeTruthy()
+  })
+})

--- a/src/components/ResponsiveDialog.tsx
+++ b/src/components/ResponsiveDialog.tsx
@@ -1,0 +1,71 @@
+import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
+import { useOutsideClickHandler } from 'hooks/useOutsideClickHandler'
+import { Info } from 'icons'
+import { PropsWithChildren, useState } from 'react'
+
+import { BottomSheetModal } from './BottomSheetModal'
+import { IconButton } from './Button'
+import Dialog, { useIsDialogPageCentered } from './Dialog'
+import Popover, { PopoverBoundaryProvider } from './Popover'
+
+interface ResponsiveDialogProps {
+  open: boolean
+  setOpen: (open: boolean) => void
+  // when not on a mobile width, use the default view.
+  defaultView?: 'dialog' | 'popover'
+  // an anchor view to render when the dialog is closed. Useful as an entry point to a bottom sheet or popover.
+  // if not provided, a default info icon will be used.
+  anchor?: React.ReactNode
+  // If true, always render the dialog as a bottom sheet on mobile.
+  // If false, it will only be a bottom sheet if it was page-centered.
+  mobileBottomSheet?: boolean
+}
+
+/**
+ * A dialog that renders as a bottom sheet on mobile.
+ */
+export function ResponsiveDialog({
+  children,
+  open,
+  setOpen,
+  defaultView = 'dialog',
+  anchor,
+  mobileBottomSheet,
+}: PropsWithChildren<ResponsiveDialogProps>) {
+  const isMobile = useIsMobileWidth()
+  const pageCenteredDialogsEnabled = useIsDialogPageCentered()
+  const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
+  useOutsideClickHandler(isMobile ? null : wrapper, () => setOpen(false))
+
+  if (isMobile && (pageCenteredDialogsEnabled || mobileBottomSheet)) {
+    return (
+      <>
+        {anchor}
+        <BottomSheetModal onClose={() => setOpen(false)} open={open}>
+          {children}
+        </BottomSheetModal>
+      </>
+    )
+  } else if (defaultView === 'popover') {
+    return (
+      <div ref={setWrapper}>
+        <PopoverBoundaryProvider value={wrapper}>
+          <Popover showArrow={false} offset={10} show={open} placement="top-end" content={children}>
+            {anchor ?? <IconButton icon={Info} />}
+          </Popover>
+        </PopoverBoundaryProvider>
+      </div>
+    )
+  } else {
+    return (
+      <>
+        {anchor}
+        {open && (
+          <Dialog color="container" onClose={() => setOpen(false)}>
+            {children}
+          </Dialog>
+        )}
+      </>
+    )
+  }
+}

--- a/src/components/ResponsiveDialog.tsx
+++ b/src/components/ResponsiveDialog.tsx
@@ -19,10 +19,11 @@ interface ResponsiveDialogProps {
   // If true, always render the dialog as a bottom sheet on mobile.
   // If false, it will only be a bottom sheet if it was page-centered.
   mobileBottomSheet?: boolean
+  bottomSheetTitle?: string
 }
 
 /**
- * A dialog that renders as a bottom sheet on mobile.
+ * A Dialog or Popover that renders as a bottom sheet on mobile.
  */
 export function ResponsiveDialog({
   children,
@@ -31,6 +32,7 @@ export function ResponsiveDialog({
   defaultView = 'dialog',
   anchor,
   mobileBottomSheet,
+  bottomSheetTitle,
 }: PropsWithChildren<ResponsiveDialogProps>) {
   const isMobile = useIsMobileWidth()
   const pageCenteredDialogsEnabled = useIsDialogPageCentered()
@@ -41,7 +43,7 @@ export function ResponsiveDialog({
     return (
       <>
         {anchor}
-        <BottomSheetModal onClose={() => setOpen(false)} open={open}>
+        <BottomSheetModal onClose={() => setOpen(false)} open={open} title={bottomSheetTitle}>
           {children}
         </BottomSheetModal>
       </>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -65,6 +65,7 @@ export default function Settings() {
       defaultView="popover"
       anchor={<SettingsButton data-testid="settings-button" onClick={() => setOpen(!open)} icon={SettingsIcon} />}
       mobileBottomSheet={true}
+      bottomSheetTitle="Settings"
     >
       <SettingsMenu />
     </ResponsiveDialog>

--- a/src/components/Swap/Settings/index.tsx
+++ b/src/components/Swap/Settings/index.tsx
@@ -1,8 +1,6 @@
-import { BottomSheetModal } from 'components/BottomSheetModal'
+import { ResponsiveDialog } from 'components/ResponsiveDialog'
 import Rule from 'components/Rule'
-import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import { useOnEscapeHandler } from 'hooks/useOnEscapeHandler'
-import { useOutsideClickHandler } from 'hooks/useOutsideClickHandler'
 import { Settings as SettingsIcon } from 'icons'
 import { useAtom } from 'jotai'
 import { useState } from 'react'
@@ -12,7 +10,7 @@ import { AnimationSpeed } from 'theme'
 
 import { IconButton } from '../../Button'
 import Column from '../../Column'
-import Popover, { PopoverBoundaryProvider } from '../../Popover'
+import { PopoverBoundaryProvider } from '../../Popover'
 import MaxSlippageSelect from './MaxSlippageSelect'
 import RouterPreferenceToggle from './RouterPreferenceToggle'
 import TransactionTtlInput from './TransactionTtlInput'
@@ -57,27 +55,18 @@ const SettingsButton = styled(IconButton)`
 
 export default function Settings() {
   const [open, setOpen] = useState(false)
-  const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null)
-  const isMobile = useIsMobileWidth()
-  useOutsideClickHandler(isMobile ? null : wrapper, () => setOpen(false))
+
   useOnEscapeHandler(() => setOpen(false))
 
   return (
-    <div ref={setWrapper}>
-      {isMobile ? (
-        <>
-          <SettingsButton onClick={() => setOpen(!open)} icon={SettingsIcon} />
-          <BottomSheetModal title="Settings" onClose={() => setOpen(false)} open={open}>
-            <SettingsMenu />
-          </BottomSheetModal>
-        </>
-      ) : (
-        <PopoverBoundaryProvider value={wrapper}>
-          <Popover showArrow={false} offset={10} show={open} placement="top-end" content={<SettingsMenu />}>
-            <SettingsButton data-testid="settings-button" onClick={() => setOpen(!open)} icon={SettingsIcon} />
-          </Popover>
-        </PopoverBoundaryProvider>
-      )}
-    </div>
+    <ResponsiveDialog
+      open={open}
+      setOpen={setOpen}
+      defaultView="popover"
+      anchor={<SettingsButton data-testid="settings-button" onClick={() => setOpen(!open)} icon={SettingsIcon} />}
+      mobileBottomSheet={true}
+    >
+      <SettingsMenu />
+    </ResponsiveDialog>
   )
 }

--- a/src/components/Swap/SwapActionButton/SwapButton.tsx
+++ b/src/components/Swap/SwapActionButton/SwapButton.tsx
@@ -1,11 +1,10 @@
 import { Trans } from '@lingui/macro'
 import { useWeb3React } from '@web3-react/core'
-import { BottomSheetModal } from 'components/BottomSheetModal'
 import { useAsyncError } from 'components/Error/ErrorBoundary'
+import { ResponsiveDialog } from 'components/ResponsiveDialog'
 import { useSwapInfo } from 'hooks/swap'
 import { useSwapCallback } from 'hooks/swap/useSwapCallback'
 import { useConditionalHandler } from 'hooks/useConditionalHandler'
-import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import { useSetOldestValidBlock } from 'hooks/useIsValidBlock'
 import { AllowanceState } from 'hooks/usePermit2Allowance'
 import { usePermit2 as usePermit2Enabled } from 'hooks/useSyncFlags'
@@ -19,7 +18,6 @@ import { TransactionType } from 'state/transactions'
 import invariant from 'tiny-invariant'
 
 import ActionButton from '../../ActionButton'
-import Dialog, { useIsDialogPageCentered } from '../../Dialog'
 import { SummaryDialog } from '../Summary'
 import { useCollapseToolbar } from '../Toolbar/ToolbarContext'
 import useOnSubmit from './useOnSubmit'
@@ -107,44 +105,25 @@ export default function SwapButton({ disabled }: { disabled: boolean }) {
     setOpen(await onReviewSwapClick())
   }, [onReviewSwapClick, collapseToolbar])
 
-  const isMobile = useIsMobileWidth()
-  const pageCenteredDialogsEnabled = useIsDialogPageCentered()
-
   return (
     <>
       <ActionButton color={color} onClick={onClick} disabled={disabled}>
         <Trans>Review swap</Trans>
       </ActionButton>
-      {trade &&
-        (isMobile && pageCenteredDialogsEnabled ? (
-          <BottomSheetModal onClose={() => setOpen(false)} open={open && Boolean(trade)}>
-            <SummaryDialog
-              trade={trade}
-              slippage={slippage}
-              gasUseEstimateUSD={gasUseEstimateUSD}
-              inputUSDC={inputUSDC}
-              outputUSDC={outputUSDC}
-              impact={impact}
-              onConfirm={onSwap}
-              allowance={allowance}
-            />
-          </BottomSheetModal>
-        ) : (
-          open && (
-            <Dialog color="container" onClose={() => setOpen(false)}>
-              <SummaryDialog
-                trade={trade}
-                slippage={slippage}
-                gasUseEstimateUSD={gasUseEstimateUSD}
-                inputUSDC={inputUSDC}
-                outputUSDC={outputUSDC}
-                impact={impact}
-                onConfirm={onSwap}
-                allowance={allowance}
-              />
-            </Dialog>
-          )
-        ))}
+      {trade && (
+        <ResponsiveDialog open={open} setOpen={setOpen}>
+          <SummaryDialog
+            trade={trade}
+            slippage={slippage}
+            gasUseEstimateUSD={gasUseEstimateUSD}
+            inputUSDC={inputUSDC}
+            outputUSDC={outputUSDC}
+            impact={impact}
+            onConfirm={onSwap}
+            allowance={allowance}
+          />
+        </ResponsiveDialog>
+      )}
     </>
   )
 }

--- a/src/components/TokenSelect/index.tsx
+++ b/src/components/TokenSelect/index.tsx
@@ -1,11 +1,10 @@
 import { t, Trans } from '@lingui/macro'
 import { Currency } from '@uniswap/sdk-core'
 import { useWeb3React } from '@web3-react/core'
-import { BottomSheetModal } from 'components/BottomSheetModal'
 import { inputCss, StringInput } from 'components/Input'
+import { ResponsiveDialog } from 'components/ResponsiveDialog'
 import { useConditionalHandler } from 'hooks/useConditionalHandler'
 import { useCurrencyBalances } from 'hooks/useCurrencyBalance'
-import { useIsMobileWidth } from 'hooks/useIsMobileWidth'
 import useNativeCurrency from 'hooks/useNativeCurrency'
 import useTokenList, { useIsTokenListLoaded, useQueryTokens } from 'hooks/useTokenList'
 import { Search } from 'icons'
@@ -166,23 +165,13 @@ export default memo(function TokenSelect({ field, value, approved, disabled, onS
     },
     [onSelect, setOpen]
   )
-  const isMobile = useIsMobileWidth()
-  const pageCenteredDialogsEnabled = useIsDialogPageCentered()
 
   return (
     <>
       <TokenButton value={value} approved={approved} disabled={disabled} onClick={onOpen} />
-      {isMobile && pageCenteredDialogsEnabled ? (
-        <BottomSheetModal onClose={() => setOpen(false)} open={open}>
-          <TokenSelectDialogContent value={value} onSelect={selectAndClose} onClose={() => setOpen(false)} />
-        </BottomSheetModal>
-      ) : (
-        open && (
-          <Dialog onClose={() => setOpen(false)} color="container" padded={false}>
-            <TokenSelectDialogContent value={value} onSelect={selectAndClose} onClose={() => setOpen(false)} />
-          </Dialog>
-        )
-      )}
+      <ResponsiveDialog open={open} setOpen={setOpen}>
+        <TokenSelectDialogContent value={value} onSelect={selectAndClose} onClose={() => setOpen(false)} />
+      </ResponsiveDialog>
     </>
   )
 })

--- a/src/components/__snapshots__/Header.test.tsx.snap
+++ b/src/components/__snapshots__/Header.test.tsx.snap
@@ -60,6 +60,7 @@ Object {
               </div>
               <div
                 class="Popover__PopoverContainer-sc-1liex6z-0 koqvVY"
+                data-testid="popover-container"
                 style="position: absolute; left: 0px; top: 0px;"
               >
                 <div
@@ -326,6 +327,7 @@ Object {
                   </div>
                   <div
                     class="Popover__PopoverContainer-sc-1liex6z-0 koqvVY"
+                    data-testid="popover-container"
                     style="position: absolute; left: 0px; top: 0px;"
                   >
                     <div
@@ -340,6 +342,7 @@ Object {
                   </div>
                   <div
                     class="Popover__PopoverContainer-sc-1liex6z-0 koqvVY"
+                    data-testid="popover-container"
                     style="position: absolute; left: 0px; top: 0px;"
                   >
                     <div
@@ -416,6 +419,7 @@ Object {
             </div>
             <div
               class="Popover__PopoverContainer-sc-1liex6z-0 koqvVY"
+              data-testid="popover-container"
               style="position: absolute; left: 0px; top: 0px;"
             >
               <div
@@ -682,6 +686,7 @@ Object {
                 </div>
                 <div
                   class="Popover__PopoverContainer-sc-1liex6z-0 koqvVY"
+                  data-testid="popover-container"
                   style="position: absolute; left: 0px; top: 0px;"
                 >
                   <div
@@ -696,6 +701,7 @@ Object {
                 </div>
                 <div
                   class="Popover__PopoverContainer-sc-1liex6z-0 koqvVY"
+                  data-testid="popover-container"
                   style="position: absolute; left: 0px; top: 0px;"
                 >
                   <div


### PR DESCRIPTION
this PR is just trying to reduce code duplication - we have similar logic in a few places for switching between Bottom Sheets and Popovers/Dialogs depending on the screen size. 

screen recordings:

widget-contained dialogs, slide animation:

https://user-images.githubusercontent.com/66155195/223275255-5d6ed05b-b9b1-4dc1-a0cc-375538c35856.mov

widget-contained dialogs, fade animation:

https://user-images.githubusercontent.com/66155195/223275470-446cc02a-8a54-4c4d-9125-d6bd9a18717d.mov


page-centered dialogs, fade animation:


https://user-images.githubusercontent.com/66155195/223276227-36a9074a-3810-4d24-9cbc-00e01c19ac9d.mov

