### PR TITLE
fix: price impact tostring

### DIFF
--- a/src/components/Swap/PriceImpactRow.test.tsx
+++ b/src/components/Swap/PriceImpactRow.test.tsx
@@ -14,7 +14,7 @@ describe('PriceImpactRow', () => {
       />
     )
     // verify that the percentage string is visible
-    expect(el.getByText('(10%)')).toBeTruthy()
+    expect(el.getByText('(-10%)')).toBeTruthy()
     // verify the tooltip is visible
     const iconElement = el.container.querySelector('svg')
     expect(iconElement).toBeTruthy()
@@ -30,7 +30,7 @@ describe('PriceImpactRow', () => {
       />
     )
     // verify that the percentage string is visible
-    expect(el.getByText('(1%)')).toBeTruthy()
+    expect(el.getByText('(-1%)')).toBeTruthy()
     // verify the tooltip is visible
     const iconElement = el.container.querySelector('svg')
     expect(iconElement).toBeTruthy()
@@ -45,7 +45,7 @@ describe('PriceImpactRow', () => {
       />
     )
     // verify that the percentage string is visible
-    expect(el.getByText('(0.01%)')).toBeTruthy()
+    expect(el.getByText('(-0.01%)')).toBeTruthy()
     // verify the tooltip is visible
     const iconElement = el.container.querySelector('svg')
     expect(iconElement).not.toBeTruthy()

--- a/src/components/Swap/PriceImpactRow.test.tsx
+++ b/src/components/Swap/PriceImpactRow.test.tsx
@@ -10,7 +10,6 @@ describe('PriceImpactRow', () => {
         impact={{
           percent: new Percent(10, 100),
           warning: 'error',
-          toString: () => '10%',
         }}
       />
     )
@@ -27,7 +26,6 @@ describe('PriceImpactRow', () => {
         impact={{
           percent: new Percent(1, 100),
           warning: 'warning',
-          toString: () => '1%',
         }}
       />
     )
@@ -43,7 +41,6 @@ describe('PriceImpactRow', () => {
       <PriceImpactRow
         impact={{
           percent: new Percent(1, 10000),
-          toString: () => '0.01%',
         }}
       />
     )

--- a/src/components/Swap/PriceImpactRow.tsx
+++ b/src/components/Swap/PriceImpactRow.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro'
 import Row from 'components/Row'
 import Tooltip, { SmallToolTipBody } from 'components/Tooltip'
-import { PriceImpact } from 'hooks/usePriceImpact'
+import { formatPriceImpact, PriceImpact } from 'hooks/usePriceImpact'
 import { AlertTriangle } from 'icons'
 import { ThemedText } from 'theme'
 
@@ -17,7 +17,7 @@ export function PriceImpactRow({ impact, reverse }: PriceImpactProps) {
   return (
     <Row gap={0.25} flex align="center" flow={reverse ? 'row-reverse' : 'row wrap'}>
       <ThemedText.Body2 userSelect={false} color={impact.warning ?? 'hint'}>
-        ({impact.toString()})
+        ({formatPriceImpact(impact)})
       </ThemedText.Body2>
       {impact?.warning && (
         <Tooltip icon={AlertTriangle} iconProps={{ color: impact.warning }} data-testid="alert-tooltip">

--- a/src/components/Swap/Summary/Summary.tsx
+++ b/src/components/Swap/Summary/Summary.tsx
@@ -1,5 +1,5 @@
 import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
-import { PriceImpact } from 'hooks/usePriceImpact'
+import { formatPriceImpact, PriceImpact } from 'hooks/usePriceImpact'
 import { ArrowDown, ArrowRight } from 'icons'
 import { PropsWithChildren } from 'react'
 import styled from 'styled-components/macro'
@@ -56,7 +56,7 @@ export default function Summary({ input, output, inputUSDC, outputUSDC, impact, 
       <TokenValue input={input} usdc={inputUSDC} open={open} />
       {open ? <ArrowRight /> : <ArrowDown />}
       <TokenValue input={output} usdc={outputUSDC} open={open}>
-        {impact && <ThemedText.Caption color={impact.warning}>({impact.toString()})</ThemedText.Caption>}
+        {impact && <ThemedText.Caption color={impact.warning}>({formatPriceImpact(impact)})</ThemedText.Caption>}
       </TokenValue>
     </>
   )

--- a/src/components/Swap/Summary/index.tsx
+++ b/src/components/Swap/Summary/index.tsx
@@ -7,7 +7,7 @@ import { PopoverBoundaryProvider } from 'components/Popover'
 import { SmallToolTipBody, TooltipText } from 'components/Tooltip'
 import { UserRejectedRequestError } from 'errors'
 import { Allowance, AllowanceState } from 'hooks/usePermit2Allowance'
-import { PriceImpact } from 'hooks/usePriceImpact'
+import { formatPriceImpact, PriceImpact } from 'hooks/usePriceImpact'
 import { Slippage } from 'hooks/useSlippage'
 import { useWindowWidth } from 'hooks/useWindowWidth'
 import { AlertTriangle, Spinner } from 'icons'
@@ -290,7 +290,7 @@ export function SummaryDialog(props: SummaryDialogProps) {
     <>
       {showSpeedbump && props.impact ? (
         <SpeedBumpDialog onAcknowledge={onAcknowledgeSpeedbump}>
-          {t`This transaction will result in a`} <PriceImpactText>{props.impact.toString()} </PriceImpactText>
+          {t`This transaction will result in a`} <PriceImpactText>{formatPriceImpact(props.impact)} </PriceImpactText>
           {t`price impact on the market price of this pool. Do you wish to continue? `}
         </SpeedBumpDialog>
       ) : (

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -5,6 +5,7 @@ import Column from 'components/Column'
 import Expando from 'components/Expando'
 import { ChainError, useIsAmountPopulated, useSwapInfo } from 'hooks/swap'
 import { useIsWrap } from 'hooks/swap/useWrapCallback'
+import { formatPriceImpact } from 'hooks/usePriceImpact'
 import { AlertTriangle, Info } from 'icons'
 import { memo, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { TradeState } from 'state/routing/types'
@@ -119,7 +120,7 @@ function CaptionRow() {
       {
         color: impact?.warning,
         name: t`Price impact`,
-        value: impact?.percent ? impact?.toString() : '-',
+        value: impact?.percent ? formatPriceImpact(impact) : '-',
         valueTooltip: impact?.warning
           ? {
               icon: AlertTriangle,

--- a/src/hooks/usePriceImpact.test.tsx
+++ b/src/hooks/usePriceImpact.test.tsx
@@ -3,7 +3,7 @@ import { InterfaceTrade } from 'state/routing/types'
 import { renderHook } from 'test'
 import { buildSingleV3Route, DAI, USDC } from 'test/utils'
 
-import { usePriceImpact } from './usePriceImpact'
+import { formatPriceImpact, usePriceImpact } from './usePriceImpact'
 
 const usdc = CurrencyAmount.fromRawAmount(USDC, 1)
 const dai = CurrencyAmount.fromRawAmount(DAI, 1)
@@ -16,7 +16,7 @@ describe('usePriceImpact', () => {
       tradeType: TradeType.EXACT_INPUT,
     })
     const { result } = renderHook(() => usePriceImpact(trade))
-    expect(result.current?.toString()).toEqual('-99.61%')
+    expect(formatPriceImpact(result.current)).toEqual('-99.61%')
     expect(result.current?.warning).toEqual('error')
   })
 })

--- a/src/hooks/usePriceImpact.ts
+++ b/src/hooks/usePriceImpact.ts
@@ -33,7 +33,6 @@ export function useFiatValueChange(trade?: InterfaceTrade) {
     return {
       percent: fiatPriceImpact,
       warning: getPriceImpactWarning(fiatPriceImpact),
-      toString: () => toHumanReadablePercent(fiatPriceImpact),
     }
   }, [inputUSDCValue, outputUSDCValue])
 }
@@ -48,6 +47,7 @@ export function toHumanReadablePercent(priceImpact: Percent): string {
   return `${sign}${number}%`
 }
 
-export function formatPriceImpact(impact: PriceImpact): string {
+export function formatPriceImpact(impact: PriceImpact | undefined): string {
+  if (!impact) return '-'
   return toHumanReadablePercent(impact.percent)
 }

--- a/src/hooks/usePriceImpact.ts
+++ b/src/hooks/usePriceImpact.ts
@@ -9,7 +9,6 @@ import { useUSDCValue } from './useUSDCPrice'
 export interface PriceImpact {
   percent: Percent
   warning?: 'warning' | 'error'
-  toString(): string
 }
 
 export function usePriceImpact(trade?: InterfaceTrade): PriceImpact | undefined {
@@ -19,7 +18,6 @@ export function usePriceImpact(trade?: InterfaceTrade): PriceImpact | undefined 
       ? {
           percent: marketPriceImpact,
           warning: getPriceImpactWarning(marketPriceImpact),
-          toString: () => toHumanReadablePercent(marketPriceImpact),
         }
       : undefined
   }, [trade])
@@ -48,4 +46,8 @@ export function toHumanReadablePercent(priceImpact: Percent): string {
   }
   const number = parseFloat(priceImpact.multiply(-1)?.toFixed(2))
   return `${sign}${number}%`
+}
+
+export function formatPriceImpact(impact: PriceImpact): string {
+  return toHumanReadablePercent(impact.percent)
 }


### PR DESCRIPTION
remove the custom `toString` field on Price Impact objects because it makes them unserializable. prefer to use a helper function.