### PR TITLE
feat: upgrade sor

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@uniswap/redux-multicall": "^1.1.8",
     "@uniswap/router-sdk": "^1.3.0",
     "@uniswap/sdk-core": "^3.2.0",
-    "@uniswap/smart-order-router": "^3.6.0",
+    "@uniswap/smart-order-router": "^3.10.0",
     "@uniswap/token-lists": "^1.0.0-beta.30",
     "@uniswap/universal-router-sdk": "^1.3.8",
     "@uniswap/v2-sdk": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3586,10 +3586,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/smart-order-router@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/smart-order-router/-/smart-order-router-3.6.0.tgz#45141dd97083725d185b841e0a465ab4107cc1be"
-  integrity sha512-NUkvQiuK8xXpzJf8DFKxpURaUEyvYYWf1tfau7tKI/sV7pFHm7/FGdL6mWo5xq5VWHXy87rkXxfDJCi1M6fa4Q==
+"@uniswap/smart-order-router@^3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/smart-order-router/-/smart-order-router-3.10.0.tgz#ecbc6ace97d4addc407703f606210ca08ea059a8"
+  integrity sha512-lgSaZpJKtAH/HJCRCkdP2e5um2tPn3A8/DUvd8XtsuqlX1bR6KK1BnZJCT7kbPS6Nqi7PdExkGrzJCcZeN97YA==
   dependencies:
     "@uniswap/default-token-list" "^2.0.0"
     "@uniswap/permit2-sdk" "^1.2.0"
@@ -3597,7 +3597,7 @@
     "@uniswap/swap-router-contracts" "^1.3.0"
     "@uniswap/token-lists" "^1.0.0-beta.25"
     "@uniswap/universal-router" "^1.0.1"
-    "@uniswap/universal-router-sdk" "^1.3.8"
+    "@uniswap/universal-router-sdk" "^1.3.9"
     "@uniswap/v2-sdk" "^3.0.1"
     "@uniswap/v3-sdk" "^3.7.0"
     async-retry "^1.3.1"
@@ -3655,10 +3655,33 @@
     bignumber.js "^9.0.2"
     ethers "^5.3.1"
 
+"@uniswap/universal-router-sdk@^1.3.9":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.4.3.tgz#9a62793e42937ae7b309a4e663916cd394e231e8"
+  integrity sha512-drfeHvfCt5I2hvvF7EFBnZQJFWeK1ihaZdrrSTWwxAAhnMNo1Css5lSeHBE0B9W1W6AegKDSoyLRQ/qsrxDXpA==
+  dependencies:
+    "@uniswap/permit2-sdk" "^1.2.0"
+    "@uniswap/router-sdk" "^1.4.0"
+    "@uniswap/sdk-core" "^3.1.0"
+    "@uniswap/universal-router" "1.3.1"
+    "@uniswap/v2-sdk" "^3.0.1"
+    "@uniswap/v3-sdk" "^3.9.0"
+    bignumber.js "^9.0.2"
+    ethers "^5.3.1"
+
 "@uniswap/universal-router@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.2.1.tgz#5fe4aa21d6bc89314d99f26407f28154f8e16f42"
   integrity sha512-F3S1wKylncuvIG2qwC1ciXXc1z1QmKsalo4p6H2A90LSRylEEhNp7ITxs7qCcnfRh+ZNkGJ0yQ0zmuVJSBezOQ==
+  dependencies:
+    "@openzeppelin/contracts" "4.7.0"
+    "@uniswap/v2-core" "1.0.1"
+    "@uniswap/v3-core" "1.0.0"
+
+"@uniswap/universal-router@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.3.1.tgz#cf0bf662e3056336c5bb5804e353dc5fd34a24a1"
+  integrity sha512-JJY4Z1aXJ70OB08WKl+wSazTfV7pZ1bXgKRhvPLSv8/4HXxQPCYMVi53Waeu93VdAdaYt1jviWR+uRV6a6/uoA==
   dependencies:
     "@openzeppelin/contracts" "4.7.0"
     "@uniswap/v2-core" "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3641,21 +3641,7 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.30.tgz#2103ca23b8007c59ec71718d34cdc97861c409e5"
   integrity sha512-HwY2VvkQ8lNR6ks5NqQfAtg+4IZqz3KV1T8d2DlI8emIn9uMmaoFbIOg0nzjqAVKKnZSbMTRRtUoAh6mmjRvog==
 
-"@uniswap/universal-router-sdk@^1.3.8":
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.3.8.tgz#1e6bf1081aa6c7f5d800d5b8a20773016c98bbb6"
-  integrity sha512-WwmcIL20DSExTNep31OxyVCMsi/JqRsZsCqZEqwYTP+Ip1qQ9P8mcR3wtGAfBmYlWFS1lcIhI6SDvXayIk6DDw==
-  dependencies:
-    "@uniswap/permit2-sdk" "^1.2.0"
-    "@uniswap/router-sdk" "^1.4.0"
-    "@uniswap/sdk-core" "^3.1.0"
-    "@uniswap/universal-router" "1.2.1"
-    "@uniswap/v2-sdk" "^3.0.1"
-    "@uniswap/v3-sdk" "^3.9.0"
-    bignumber.js "^9.0.2"
-    ethers "^5.3.1"
-
-"@uniswap/universal-router-sdk@^1.3.9":
+"@uniswap/universal-router-sdk@^1.3.8", "@uniswap/universal-router-sdk@^1.3.9":
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@uniswap/universal-router-sdk/-/universal-router-sdk-1.4.3.tgz#9a62793e42937ae7b309a4e663916cd394e231e8"
   integrity sha512-drfeHvfCt5I2hvvF7EFBnZQJFWeK1ihaZdrrSTWwxAAhnMNo1Css5lSeHBE0B9W1W6AegKDSoyLRQ/qsrxDXpA==
@@ -3678,19 +3664,10 @@
     "@uniswap/v2-core" "1.0.1"
     "@uniswap/v3-core" "1.0.0"
 
-"@uniswap/universal-router@1.3.1":
+"@uniswap/universal-router@1.3.1", "@uniswap/universal-router@^1.0.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.3.1.tgz#cf0bf662e3056336c5bb5804e353dc5fd34a24a1"
   integrity sha512-JJY4Z1aXJ70OB08WKl+wSazTfV7pZ1bXgKRhvPLSv8/4HXxQPCYMVi53Waeu93VdAdaYt1jviWR+uRV6a6/uoA==
-  dependencies:
-    "@openzeppelin/contracts" "4.7.0"
-    "@uniswap/v2-core" "1.0.1"
-    "@uniswap/v3-core" "1.0.0"
-
-"@uniswap/universal-router@^1.0.1":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@uniswap/universal-router/-/universal-router-1.2.2.tgz#7b3704a307fad53ba2a80718362b1b7718ada4cc"
-  integrity sha512-ipQQpo3xO21EIS5pBjJazZbh9Vth6wzeta85Xva2HKoJ0uBvnugCjqvjkJMqiiz+osBnC12yemitjTOOxcqXjA==
   dependencies:
     "@openzeppelin/contracts" "4.7.0"
     "@uniswap/v2-core" "1.0.1"


### PR DESCRIPTION
upgrades the Smart Order Router dependency because we want this bug fix: https://github.com/Uniswap/smart-order-router/pull/211

this fixes an issue Opensea is having with their integration related to `provider` compatibility.

-----

also, remove the dynamic import for the client side routing code. this code splitting is not working for third party integrators using next.js.