### PR TITLE
fix: hide toolbar when insufficient liquidity

### DIFF
--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -149,10 +149,10 @@ function CaptionRow() {
     return rows
   }, [gasUseEstimateUSD, impact, slippage, trade])
 
-  if (inputCurrency == null || outputCurrency == null || error === ChainError.MISMATCHED_CHAINS) {
+  if (inputCurrency == null || outputCurrency == null || error === ChainError.MISMATCHED_CHAINS || caption === null) {
     return null
   }
-  return caption ? (
+  return (
     <StyledExpando
       title={
         <ToolbarRow
@@ -176,7 +176,7 @@ function CaptionRow() {
         <ToolbarOrderRouting trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} />
       </Column>
     </StyledExpando>
-  ) : null
+  )
 }
 
 function ToolbarActionButton() {

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -83,8 +83,11 @@ function CaptionRow() {
         }
       }
 
-      if (state === TradeState.INVALID || state === TradeState.NO_ROUTE_FOUND) {
+      if (state === TradeState.INVALID) {
         return { caption: <Caption.Error /> }
+      }
+      if (state === TradeState.NO_ROUTE_FOUND) {
+        return { caption: null }
       }
     }
 
@@ -149,7 +152,7 @@ function CaptionRow() {
   if (inputCurrency == null || outputCurrency == null || error === ChainError.MISMATCHED_CHAINS) {
     return null
   }
-  return (
+  return caption ? (
     <StyledExpando
       title={
         <ToolbarRow
@@ -173,7 +176,7 @@ function CaptionRow() {
         <ToolbarOrderRouting trade={trade} gasUseEstimateUSD={gasUseEstimateUSD} />
       </Column>
     </StyledExpando>
-  )
+  ) : null
 }
 
 function ToolbarActionButton() {


### PR DESCRIPTION
it's redundant to show "error fetching trade" when we know the error - there's not enough liquidity to calculate a trade between these tokens. in this case we should just hide the toolbar.

https://www.notion.so/uniswaplabs/Generic-error-fetching-trade-when-the-error-state-is-insufficient-liquidity-and-displayed-in-the-9d04b1253f38425b89b3edfa0b5927ec?pvs=4


### test plan

<img width="387" alt="image" src="https://user-images.githubusercontent.com/66155195/224856960-83389061-5d58-40da-bc73-7c2b201832b3.png">
