### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 [![Lint](https://github.com/Uniswap/interface/actions/workflows/lint.yml/badge.svg)](https://github.com/Uniswap/interface/actions/workflows/lint.yml)
 [![Crowdin](https://badges.crowdin.net/uniswap-interface/localized.svg)](https://crowdin.com/project/uniswap-interface)
 
+# Deprecation Notice:
+
+The @uniswap/widgets package is no longer actively supported by Uniswap Labs. Developers are encouraged to transition to Uniswap v4 and build custom swap functionality using the new version of the protocol. Uniswap v4 offers more flexibility and is the recommended approach moving forward.
+
 The `@uniswap/widgets` package is an [npm package](https://www.npmjs.com/package/@uniswap/widgets) of React components used to provide subsets of the Uniswap Protocol functionality in a small and configurable user interface element.
 
 # Uniswap Labs Swap Widget


### PR DESCRIPTION
### **Pull Request Description**

**Summary:**
This pull request updates the README of the `@uniswap/widgets` package to include a deprecation notice and guidance for developers. The notice informs users that the package is no longer actively supported by Uniswap Labs and encourages them to transition to **Uniswap v4** for building custom swap functionality.

**Changes:**
- Added a **deprecation notice** at the beginning of the README, clearly stating that the `@uniswap/widgets` package is no longer supported.
- Recommended using **Uniswap v4** and building custom swap components using the latest version of the Uniswap protocol.

**Reason for Changes:**
The `@uniswap/widgets` package is no longer actively supported by Uniswap Labs, and the team is recommending developers to move to **Uniswap v4** for greater flexibility and customization. This update is intended to save other developers time.

**Related Issues:**
- N/A

**Impact:**
- Developers relying on the `@uniswap/widgets` package should transition to Uniswap v4 for building their own swap functionality.
- The README now clearly communicates the deprecation, helping users make informed decisions about using the package.
