### PR TITLE
feat: new warning UI in toolbar

### DIFF
--- a/src/components/Swap/PriceImpactRow.tsx
+++ b/src/components/Swap/PriceImpactRow.tsx
@@ -19,7 +19,9 @@ export function PriceImpactRow({ impact, reverse, tooltipText }: PriceImpactProp
   return (
     <Row gap={0.25} flex align="center" flow={reverse ? 'row-reverse' : 'row wrap'}>
       <ThemedText.Body2 userSelect={false} color={impact.warning ?? 'hint'}>
-        <TooltipText text={`(${formatPriceImpact(impact?.percent)})`}>{tooltipText}</TooltipText>
+        <TooltipText text={`(${formatPriceImpact(impact?.percent)})`}>
+          <ThemedText.Caption>{tooltipText}</ThemedText.Caption>
+        </TooltipText>
       </ThemedText.Body2>
       {impact?.warning && (
         <Tooltip icon={AlertTriangle} iconProps={{ color: impact.warning }} data-testid="alert-tooltip">

--- a/src/components/Swap/Settings/TransactionTtlInput.tsx
+++ b/src/components/Swap/Settings/TransactionTtlInput.tsx
@@ -9,6 +9,7 @@ import { Expando as ExpandoIcon } from 'icons'
 import { useRef, useState } from 'react'
 import styled from 'styled-components/macro'
 import { ThemedText } from 'theme'
+import { WIDGET_BREAKPOINTS } from 'theme/breakpoints'
 
 import { Label } from './components'
 
@@ -16,7 +17,7 @@ const Input = styled(Row)`
   ${inputCss};
 
   background-color: transparent;
-  max-width: 360px;
+  max-width: ${WIDGET_BREAKPOINTS.EXTRA_SMALL}px;
 
   input {
     text-align: right;

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -4,7 +4,7 @@ import { Currency, CurrencyAmount } from '@uniswap/sdk-core'
 import Row from 'components/Row'
 import Tooltip from 'components/Tooltip'
 import { loadingCss } from 'css/loading'
-import { useIsWideWidget } from 'hooks/useWidgetWidth'
+import { useIsWideWidget, useWidgetWidth } from 'hooks/useWidgetWidth'
 import { AlertTriangle, ChevronDown, Icon, Info, LargeIcon, Spinner } from 'icons'
 import { ReactNode, useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
@@ -146,7 +146,7 @@ const ExpanderRow = styled(Row)<{ $expanded: boolean; warning?: 'warning' | 'err
     css`
       background-color: ${({ theme }) =>
         $expanded ? 'transparent' : warning === 'error' ? theme.criticalSoft : theme.warningSoft};
-      border-radius: 0.25rem;
+      border-radius: ${({ theme }) => theme.borderRadius.xsmall}rem;
       padding: 0.375rem 0.5rem 0.375rem 0.375rem;
       transition: background-color ${AnimationSpeed.Medium} linear, padding ${AnimationSpeed.Medium} linear,
         width ${AnimationSpeed.Medium} linear;
@@ -176,12 +176,14 @@ export function Trade({
   loading,
   warning,
 }: TradeProps & TradeTooltip & ExpandProps) {
+  const widgetWidth = useWidgetWidth()
+  const shouldHideUSD = widgetWidth < 360 && warning && !expanded
   return (
     <>
       <Caption
         caption={
           <ThemedText.Body2 opacity={loading ? 0.4 : 1}>
-            <Price trade={trade} outputUSDC={outputUSDC} />
+            <Price trade={trade} outputUSDC={shouldHideUSD ? undefined : outputUSDC} />
           </ThemedText.Body2>
         }
         icon={loading ? Spinner : null}

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -179,6 +179,7 @@ export function Trade({
   warning,
 }: TradeProps & TradeTooltip & ExpandProps) {
   const widgetWidth = useWidgetWidth()
+  // The USD value doesn't fit in the widget at small sizes when we show the warning UI.
   const shouldHideUSD = widgetWidth < WIDGET_BREAKPOINTS.EXTRA_SMALL && warning && !expanded
   return (
     <>

--- a/src/components/Swap/Toolbar/Caption.tsx
+++ b/src/components/Swap/Toolbar/Caption.tsx
@@ -10,6 +10,7 @@ import { ReactNode, useCallback } from 'react'
 import { InterfaceTrade } from 'state/routing/types'
 import styled, { css } from 'styled-components/macro'
 import { AnimationSpeed, Color, ThemedText } from 'theme'
+import { WIDGET_BREAKPOINTS } from 'theme/breakpoints'
 
 import Price from '../Price'
 import { GasEstimateTooltip, TradeTooltip } from './GasEstimateTooltip'
@@ -141,16 +142,17 @@ interface ExpandProps {
 }
 
 const ExpanderRow = styled(Row)<{ $expanded: boolean; warning?: 'warning' | 'error' }>`
-  ${({ warning, $expanded }) =>
-    warning &&
-    css`
+  ${({ warning, $expanded }) => {
+    if (!warning) return undefined
+    return css`
       background-color: ${({ theme }) =>
         $expanded ? 'transparent' : warning === 'error' ? theme.criticalSoft : theme.warningSoft};
       border-radius: ${({ theme }) => theme.borderRadius.xsmall}rem;
       padding: 0.375rem 0.5rem 0.375rem 0.375rem;
       transition: background-color ${AnimationSpeed.Medium} linear, padding ${AnimationSpeed.Medium} linear,
         width ${AnimationSpeed.Medium} linear;
-    `}
+    `
+  }}
 `
 
 function Expander({ expanded, warning }: ExpandProps) {
@@ -177,7 +179,7 @@ export function Trade({
   warning,
 }: TradeProps & TradeTooltip & ExpandProps) {
   const widgetWidth = useWidgetWidth()
-  const shouldHideUSD = widgetWidth < 360 && warning && !expanded
+  const shouldHideUSD = widgetWidth < WIDGET_BREAKPOINTS.EXTRA_SMALL && warning && !expanded
   return (
     <>
       <Caption

--- a/src/components/Swap/Toolbar/index.tsx
+++ b/src/components/Swap/Toolbar/index.tsx
@@ -77,6 +77,7 @@ function CaptionRow() {
               gasUseEstimateUSD={open ? null : gasUseEstimateUSD}
               expanded={open}
               loading={state === TradeState.LOADING}
+              warning={impact?.warning}
             />
           ),
           isExpandable: true,
@@ -95,14 +96,15 @@ function CaptionRow() {
   }, [
     error,
     state,
+    trade,
     inputCurrency,
     outputCurrency,
     isAmountPopulated,
     gasUseEstimateUSD,
     isWrap,
-    trade,
-    open,
     outputUSDC,
+    open,
+    impact?.warning,
   ])
 
   const maybeToggleOpen = useCallback(() => {

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -19,7 +19,7 @@ const StyledWidgetWrapper = styled.div<{ width: number | string }>`
 
   max-width: 600px;
   min-height: 300px;
-  min-width: 300px;
+  min-width: 340px;
   padding: ${ROOT_CONTAINER_PADDING}px;
   position: relative;
   user-select: none;
@@ -40,9 +40,9 @@ interface WidgetWrapperProps {
 export default function WidgetWrapper(props: PropsWithChildren<WidgetWrapperProps>) {
   const initialWidth: string | number = useMemo(() => {
     if (props.width) {
-      if (props.width < 300) {
-        console.warn(`Widget width must be at least 300px (you set it to ${props.width}). Falling back to 300px.`)
-        return 300
+      if (props.width < 340) {
+        console.warn(`Widget width must be at least 340px (you set it to ${props.width}). Falling back to 340px.`)
+        return 340
       }
       if (props.width > 600) {
         console.warn(`Widget width must be at most 600px (you set it to ${props.width}). Falling back to 600px.`)

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -3,6 +3,7 @@ import { WidgetWidthProvider } from 'hooks/useWidgetWidth'
 import { PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 import styled from 'styled-components/macro'
+import { WIDGET_BREAKPOINTS } from 'theme/breakpoints'
 import toLength from 'utils/toLength'
 
 const ROOT_CONTAINER_PADDING = 8
@@ -49,7 +50,7 @@ export default function WidgetWrapper(props: PropsWithChildren<WidgetWrapperProp
         return 600
       }
     }
-    return props.width ?? 360
+    return props.width ?? WIDGET_BREAKPOINTS.EXTRA_SMALL
   }, [props.width])
 
   /**
@@ -59,7 +60,7 @@ export default function WidgetWrapper(props: PropsWithChildren<WidgetWrapperProp
   const ref = useRef<HTMLDivElement>(null)
   const [wrapperWidth, setWidgetWidth] = useState<number>(
     toLength(initialWidth) === initialWidth
-      ? 360 // If the initial width is a string, use default width until the ResizeObserver gives us the true width as a number.
+      ? WIDGET_BREAKPOINTS.EXTRA_SMALL // If the initial width is a string, use default width until the ResizeObserver gives us the true width as a number.
       : (initialWidth as number)
   )
   useEffect(() => {

--- a/src/components/WidgetWrapper.tsx
+++ b/src/components/WidgetWrapper.tsx
@@ -19,7 +19,7 @@ const StyledWidgetWrapper = styled.div<{ width: number | string }>`
 
   max-width: 600px;
   min-height: 300px;
-  min-width: 340px;
+  min-width: 300px;
   padding: ${ROOT_CONTAINER_PADDING}px;
   position: relative;
   user-select: none;
@@ -40,9 +40,9 @@ interface WidgetWrapperProps {
 export default function WidgetWrapper(props: PropsWithChildren<WidgetWrapperProps>) {
   const initialWidth: string | number = useMemo(() => {
     if (props.width) {
-      if (props.width < 340) {
-        console.warn(`Widget width must be at least 340px (you set it to ${props.width}). Falling back to 340px.`)
-        return 340
+      if (props.width < 300) {
+        console.warn(`Widget width must be at least 300px (you set it to ${props.width}). Falling back to 300px.`)
+        return 300
       }
       if (props.width > 600) {
         console.warn(`Widget width must be at most 600px (you set it to ${props.width}). Falling back to 600px.`)

--- a/src/components/__snapshots__/Header.test.tsx.snap
+++ b/src/components/__snapshots__/Header.test.tsx.snap
@@ -299,7 +299,7 @@ Object {
                             class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gQrhhv eMmnPF"
                           >
                             <div
-                              class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fcddMn ehOYyS"
+                              class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fcddMn itTgvP"
                             >
                               <input
                                 autocomplete="off"
@@ -658,7 +658,7 @@ Object {
                           class="Row-sc-1nzvhrh-0 TransactionTtlInput__InputContainer-sc-1fem02o-1 gQrhhv eMmnPF"
                         >
                           <div
-                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fcddMn ehOYyS"
+                            class="Row-sc-1nzvhrh-0 TransactionTtlInput__Input-sc-1fem02o-0 fcddMn itTgvP"
                           >
                             <input
                               autocomplete="off"

--- a/src/cosmos/SwapSkeleton.fixture.tsx
+++ b/src/cosmos/SwapSkeleton.fixture.tsx
@@ -1,9 +1,10 @@
 import { darkTheme, defaultTheme, lightTheme, SwapWidgetSkeleton } from '@uniswap/widgets'
 import { useEffect } from 'react'
 import { useValue } from 'react-cosmos/fixture'
+import { WIDGET_BREAKPOINTS } from 'theme/breakpoints'
 
 function Fixture() {
-  const [width] = useValue('width', { defaultValue: 360 })
+  const [width] = useValue('width', { defaultValue: WIDGET_BREAKPOINTS.EXTRA_SMALL })
   const [theme, setTheme] = useValue('theme', { defaultValue: defaultTheme })
   const [darkMode] = useValue('darkMode', { defaultValue: false })
   useEffect(() => setTheme((theme) => ({ ...theme, ...(darkMode ? darkTheme : lightTheme) })), [darkMode, setTheme])

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -95,6 +95,7 @@ const defaultBorderRadius = {
   large: 1.5,
   medium: 1,
   small: 0.75,
+  xsmall: 0.5,
 }
 
 export const defaultTheme = {
@@ -155,6 +156,7 @@ function toDefaultTheme(theme: Required<Theme>): DefaultTheme {
       large: clampNum(value.large),
       medium: clampNum(value.medium),
       small: clampNum(value.small),
+      xsmall: clampNum(value.xsmall),
     }
   }
 }

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -38,6 +38,7 @@ export type ThemeBorderRadius = {
   large: number
   medium: number
   small: number
+  xsmall: number
 }
 
 export type ZIndex = {


### PR DESCRIPTION
adds a warning UI to the expander on the right when the toolbar is collapsed  - IF there is a price impact warning to view in the expanded state.

<img width="421" alt="Screenshot 2023-03-20 at 11 14 22 AM" src="https://user-images.githubusercontent.com/66155195/226430854-7a53be4b-1170-4226-b549-4c8c52b45679.png">

<img width="421" alt="Screenshot 2023-03-20 at 11 14 16 AM" src="https://user-images.githubusercontent.com/66155195/226430863-ad632408-a6d6-421d-bea0-545a275f862c.png">
