### PR TITLE
fix: rollup errors

### DIFF
--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -141,7 +141,7 @@ interface ExpandProps {
   expanded: boolean
 }
 
-const Expander = ({ expanded }: ExpandProps) => {
+function Expander({ expanded }: ExpandProps) {
   return <ExpandIcon $expanded={expanded} />
 }
 
@@ -178,11 +178,13 @@ interface PriceImpactProps {
   impact: PriceImpactType
 }
 
-export const PriceImpactWarningTooltipContent = () => (
-  <ThemedText.Caption>
-    There will be a large difference between your input and output values due to current liquidity.
-  </ThemedText.Caption>
-)
+export function PriceImpactWarningTooltipContent() {
+  return (
+    <ThemedText.Caption>
+      There will be a large difference between your input and output values due to current liquidity.
+    </ThemedText.Caption>
+  )
+}
 
 export function PriceImpact({ impact, expanded }: PriceImpactProps & ExpandProps) {
   return (

--- a/src/components/Swap/Toolbar/ToolbarContext.tsx
+++ b/src/components/Swap/Toolbar/ToolbarContext.tsx
@@ -10,7 +10,7 @@ export const Context = createContext<{
   onToggleOpen: () => null,
 })
 
-export const Provider = ({ children }: PropsWithChildren) => {
+export function Provider({ children }: PropsWithChildren) {
   const [open, setOpen] = useState(false)
   const onToggleOpen = () => setOpen((open) => !open)
   const collapse = () => setOpen(false)


### PR DESCRIPTION
for some reason, changing these `const`s to regular `function` syntax fixes the rollup errors that we've been seeing (in the terminal when running `yarn start`)

example of the error:
```
rollup building...
Error when using sourcemap for reporting an error: Can't resolve original location of error.
{
  column: 13,
  file: '/Users/eddie.dugan/Documents/widgets/src/components/Swap/Toolbar/Caption.tsx',
  line: 4
} 

The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten
{
  column: 13,
  file: '/Users/eddie.dugan/Documents/widgets/src/components/Swap/Toolbar/Caption.tsx',
  line: 4
} 

```

to verify that this actually fixes the errors like I claim, checkout this branch and run `yarn && yarn start`