### PR TITLE
fix: stricter typing for router query

### DIFF
--- a/src/hooks/routing/transformSwapRouteToGetQuoteResult.ts
+++ b/src/hooks/routing/transformSwapRouteToGetQuoteResult.ts
@@ -1,6 +1,6 @@
 import { Protocol } from '@uniswap/router-sdk'
 import type { SwapRoute } from '@uniswap/smart-order-router'
-import { QuoteResult, V2PoolInRoute, V3PoolInRoute } from 'state/routing/types'
+import { QuoteResult, QuoteState, V2PoolInRoute, V3PoolInRoute } from 'state/routing/types'
 import { isExactInput } from 'utils/tradeType'
 
 // from routing-api (https://github.com/Uniswap/routing-api/blob/main/lib/handlers/quote/quote.ts#L243-L311)
@@ -128,20 +128,23 @@ export function transformSwapRouteToGetQuoteResult({
 
   const amount = isExactInput(tradeType) ? inputAmount : outputAmount
   return {
-    methodParameters,
-    blockNumber: blockNumber.toString(),
-    amount: amount.quotient.toString(),
-    amountDecimals: amount.toExact(),
-    quote: quote.quotient.toString(),
-    quoteDecimals: quote.toExact(),
-    quoteGasAdjusted: quoteGasAdjusted.quotient.toString(),
-    quoteGasAdjustedDecimals: quoteGasAdjusted.toExact(),
-    gasUseEstimateQuote: estimatedGasUsedQuoteToken.quotient.toString(),
-    gasUseEstimateQuoteDecimals: estimatedGasUsedQuoteToken.toExact(),
-    gasUseEstimate: estimatedGasUsed.toString(),
-    gasUseEstimateUSD: estimatedGasUsedUSD.toExact(),
-    gasPriceWei: gasPriceWei.toString(),
-    route: routeResponse,
-    routeString,
+    state: QuoteState.SUCCESS,
+    data: {
+      methodParameters,
+      blockNumber: blockNumber.toString(),
+      amount: amount.quotient.toString(),
+      amountDecimals: amount.toExact(),
+      quote: quote.quotient.toString(),
+      quoteDecimals: quote.toExact(),
+      quoteGasAdjusted: quoteGasAdjusted.quotient.toString(),
+      quoteGasAdjustedDecimals: quoteGasAdjusted.toExact(),
+      gasUseEstimateQuote: estimatedGasUsedQuoteToken.quotient.toString(),
+      gasUseEstimateQuoteDecimals: estimatedGasUsedQuoteToken.toExact(),
+      gasUseEstimate: estimatedGasUsed.toString(),
+      gasUseEstimateUSD: estimatedGasUsedUSD.toExact(),
+      gasPriceWei: gasPriceWei.toString(),
+      route: routeResponse,
+      routeString,
+    },
   }
 }

--- a/src/state/routing/slice.ts
+++ b/src/state/routing/slice.ts
@@ -1,4 +1,4 @@
-import { BaseQueryFn, createApi, SkipToken, skipToken } from '@reduxjs/toolkit/query/react'
+import { BaseQueryFn, createApi, FetchBaseQueryError, SkipToken, skipToken } from '@reduxjs/toolkit/query/react'
 import { Protocol } from '@uniswap/router-sdk'
 import { RouterPreference } from 'hooks/routing/types'
 import ms from 'ms.macro'
@@ -6,7 +6,7 @@ import qs from 'qs'
 import { isExactInput } from 'utils/tradeType'
 
 import { serializeGetQuoteArgs } from './args'
-import { GetQuoteArgs, GetQuoteError, NO_ROUTE, QuoteResult, TradeResult } from './types'
+import { GetQuoteArgs, QuoteData, QuoteState, TradeResult } from './types'
 import { transformQuoteToTradeResult } from './utils'
 
 const protocols: Protocol[] = [Protocol.V2, Protocol.V3, Protocol.MIXED]
@@ -16,11 +16,9 @@ const DEFAULT_QUERY_PARAMS = {
   protocols: protocols.map((p) => p.toLowerCase()).join(','),
 }
 
-const baseQuery: BaseQueryFn<GetQuoteArgs, TradeQuoteResult> = () => {
+const baseQuery: BaseQueryFn<GetQuoteArgs, TradeResult> = () => {
   return { error: { reason: 'Unimplemented baseQuery' } }
 }
-
-type TradeQuoteResult = TradeResult | GetQuoteError
 
 export const routing = createApi({
   reducerPath: 'routing',
@@ -28,7 +26,8 @@ export const routing = createApi({
   serializeQueryArgs: serializeGetQuoteArgs,
   endpoints: (build) => ({
     getTradeQuote: build.query({
-      async queryFn(args: GetQuoteArgs | SkipToken) {
+      // Explicitly typing the return type enables typechecking of return values.
+      async queryFn(args: GetQuoteArgs | SkipToken): Promise<{ data: TradeResult } | { error: FetchBaseQueryError }> {
         if (args === skipToken) return { error: { status: 'CUSTOM_ERROR', error: 'Skipped' } }
 
         if (
@@ -59,14 +58,14 @@ export const routing = createApi({
 
               // NO_ROUTE should be treated as a valid response to prevent retries.
               if (typeof data === 'object' && data.errorCode === 'NO_ROUTE') {
-                return { data: NO_ROUTE as TradeQuoteResult }
+                return { data: { state: QuoteState.NOT_FOUND } }
               }
 
               throw data
             }
 
-            const quote: QuoteResult = await response.json()
-            const tradeResult = transformQuoteToTradeResult(args, quote)
+            const quoteData: QuoteData = await response.json()
+            const tradeResult = transformQuoteToTradeResult(args, quoteData)
             return { data: tradeResult }
           } catch (error: any) {
             console.warn(
@@ -78,12 +77,13 @@ export const routing = createApi({
         // Lazy-load the client-side router to improve initial pageload times.
         const clientSideSmartOrderRouter = await import('../../hooks/routing/clientSideSmartOrderRouter')
         try {
-          const quote: QuoteResult | GetQuoteError = await clientSideSmartOrderRouter.getClientSideQuote(args, {
-            protocols,
-          })
-          if (typeof quote === 'string') return { data: quote as TradeQuoteResult }
-          const tradeResult = transformQuoteToTradeResult(args, quote)
-          return { data: tradeResult }
+          const quoteResult = await clientSideSmartOrderRouter.getClientSideQuoteResult(args, { protocols })
+          if (quoteResult.state === QuoteState.SUCCESS) {
+            const tradeResult = transformQuoteToTradeResult(args, quoteResult.data)
+            return { data: tradeResult }
+          } else {
+            return { data: quoteResult }
+          }
         } catch (error: any) {
           console.warn(`GetQuote failed on client: ${error}`)
           return { error: { status: 'CUSTOM_ERROR', error: error?.message ?? error?.detail ?? error } }

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -2,8 +2,7 @@ import { BaseProvider } from '@ethersproject/providers'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Token, TradeType } from '@uniswap/sdk-core'
 import type { ChainId } from '@uniswap/smart-order-router'
-import { QuoteType, RouterPreference } from 'hooks/routing/types'
-import { OnSwapQuote } from 'state/swap'
+import { RouterPreference } from 'hooks/routing/types'
 
 export enum TradeState {
   LOADING,

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -93,7 +93,7 @@ export interface QuoteData {
 export type QuoteResult =
   | {
       state: QuoteState.INITIALIZED | QuoteState.NOT_FOUND
-      data?: QuoteData
+      data?: undefined
     }
   | {
       state: QuoteState.SUCCESS
@@ -103,9 +103,9 @@ export type QuoteResult =
 export type TradeResult =
   | {
       state: QuoteState.INITIALIZED | QuoteState.NOT_FOUND
-      trade?: InterfaceTrade
-      gasUseEstimateUSD?: string
-      blockNumber?: string
+      trade?: undefined
+      gasUseEstimateUSD?: undefined
+      blockNumber?: undefined
     }
   | {
       state: QuoteState.SUCCESS

--- a/src/state/routing/types.ts
+++ b/src/state/routing/types.ts
@@ -2,7 +2,8 @@ import { BaseProvider } from '@ethersproject/providers'
 import { Trade } from '@uniswap/router-sdk'
 import { Currency, Token, TradeType } from '@uniswap/sdk-core'
 import type { ChainId } from '@uniswap/smart-order-router'
-import { RouterPreference } from 'hooks/routing/types'
+import { QuoteType, RouterPreference } from 'hooks/routing/types'
+import { OnSwapQuote } from 'state/swap'
 
 export enum TradeState {
   LOADING,
@@ -59,13 +60,19 @@ export interface GetQuoteArgs {
   tokenOutDecimals: number
   tokenOutSymbol?: string
   amount: string | null // passing null will initialize the client-side SOR
-  routerPreference?: RouterPreference
+  routerPreference: RouterPreference
   routerUrl?: string
   tradeType: TradeType
   provider: BaseProvider
 }
 
-export interface QuoteResult {
+export enum QuoteState {
+  SUCCESS = 'Success',
+  INITIALIZED = 'Initialized',
+  NOT_FOUND = 'Not found',
+}
+
+export interface QuoteData {
   quoteId?: string
   blockNumber: string
   amount: string
@@ -84,17 +91,28 @@ export interface QuoteResult {
   routeString: string
 }
 
-export const INITIALIZED = 'Initialized'
-export const NO_ROUTE = 'No Route'
+export type QuoteResult =
+  | {
+      state: QuoteState.INITIALIZED | QuoteState.NOT_FOUND
+      data?: QuoteData
+    }
+  | {
+      state: QuoteState.SUCCESS
+      data: QuoteData
+    }
 
-export type GetQuoteError = typeof INITIALIZED | typeof NO_ROUTE
-
-export type TradeResult = {
-  trade?: InterfaceTrade
-  gasUseEstimateUSD?: string
-  blockNumber: string
-}
-
-export type TradeQuoteResult = TradeResult | GetQuoteError
+export type TradeResult =
+  | {
+      state: QuoteState.INITIALIZED | QuoteState.NOT_FOUND
+      trade?: InterfaceTrade
+      gasUseEstimateUSD?: string
+      blockNumber?: string
+    }
+  | {
+      state: QuoteState.SUCCESS
+      trade: InterfaceTrade
+      gasUseEstimateUSD: string
+      blockNumber: string
+    }
 
 export class InterfaceTrade extends Trade<Currency, Currency, TradeType> {}

--- a/src/state/routing/utils.test.ts
+++ b/src/state/routing/utils.test.ts
@@ -8,36 +8,28 @@ import { computeRoutes } from './utils'
 const ETH = nativeOnChain(1)
 
 describe('#useRoute', () => {
-  it('handles an undefined payload', () => {
-    const result = computeRoutes(false, false, undefined)
-
-    expect(result).toBeUndefined()
-  })
-
   it('handles empty edges and nodes', () => {
-    const result = computeRoutes(false, false, { route: [] })
+    const result = computeRoutes(false, false, [])
     expect(result).toEqual([])
   })
 
   it('handles a single route trade from DAI to USDC from v3', () => {
-    const result = computeRoutes(false, false, {
-      route: [
-        [
-          {
-            type: 'v3-pool',
-            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`1`,
-            amountOut: amount`5`,
-            fee: '500',
-            sqrtRatioX96: '2437312313659959819381354528',
-            liquidity: '10272714736694327408',
-            tickCurrent: '-69633',
-            tokenIn: DAI,
-            tokenOut: USDC,
-          },
-        ],
+    const result = computeRoutes(false, false, [
+      [
+        {
+          type: 'v3-pool',
+          address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`1`,
+          amountOut: amount`5`,
+          fee: '500',
+          sqrtRatioX96: '2437312313659959819381354528',
+          liquidity: '10272714736694327408',
+          tickCurrent: '-69633',
+          tokenIn: DAI,
+          tokenOut: USDC,
+        },
       ],
-    })
+    ])
 
     const r = result?.[0]
 
@@ -52,28 +44,26 @@ describe('#useRoute', () => {
   })
 
   it('handles a single route trade from DAI to USDC from v2', () => {
-    const result = computeRoutes(false, false, {
-      route: [
-        [
-          {
-            type: 'v2-pool',
-            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`1`,
-            amountOut: amount`5`,
-            tokenIn: DAI,
-            tokenOut: USDC,
-            reserve0: {
-              token: DAI,
-              quotient: amount`100`,
-            },
-            reserve1: {
-              token: USDC,
-              quotient: amount`200`,
-            },
+    const result = computeRoutes(false, false, [
+      [
+        {
+          type: 'v2-pool',
+          address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`1`,
+          amountOut: amount`5`,
+          tokenIn: DAI,
+          tokenOut: USDC,
+          reserve0: {
+            token: DAI,
+            quotient: amount`100`,
           },
-        ],
+          reserve1: {
+            token: USDC,
+            quotient: amount`200`,
+          },
+        },
       ],
-    })
+    ])
 
     const r = result?.[0]
 
@@ -88,54 +78,52 @@ describe('#useRoute', () => {
   })
 
   it('handles a multi-route trade from DAI to USDC', () => {
-    const result = computeRoutes(false, false, {
-      route: [
-        [
-          {
-            type: 'v2-pool',
-            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`5`,
-            amountOut: amount`6`,
-            tokenIn: DAI,
-            tokenOut: USDC,
-            reserve0: {
-              token: DAI,
-              quotient: amount`1000`,
-            },
-            reserve1: {
-              token: USDC,
-              quotient: amount`500`,
-            },
+    const result = computeRoutes(false, false, [
+      [
+        {
+          type: 'v2-pool',
+          address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`5`,
+          amountOut: amount`6`,
+          tokenIn: DAI,
+          tokenOut: USDC,
+          reserve0: {
+            token: DAI,
+            quotient: amount`1000`,
           },
-        ],
-        [
-          {
-            type: 'v3-pool',
-            address: '0x2f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`10`,
-            amountOut: amount`1`,
-            fee: '3000',
-            tokenIn: DAI,
-            tokenOut: MKR,
-            sqrtRatioX96: '2437312313659959819381354528',
-            liquidity: '10272714736694327408',
-            tickCurrent: '-69633',
+          reserve1: {
+            token: USDC,
+            quotient: amount`500`,
           },
-          {
-            type: 'v3-pool',
-            address: '0x3f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`1`,
-            amountOut: amount`200`,
-            fee: '10000',
-            tokenIn: MKR,
-            tokenOut: USDC,
-            sqrtRatioX96: '2437312313659959819381354528',
-            liquidity: '10272714736694327408',
-            tickCurrent: '-69633',
-          },
-        ],
+        },
       ],
-    })
+      [
+        {
+          type: 'v3-pool',
+          address: '0x2f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`10`,
+          amountOut: amount`1`,
+          fee: '3000',
+          tokenIn: DAI,
+          tokenOut: MKR,
+          sqrtRatioX96: '2437312313659959819381354528',
+          liquidity: '10272714736694327408',
+          tickCurrent: '-69633',
+        },
+        {
+          type: 'v3-pool',
+          address: '0x3f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`1`,
+          amountOut: amount`200`,
+          fee: '10000',
+          tokenIn: MKR,
+          tokenOut: USDC,
+          sqrtRatioX96: '2437312313659959819381354528',
+          liquidity: '10272714736694327408',
+          tickCurrent: '-69633',
+        },
+      ],
+    ])
 
     expect(result).toBeDefined()
     expect(result?.length).toBe(2)
@@ -157,38 +145,36 @@ describe('#useRoute', () => {
   })
 
   it('handles a single route trade with same token pair, different fee tiers', () => {
-    const result = computeRoutes(false, false, {
-      route: [
-        [
-          {
-            type: 'v3-pool',
-            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`1`,
-            amountOut: amount`5`,
-            fee: '500',
-            tokenIn: DAI,
-            tokenOut: USDC,
-            sqrtRatioX96: '2437312313659959819381354528',
-            liquidity: '10272714736694327408',
-            tickCurrent: '-69633',
-          },
-        ],
-        [
-          {
-            type: 'v3-pool',
-            address: '0x2f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`10`,
-            amountOut: amount`50`,
-            fee: '3000',
-            tokenIn: DAI,
-            tokenOut: USDC,
-            sqrtRatioX96: '2437312313659959819381354528',
-            liquidity: '10272714736694327408',
-            tickCurrent: '-69633',
-          },
-        ],
+    const result = computeRoutes(false, false, [
+      [
+        {
+          type: 'v3-pool',
+          address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`1`,
+          amountOut: amount`5`,
+          fee: '500',
+          tokenIn: DAI,
+          tokenOut: USDC,
+          sqrtRatioX96: '2437312313659959819381354528',
+          liquidity: '10272714736694327408',
+          tickCurrent: '-69633',
+        },
       ],
-    })
+      [
+        {
+          type: 'v3-pool',
+          address: '0x2f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`10`,
+          amountOut: amount`50`,
+          fee: '3000',
+          tokenIn: DAI,
+          tokenOut: USDC,
+          sqrtRatioX96: '2437312313659959819381354528',
+          liquidity: '10272714736694327408',
+          tickCurrent: '-69633',
+        },
+      ],
+    ])
 
     expect(result).toBeDefined()
     expect(result?.length).toBe(2)
@@ -199,40 +185,38 @@ describe('#useRoute', () => {
   })
 
   it('computes mixed routes correctly', () => {
-    const result = computeRoutes(false, false, {
-      route: [
-        [
-          {
-            type: PoolType.V3Pool,
-            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`1`,
-            amountOut: amount`5`,
-            fee: '500',
-            tokenIn: DAI,
-            tokenOut: USDC,
-            sqrtRatioX96: '2437312313659959819381354528',
-            liquidity: '10272714736694327408',
-            tickCurrent: '-69633',
+    const result = computeRoutes(false, false, [
+      [
+        {
+          type: PoolType.V3Pool,
+          address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`1`,
+          amountOut: amount`5`,
+          fee: '500',
+          tokenIn: DAI,
+          tokenOut: USDC,
+          sqrtRatioX96: '2437312313659959819381354528',
+          liquidity: '10272714736694327408',
+          tickCurrent: '-69633',
+        },
+        {
+          type: PoolType.V2Pool,
+          address: 'x2f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+          amountIn: amount`10`,
+          amountOut: amount`50`,
+          tokenIn: USDC,
+          tokenOut: MKR,
+          reserve0: {
+            token: USDC,
+            quotient: amount`100`,
           },
-          {
-            type: PoolType.V2Pool,
-            address: 'x2f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-            amountIn: amount`10`,
-            amountOut: amount`50`,
-            tokenIn: USDC,
-            tokenOut: MKR,
-            reserve0: {
-              token: USDC,
-              quotient: amount`100`,
-            },
-            reserve1: {
-              token: MKR,
-              quotient: amount`200`,
-            },
+          reserve1: {
+            token: MKR,
+            quotient: amount`200`,
           },
-        ],
+        },
       ],
-    })
+    ])
 
     expect(result).toBeDefined()
     expect(result?.length).toBe(1)
@@ -246,24 +230,22 @@ describe('#useRoute', () => {
     it('outputs native ETH as input currency', () => {
       const WETH = ETH.wrapped
 
-      const result = computeRoutes(true, false, {
-        route: [
-          [
-            {
-              type: 'v3-pool',
-              address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-              amountIn: (1e18).toString(),
-              amountOut: amount`5`,
-              fee: '500',
-              sqrtRatioX96: '2437312313659959819381354528',
-              liquidity: '10272714736694327408',
-              tickCurrent: '-69633',
-              tokenIn: WETH,
-              tokenOut: USDC,
-            },
-          ],
+      const result = computeRoutes(true, false, [
+        [
+          {
+            type: 'v3-pool',
+            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+            amountIn: (1e18).toString(),
+            amountOut: amount`5`,
+            fee: '500',
+            sqrtRatioX96: '2437312313659959819381354528',
+            liquidity: '10272714736694327408',
+            tickCurrent: '-69633',
+            tokenIn: WETH,
+            tokenOut: USDC,
+          },
         ],
-      })
+      ])
 
       expect(result).toBeDefined()
       expect(result?.length).toBe(1)
@@ -275,24 +257,22 @@ describe('#useRoute', () => {
 
     it('outputs native ETH as output currency', () => {
       const WETH = new Token(1, ETH.wrapped.address, 18, 'WETH')
-      const result = computeRoutes(false, true, {
-        route: [
-          [
-            {
-              type: 'v3-pool',
-              address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-              amountIn: amount`5`,
-              amountOut: (1e18).toString(),
-              fee: '500',
-              sqrtRatioX96: '2437312313659959819381354528',
-              liquidity: '10272714736694327408',
-              tickCurrent: '-69633',
-              tokenIn: USDC,
-              tokenOut: WETH,
-            },
-          ],
+      const result = computeRoutes(false, true, [
+        [
+          {
+            type: 'v3-pool',
+            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+            amountIn: amount`5`,
+            amountOut: (1e18).toString(),
+            fee: '500',
+            sqrtRatioX96: '2437312313659959819381354528',
+            liquidity: '10272714736694327408',
+            tickCurrent: '-69633',
+            tokenIn: USDC,
+            tokenOut: WETH,
+          },
         ],
-      })
+      ])
 
       expect(result?.length).toBe(1)
       expect(result?.[0].routev3?.input).toStrictEqual(USDC)
@@ -304,28 +284,26 @@ describe('#useRoute', () => {
     it('outputs native ETH as input currency for v2 routes', () => {
       const WETH = ETH.wrapped
 
-      const result = computeRoutes(true, false, {
-        route: [
-          [
-            {
-              type: 'v2-pool',
-              address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-              amountIn: (1e18).toString(),
-              amountOut: amount`5`,
-              tokenIn: WETH,
-              tokenOut: USDC,
-              reserve0: {
-                token: WETH,
-                quotient: amount`100`,
-              },
-              reserve1: {
-                token: USDC,
-                quotient: amount`200`,
-              },
+      const result = computeRoutes(true, false, [
+        [
+          {
+            type: 'v2-pool',
+            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+            amountIn: (1e18).toString(),
+            amountOut: amount`5`,
+            tokenIn: WETH,
+            tokenOut: USDC,
+            reserve0: {
+              token: WETH,
+              quotient: amount`100`,
             },
-          ],
+            reserve1: {
+              token: USDC,
+              quotient: amount`200`,
+            },
+          },
         ],
-      })
+      ])
 
       expect(result).toBeDefined()
       expect(result?.length).toBe(1)
@@ -337,28 +315,26 @@ describe('#useRoute', () => {
 
     it('outputs native ETH as output currency for v2 routes', () => {
       const WETH = new Token(1, ETH.wrapped.address, 18, 'WETH')
-      const result = computeRoutes(false, true, {
-        route: [
-          [
-            {
-              type: 'v2-pool',
-              address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
-              amountIn: amount`5`,
-              amountOut: (1e18).toString(),
-              tokenIn: USDC,
-              tokenOut: WETH,
-              reserve0: {
-                token: WETH,
-                quotient: amount`100`,
-              },
-              reserve1: {
-                token: USDC,
-                quotient: amount`200`,
-              },
+      const result = computeRoutes(false, true, [
+        [
+          {
+            type: 'v2-pool',
+            address: '0x1f8F72aA9304c8B593d555F12eF6589cC3A579A2',
+            amountIn: amount`5`,
+            amountOut: (1e18).toString(),
+            tokenIn: USDC,
+            tokenOut: WETH,
+            reserve0: {
+              token: WETH,
+              quotient: amount`100`,
             },
-          ],
+            reserve1: {
+              token: USDC,
+              quotient: amount`200`,
+            },
+          },
         ],
-      })
+      ])
 
       expect(result?.length).toBe(1)
       expect(result?.[0].routev2?.input).toStrictEqual(USDC)


### PR DESCRIPTION
Narrows typings for router queries, which avoids having to coerce types in useRouterTrade.
This will enable cleaner code for a planned perf event hook (see #549).

Also uncovers and fixes a bug for swaps with no quote (`QuoteState.NOT_FOUND`), which do not include a `blockNumber` but should still be rendered.