### PR TITLE
fix: ignore user rejection from metamask

### DIFF
--- a/src/hooks/useUniversalRouter.ts
+++ b/src/hooks/useUniversalRouter.ts
@@ -29,6 +29,7 @@ function didUserReject(error: any): boolean {
   const reason = getReason(error)
   if (
     error?.code === ErrorCode.USER_REJECTED_REQUEST ||
+    error?.code === 'ACTION_REJECTED' ||
     (reason?.match(/request/i) && reason?.match(/reject/i)) || // For Rainbow
     reason?.match(/declined/i) || // For Frame
     reason?.match(/cancelled by user/i) || // For SafePal


### PR DESCRIPTION
ensures we don't show the error modal when metamask rejects a transaction