### PR TITLE
fix: use correct network name for logo URLs

### DIFF
--- a/src/components/Logo/util.ts
+++ b/src/components/Logo/util.ts
@@ -7,7 +7,7 @@ import CeloLogo from '../../assets/svg/celo_logo.svg'
 import MaticLogo from '../../assets/svg/matic-token-icon.svg'
 import { LogoTableInput } from './LogoTable'
 
-type Network = 'ethereum' | 'arbitrum' | 'optimism' | 'polygon' | 'celo' | 'binance'
+type Network = 'ethereum' | 'arbitrum' | 'optimism' | 'polygon' | 'celo' | 'smartchain'
 
 function chainIdToNetworkName(networkId: SupportedChainId): Network | undefined {
   switch (networkId) {
@@ -22,7 +22,7 @@ function chainIdToNetworkName(networkId: SupportedChainId): Network | undefined 
     case SupportedChainId.CELO:
       return 'celo'
     case SupportedChainId.BNB:
-      return 'binance'
+      return 'smartchain'
     default:
       return 'ethereum'
   }


### PR DESCRIPTION
this is used to fetch token logos

example using the widget:

https://user-images.githubusercontent.com/66155195/223776248-bfff2197-8417-489e-8c55-7e6708258a95.mov

